### PR TITLE
Y2log filtering

### DIFF
--- a/web/src/assets/styles/index.scss
+++ b/web/src/assets/styles/index.scss
@@ -7,6 +7,7 @@
 @use "~/assets/styles/utilities.scss";
 @use "~/assets/styles/composition.scss";
 @use "~/assets/styles/blocks.scss";
+@use "~/assets/styles/y2logviewer.scss";
 
 // PatternFly overrides
 @use "~/assets/styles/patternfly-overrides.scss";

--- a/web/src/assets/styles/y2logviewer.scss
+++ b/web/src/assets/styles/y2logviewer.scss
@@ -1,0 +1,87 @@
+@use "sass:color";
+
+// TODO: get the base text color from the PatternFly SCSS
+$base-color: #151515;
+
+// lighter color for less important log values
+$faded-color: color.scale($base-color, $lightness: +40%);
+
+// colors for each log level
+$loglevel-0-color: color.scale($faded-color, $lightness: +20%);
+$loglevel-2-color: #fdd3a2;
+$loglevel-3-color: #ffb8b8;
+$loglevel-4-color: #bdc1ff;
+$loglevel-5-color: #ffadf8;
+
+.logview {
+  .logline {
+    // rendering and line wrapping like in a <pre>
+    word-break: break-all;
+    white-space: pre-wrap;
+    font-family: var(--ff-code);
+    font-size: 90%;
+    color: $faded-color;
+  }
+
+  .log-message {
+    color: $base-color;
+  }
+
+  .loglevel-0,
+  .loglevel-0 .log-message {
+    color: $loglevel-0-color;
+
+    &:hover {
+      background-color: color.scale($loglevel-0-color, $lightness: +80%);
+    }
+  }
+
+  .loglevel-1:hover {
+    background-color: #eeeeee;
+  }
+
+  .loglevel-2 {
+    background-color: $loglevel-2-color;
+
+    &:hover {
+      background-color: color.scale($loglevel-2-color, $lightness: -10%);
+    }
+  }
+
+  .loglevel-3 {
+    background-color: $loglevel-3-color;
+
+    &:hover {
+      background-color: color.scale($loglevel-3-color, $lightness: -10%);
+    }
+  }
+
+  .loglevel-4 {
+    background-color: $loglevel-4-color;
+
+    &:hover {
+      background-color: color.scale($loglevel-4-color, $lightness: -10%);
+    }
+  }
+
+  .loglevel-5 {
+    background-color: $loglevel-5-color;
+
+    &:hover {
+      background-color: color.scale($loglevel-5-color, $lightness: -10%);
+    }
+  }
+
+  // indent nested groups
+  details>.logline,
+  details>details {
+    margin-left: 2em;
+    border-left: dashed 1px #cbcbcb;
+    padding-left: 1em;
+  }
+
+  summary {
+    font-family: var(--ff-code);
+    margin-left: -1em;
+  }
+}

--- a/web/src/components/core/ComponentFilter.jsx
+++ b/web/src/components/core/ComponentFilter.jsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState } from "react";
+import { OptionsMenu, OptionsMenuDirection, OptionsMenuItem, OptionsMenuToggleWithText, OptionsMenuSeparator } from "@patternfly/react-core";
+import { CaretDownIcon } from "@patternfly/react-icons/dist/esm/icons/caret-down-icon";
+
+export default function ComponentFilter({ components, onChangeCallback }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onSelect = (index) => {
+    const newComponents = { ...components };
+    newComponents[index] = !newComponents[index];
+    if (onChangeCallback) onChangeCallback(newComponents);
+  };
+
+  const onToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelectAll = (allValue) => {
+    const newComponents = {};
+    Object.keys(components).forEach((index) => { newComponents[index] = allValue });
+    if (onChangeCallback) onChangeCallback(newComponents);
+  };
+
+  // sort the component names alphabetically (depending on the current locale)
+  const names = Object.keys(components)
+    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+
+  const menuItems = names.map((label) => {
+    return (
+      <OptionsMenuItem
+        onSelect={() => { onSelect(label) } }
+        isSelected={components[label]}
+        key={`log-cpt-${label}`}
+      >
+        {label}
+      </OptionsMenuItem>
+    );
+  });
+
+  // add All/None items
+  menuItems.push(<OptionsMenuSeparator key="separator" />);
+  menuItems.push(<OptionsMenuItem onSelect={() => { onSelectAll(true) } } key="all">All</OptionsMenuItem>);
+  menuItems.push(<OptionsMenuItem onSelect={() => { onSelectAll(false) } } key="none">None</OptionsMenuItem>);
+
+  const toggle = (
+    <OptionsMenuToggleWithText
+    toggleText="Components"
+    toggleButtonContents={<CaretDownIcon />}
+    onToggle={onToggle}
+    />
+  );
+
+  return (
+    <OptionsMenu
+      direction={OptionsMenuDirection.up}
+      menuItems={menuItems}
+      isOpen={isOpen}
+      isText
+      toggle={toggle}
+    />
+  );
+}

--- a/web/src/components/core/FileViewer.test.jsx
+++ b/web/src/components/core/FileViewer.test.jsx
@@ -34,13 +34,13 @@ const fileFn = jest.fn();
 fileFn.mockImplementation(() => {
   return {
     read: readFn
-  }
+  };
 });
 
 cockpit.file.mockImplementation(fileFn);
 
 // testing data
-const file_name = "/testfile"
+const file_name = "/testfile";
 const content = "Read file content";
 const title = "YaST Logs";
 

--- a/web/src/components/core/LogLevelFilter.jsx
+++ b/web/src/components/core/LogLevelFilter.jsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState } from "react";
+import { OptionsMenu, OptionsMenuDirection, OptionsMenuItem, OptionsMenuToggleWithText, OptionsMenuSeparator } from "@patternfly/react-core";
+import { CaretDownIcon } from "@patternfly/react-icons/dist/esm/icons/caret-down-icon";
+
+// labels for for all log levels (0..5)
+const labels = [
+  "Debug",
+  "Info",
+  "Warning",
+  "Error",
+  "Security",
+  "Internal"
+];
+
+export default function LogLevelFilter({ levels, onChangeCallback }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onSelect = (index) => {
+    const newLevels = [...levels];
+    newLevels[index] = !newLevels[index];
+    if (onChangeCallback) onChangeCallback(newLevels);
+  };
+
+  const onSelectAll = (allValue) => {
+    const newLevels = levels.map(() => { return allValue });
+    if (onChangeCallback) onChangeCallback(newLevels);
+  };
+
+  const menuItems = labels.map((label, index) => {
+    return (
+      <OptionsMenuItem
+        onSelect={() => { onSelect(index) } }
+        isSelected={levels[index]}
+        key={`log-level-${index}`}
+      >
+        {`${index} - ${label}`}
+      </OptionsMenuItem>
+    );
+  });
+
+  // add All/None items
+  menuItems.push(<OptionsMenuSeparator key="separator" />);
+  menuItems.push(<OptionsMenuItem onSelect={() => { onSelectAll(true) } } key="all">All</OptionsMenuItem>);
+  menuItems.push(<OptionsMenuItem onSelect={() => { onSelectAll(false) } } key="none">None</OptionsMenuItem>);
+
+  const onToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const toggle = <OptionsMenuToggleWithText toggleText="Log levels" toggleButtonContents={<CaretDownIcon />} onToggle={onToggle} />;
+
+  return (
+    <OptionsMenu
+      direction={OptionsMenuDirection.up}
+      menuItems={menuItems}
+      isOpen={isOpen}
+      isText
+      toggle={toggle}
+    />
+  );
+}

--- a/web/src/components/core/PropertyFilter.jsx
+++ b/web/src/components/core/PropertyFilter.jsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState } from "react";
+import { OptionsMenu, OptionsMenuDirection, OptionsMenuItem, OptionsMenuToggleWithText, OptionsMenuSeparator } from "@patternfly/react-core";
+import { CaretDownIcon } from "@patternfly/react-icons/dist/esm/icons/caret-down-icon";
+
+// labels for each log part
+const labels = {
+  date: "Date",
+  time: "Time",
+  level: "Log level",
+  host: "Host name",
+  pid: "Process ID",
+  component: "Component",
+  location: "Location",
+  message: "Message"
+};
+
+export default function PropertyFilter({ properties, onChangeCallback }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onSelect = (index) => {
+    const newProperties = { ...properties };
+    newProperties[index] = !newProperties[index];
+    if (onChangeCallback) onChangeCallback(newProperties);
+  };
+
+  const onToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelectAll = (allValue) => {
+    const newProperties = {};
+    Object.keys(properties).forEach((key) => { newProperties[key] = allValue });
+    if (onChangeCallback) onChangeCallback(newProperties);
+  };
+
+  const menuItems = [];
+
+  for (const [key, label] of Object.entries(labels)) {
+    menuItems.push(
+      <OptionsMenuItem
+        onSelect={() => { onSelect(key) } }
+        isSelected={properties[key]}
+        key={`log-attr-${key}`}
+      >
+        {label}
+      </OptionsMenuItem>
+    );
+  }
+
+  // add All/None items
+  menuItems.push(<OptionsMenuSeparator key="separator" />);
+  menuItems.push(<OptionsMenuItem onSelect={() => { onSelectAll(true) } } key="all">All</OptionsMenuItem>);
+  menuItems.push(<OptionsMenuItem onSelect={() => { onSelectAll(false) } } key="none">None</OptionsMenuItem>);
+
+  const toggle = (
+    <OptionsMenuToggleWithText
+    toggleText="Log properties"
+    toggleButtonContents={<CaretDownIcon />}
+    onToggle={onToggle}
+    />
+  );
+
+  return (
+    <OptionsMenu
+      direction={OptionsMenuDirection.up}
+      menuItems={menuItems}
+      isOpen={isOpen}
+      isText
+      toggle={toggle}
+    />
+  );
+}

--- a/web/src/components/core/ShowLogButton.jsx
+++ b/web/src/components/core/ShowLogButton.jsx
@@ -20,9 +20,9 @@
  */
 
 import React, { useState } from "react";
-import { FileViewer } from "~/components/core";
 import { Icon } from "~/components/layout";
 import { Button } from "@patternfly/react-core";
+import { Y2logViewer } from "~/components/core";
 
 /**
  * Button for displaying the YaST logs
@@ -55,11 +55,7 @@ const ShowLogButton = ({ onClickCallback }) => {
       </Button>
 
       { isLogDisplayed &&
-        <FileViewer
-          title="YaST Logs"
-          file="/var/log/YaST2/y2log"
-          onCloseCallback={onClose}
-        /> }
+        <Y2logViewer onCloseCallback={onClose} /> }
     </>
   );
 };

--- a/web/src/components/core/Y2logViewer.jsx
+++ b/web/src/components/core/Y2logViewer.jsx
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState, useEffect, useRef } from "react";
+import { Popup } from "~/components/core";
+import { Alert, Button, Flex, FlexItem, FormGroup } from "@patternfly/react-core";
+import { LoadingEnvironment } from "~/components/layout";
+import LogLevelFilter from "./LogLevelFilter";
+import PropertyFilter from "./PropertyFilter";
+import ComponentFilter from "./ComponentFilter";
+
+import cockpit from "../../lib/cockpit";
+import y2logparser from "../../lib/y2logparser";
+
+// render a single line from y2log
+const renderLine = (item, key, filter) => {
+  if (!filter.levels[item.level] || !filter.components[item.group]) return null;
+
+  const props = filter.properties;
+
+  return (
+    <div className={`logline loglevel-${item.level}`} key={`log-line-${key}`}>
+      { props.date && <span>{item.date}{" "}</span> }
+      { props.time && <span>{item.time}{" "}</span> }
+      { props.level && <span>{"<"}{item.level}{"> "}</span> }
+      { props.host && <span>{item.host}{" "}</span> }
+      { props.pid && <span>{"("}{item.pid}{") "}</span> }
+      { props.component && <span>{"["}{item.component}{"] "}</span> }
+      { props.location && <span>{item.location}{" "}</span> }
+      { props.message && <span className="log-message">{item.message}{" "}</span> }
+    </div>
+  );
+};
+
+// render complete y2log content
+const renderLines = (lines, filter) => {
+  const ret = [];
+
+  while (lines.length > 0) {
+    const line = lines.shift();
+
+    const startGroup = line.message.match(/^::group::(\d+\.\d+)::(.*)/);
+    if (startGroup) {
+      ret.push(
+        <details key={`group-start-${lines.length}`}>
+          <summary className={`loglevel-${line.level}`}>{startGroup[2]}</summary>
+          {renderLine(line, lines.length, filter)}
+          {renderLines(lines, filter)}
+        </details>
+      );
+    } else {
+      ret.push(renderLine(line, lines.length, filter));
+    }
+
+    const endGroup = line.message.match(/^::endgroup::(\d+\.\d+)::(.*)/);
+    if (endGroup) {
+      return ret;
+    }
+  }
+
+  return ret;
+};
+
+// default displayed log properties
+const defaultProperties = {
+  date: false,
+  time: true,
+  level: false,
+  host: false,
+  pid: false,
+  component: true,
+  location: true,
+  message: true
+};
+
+// convert component set to visibility mapping (component name => boolean)
+const defaultComponents = (components) => {
+  const ret = {};
+  components.forEach((component) => { ret[component] = true });
+  return ret;
+};
+
+// which log levels should be displayed by default, a list for levels 0..5
+const defaultLogLevels = [true, true, true, true, true, true];
+
+const file = "/var/log/YaST2/y2log";
+
+export default function Y2logViewer({ onCloseCallback }) {
+  // the popup is visible
+  const [isOpen, setIsOpen] = useState(true);
+  // error message for failed load
+  const [error, setError] = useState(null);
+  // the parsed log file
+  const [content, setContent] = useState("");
+  // current state
+  const [state, setState] = useState("loading");
+
+  const [levels, setLogLevels] = useState(defaultLogLevels);
+  const [properties, setProperties] = useState(defaultProperties);
+  const [components, setComponents] = useState([]);
+
+  const endLogRef = useRef(null);
+
+  useEffect(() => {
+    // NOTE: reading non-existing files in cockpit does not fail, the result is null
+    // see https://cockpit-project.org/guide/latest/cockpit-file
+    cockpit.file(file).read()
+      .then((data) => {
+        setState("ready");
+        const parsed = y2logparser(data);
+        setComponents(defaultComponents(parsed.components));
+        setContent(parsed.lines);
+        // scroll to the end of the log
+        endLogRef.current.scrollIntoView();
+      })
+      .catch((data) => {
+        setState("ready");
+        setError(data.message);
+      });
+  }, []);
+
+  const close = () => {
+    setIsOpen(false);
+    if (onCloseCallback) onCloseCallback();
+  };
+
+  // current display filter settings
+  const filter = { levels, properties, components };
+  const lines = renderLines([...content], filter);
+
+  const footer = (
+    // FIXME: use <Flex> instead of this workaround
+    <div style={{ display: "flex", alignItems: "end", justifyContent: "space-between", width: "100%" }}>
+      <FormGroup role="group" label="Filters">
+        <Flex>
+          <FlexItem spacer={{ default: "spacerSm" }}>
+            <LogLevelFilter levels={levels} onChangeCallback={(l) => setLogLevels(l)} />
+          </FlexItem>
+          <FlexItem spacer={{ default: "spacerSm" }}>
+            <PropertyFilter properties={properties} onChangeCallback={(p) => setProperties(p)} />
+          </FlexItem>
+          <FlexItem spacer={{ default: "spacerSm" }}>
+            <ComponentFilter components={components} onChangeCallback={(c) => setComponents(c)} />
+          </FlexItem>
+        </Flex>
+      </FormGroup>
+      <Button onClick={close}>
+        Close
+      </Button>
+    </div>
+  );
+
+  return (
+    <Popup
+      isOpen={isOpen}
+      title="YaST Log"
+      variant="large"
+      className="tallest"
+      footer={footer}
+    >
+      { state === "loading" && <LoadingEnvironment text="Reading log file..." /> }
+      { (content === null || error) &&
+        <Alert
+          isInline
+          isPlain
+          variant="warning"
+          title="Cannot read the file"
+        >
+          {error}
+        </Alert> }
+
+      <div className="logview">
+        {lines}
+        <div ref={endLogRef} />
+      </div>
+    </Popup>
+  );
+}

--- a/web/src/components/core/index.js
+++ b/web/src/components/core/index.js
@@ -37,3 +37,4 @@ export { default as Popup } from "./Popup";
 export { default as ProgressReport } from "./ProgressReport";
 export { default as ChangeProductButton } from "./ChangeProductButton";
 export { default as ValidationErrors } from "./ValidationErrors";
+export { default as Y2logViewer } from "./Y2logViewer";

--- a/web/src/lib/y2logparser.js
+++ b/web/src/lib/y2logparser.js
@@ -1,0 +1,83 @@
+
+// helper function - convert component name to component group to group similar
+// e.g. for "ui-macro" and "qt-ui" use the same "UI" filtering component
+function component_group(name) {
+  if (name === "zconfig" || name === "parser::yum" || name === "Progress++" ||
+    name === "parser++" || name === "parser" || name === "FileChecker" ||
+    name === "locks" || name === "locks++" || name === "MODALIAS++" ||
+    name.match(/^zypp/) || name.match(/^librpm/)) {
+    return "libzypp";
+  } else if (name === "zypp::solver" || name.match(/^libsolv/)) {
+    return "Solver";
+  } else if (name === "Pkg" || name === "Pkg++") {
+    return "Pkg-bindings";
+  } else if (name === "bash" || name === "scr" || name.match(/^agent-/) || name.match(/^ag_/)) {
+    return "Agents";
+  } else if (name === "ui" || name === "libycp" || name.match(/^ui-/) || name.match(/-ui$/) || name.match(/^qt-/)) {
+    return "UI";
+  } else if (name === "liby2" || name === "wfm" || name === "liby2") {
+    return "yast2-core";
+  } else if (name === "Interpreter") {
+    return "Ruby";
+  } else {
+    return name;
+  }
+}
+
+// y2log parser
+export default function y2logparser(y2log) {
+  if (process.env.NODE_ENV !== "production") {
+    console.time("Parsing y2log");
+  }
+
+  const lines = [];
+  const components = new Set();
+  // regexp for parsing y2log
+  const log_regexp = /^(\d\d\d\d-\d\d-\d\d) (\d\d:\d\d:\d\d) <(\d)> ([^(]+)\((\d+)\) \[(\S+)\] (.*)/;
+
+  y2log.split("\n").forEach((line) => {
+    let res = line.match(log_regexp);
+
+    if (res) {
+      const entry = {
+        date: res[1],
+        time: res[2],
+        level: res[3],
+        host: res[4],
+        pid: res[5],
+        component: res[6],
+        group: component_group(res[6]),
+        message: res[7],
+        location: null
+      };
+
+      // Ruby locations might contains spaces, parse it specifically
+      res = entry.message.match(/^([^ ]*:\d+) (.*)/) ||
+        entry.message.match(/^(.*\(block in .*\):\d+) (.*)/) ||
+        entry.message.match(/^(.*\(block \(\d+ levels\) in .*\):\d+) (.*)/) ||
+        entry.message.match(/^(.*\(ensure in .*\):\d+) (.*)/);
+
+      if (res) {
+        entry.location = res[1];
+        entry.message = res[2];
+      }
+
+      components.add(entry.group);
+
+      lines.push(entry);
+    } else if (lines.length > 0) {
+      // if the line does not match append it to previous line message,
+      // it is a multiline message
+      const last_item = lines[lines.length - 1];
+      last_item.message = last_item.message ? last_item.message + "\n" + line : line;
+      lines[lines.length - 1] = last_item;
+    }
+  });
+
+  if (process.env.NODE_ENV !== "production") {
+    console.timeEnd("Parsing y2log");
+    console.log("Loaded " + lines.length + " lines");
+  }
+
+  return { lines, components };
+}


### PR DESCRIPTION
## Problem

Improve the y2log viewer, related to #407 

- Error level highlighting (warnings in orange, errors in red) to quickly spot the problems
- Allow filtering by log level, e.g. display only errors and warnings
- Allow filtering by component, e.g. display only libzypp or libstorage messages
- By default hide the not important data in the view (like date, host name, PID)
- Also automatically scroll to end of the y2log, the most interesting part is usually at the very end

## Questions and TODOs

- [ ] Split the code to a separate component (move from `components/core` to `components/logviewer` or so?)
- [ ] Fix the SCSS (get the values from PatternFly SCSS)
- [ ] Fix the layout, replace the `<div>` workaround with `<Flex>` PatternFly components (maybe still needs a custom CSS)
- [ ] Add more comments
- [ ] Add unit tests, fix broken ones

## Testing

- Tested manually

## Screenshots

An example how to display only the libstorage errors and warnings

![y2log_filter](https://user-images.githubusercontent.com/907998/217208282-6c0d71cf-7353-4d82-89b1-c158b306daf4.gif)
