### PR TITLE
Playwright test improvements

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -59,7 +59,7 @@ in the main `README.md` file.
 To fully run the installation type this:
 
 ```
-RUN_INSTALLATION=1 BASE_URL=https://<host>:9090 npx playwright test --headed --project chromium take_screenshots
+SCREENSHOT_MODE=1 RUN_INSTALLATION=1 BASE_URL=https://<host>:9090 npx playwright test --headed --project chromium take_screenshots
 ```
 
 The `--headed` option shows the browser window so you can see the progress.

--- a/playwright/global-setup.ts
+++ b/playwright/global-setup.ts
@@ -22,7 +22,7 @@ function findProject(config: FullConfig):FullProject {
   const optionIndex = process.argv.findIndex(a => a === "--project");
   if (optionIndex >= 0) {
     const projectName = process.argv[optionIndex + 1];
-    project = config.projects.find(p => p.name === projectName && fs.existsSync(p.use.launchOptions.executablePath));
+    project = config.projects.find(p => p.name === projectName);
   }
   else {
     project = config.projects.find(p => fs.existsSync(p.use.launchOptions.executablePath));

--- a/playwright/tests/take_screenshots.spec.ts
+++ b/playwright/tests/take_screenshots.spec.ts
@@ -22,8 +22,10 @@ test.describe("The Installer", () => {
     // maximum time for this test to run
     test.setTimeout(60 * minute);
 
-    // set screenshot size to 768x1024
-    page.setViewportSize({ width: 768, height: 1024 });
+    if (process.env.SCREENSHOT_MODE === "1") {
+      // set screenshot size to 768x1024
+      page.setViewportSize({ width: 768, height: 1024 });
+    }
 
     // optional actions done on the page
     const actions = Object.freeze({


### PR DESCRIPTION
## Small improvements for the Playwright tests

- Set the view port size only explicitly, keep the default size to be unified with the other tests
- Do not check the executable path in the setup code, when using the Playwright own browsers that option is not defined