### PR TITLE
Fix dns handling as the deprecated ipv4.dns options has precedence over ipv4["dns-data"] when given

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Mon Apr  3 08:13:55 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
-- Fix dns handling (gh#openSUSE/agama#518).
+- Fix DNS handling by using ipv4.dns-data instead of ipv4.dns (gh#openSUSE/agama#518).
 
 -------------------------------------------------------------------
 Wed Mar 29 11:32:13 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Apr  3 08:13:55 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix dns handling (gh#openSUSE/agama#518).
+
+-------------------------------------------------------------------
 Wed Mar 29 11:32:13 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Rename D-Installer to Agama (gh#openSUSE/agama#507).

--- a/web/src/client/network/network_manager.js
+++ b/web/src/client/network/network_manager.js
@@ -146,7 +146,7 @@ const connectionToCockpit = (connection) => {
  * @return {object} Object to be used with the UpdateConnection D-Bus method
  */
 const mergeConnectionSettings = (settings, connection) => {
-  // We need to delete this keys or otherwise them have precedence over the key-data ones
+  // We need to delete these keys or otherwise they have precedence over the key-data ones
   const { addresses, gateway, dns, ...cleanIPv4 } = settings.ipv4 || {};
   const { connection: conn, ipv4 } = connectionToCockpit(connection);
 

--- a/web/src/client/network/network_manager.js
+++ b/web/src/client/network/network_manager.js
@@ -23,7 +23,6 @@
 //
 import DBusClient from "../dbus";
 import cockpit from "../../lib/cockpit";
-import { intToIPString, stringToIPInt } from "./utils";
 import { NetworkEventTypes } from "./index";
 import { createAccessPoint, createConnection, SecurityProtocols } from "./model";
 
@@ -111,7 +110,7 @@ const connectionToCockpit = (connection) => {
           prefix: cockpit.variant("u", parseInt(addr.prefix.toString()))
         }
       ))),
-      dns: cockpit.variant("au", ipv4.nameServers.map(stringToIPInt)),
+      "dns-data": cockpit.variant("as", ipv4.nameServers),
       method: cockpit.variant("s", ipv4.method)
     }
   };
@@ -147,7 +146,8 @@ const connectionToCockpit = (connection) => {
  * @return {object} Object to be used with the UpdateConnection D-Bus method
  */
 const mergeConnectionSettings = (settings, connection) => {
-  const { addresses, gateway, ...cleanIPv4 } = settings.ipv4 || {};
+  // We need to delete this keys or otherwise them have precedence over the key-data ones
+  const { addresses, gateway, dns, ...cleanIPv4 } = settings.ipv4 || {};
   const { connection: conn, ipv4 } = connectionToCockpit(connection);
 
   return {
@@ -269,8 +269,7 @@ class NetworkManagerAdapter {
         addresses: ipv4["address-data"].v.map(({ address, prefix }) => {
           return { address: address.v, prefix: prefix.v };
         }),
-        // FIXME: handle different byte-order (little-endian vs big-endian)
-        nameServers: ipv4.dns?.v.map(intToIPString) || [],
+        nameServers: ipv4["dns-data"]?.v || [],
         method: ipv4.method.v,
       };
       if (ipv4.gateway?.v) conn.ipv4.gateway = ipv4.gateway.v;

--- a/web/src/client/network/network_manager.test.js
+++ b/web/src/client/network/network_manager.test.js
@@ -206,7 +206,8 @@ const connectionSettingsMock = {
       ),
       method: cockpit.variant("s", "auto"),
       gateway: cockpit.variant("s", "192.168.122.1"),
-      dns: cockpit.variant("au", [67305985, 16843009]),
+      // this field is buggy and superseded by dns-data. test that it is not used.
+      dns: cockpit.variant("au", [67305985]),
       "dns-data": cockpit.variant("as", ["192.168.122.1", "1.1.1.1"]),
       "route-data": []
     }

--- a/web/src/client/network/network_manager.test.js
+++ b/web/src/client/network/network_manager.test.js
@@ -126,7 +126,8 @@ const connections = {
         addresses: [],
         "address-data": cockpit.variant("aa{sv}", []),
         method: cockpit.variant("s", "auto"),
-        dns: cockpit.variant("au", []),
+        dns: [],
+        "dns-data": cockpit.variant("as", []),
         "route-data": []
       },
       "802-11-wireless": {
@@ -206,6 +207,7 @@ const connectionSettingsMock = {
       method: cockpit.variant("s", "auto"),
       gateway: cockpit.variant("s", "192.168.122.1"),
       dns: cockpit.variant("au", [67305985, 16843009]),
+      "dns-data": cockpit.variant("as", ["192.168.122.1", "1.1.1.1"]),
       "route-data": []
     }
   }),
@@ -321,7 +323,7 @@ describe("NetworkManagerAdapter", () => {
           addresses: [{ address: "192.168.122.200", prefix: 24 }],
           gateway: "192.168.122.1",
           method: "auto",
-          nameServers: ["1.2.3.4", "1.1.1.1"]
+          nameServers: ["192.168.122.1", "1.1.1.1"]
         }
       });
     });
@@ -503,7 +505,7 @@ describe("mergeConnectionSettings", () => {
         address: cockpit.variant("s", "192.168.1.2"),
         prefix: cockpit.variant("u", 24)
       }]),
-      dns: cockpit.variant("au", []),
+      "dns-data": cockpit.variant("as", []),
       method: cockpit.variant("s", "auto"),
       "routes-data": cockpit.variant("aau", [])
     });


### PR DESCRIPTION
It fixes issue #517 

As described in the issue, the **GetSettings** method is returning a wrong **ipv4.dns** value caused by an endianess problem therefore we should rely on the **ipv4["dns-data"]** as we do with the addresses and gateway. It is not enough to just get and set the **ipv4["dns-data"]** because when both options are given it looks like ipv4.dns still has precedence which looks like a bug in NetworkManager DBUS API.

```bash
busctl call org.freedesktop.NetworkManager /org/freedesktop/NetworkManager/Settings/1 org.freedesktop.NetworkManager.Settings.Connection GetSettings

#returns something like
... "dns" au 1 3300888568 "dns-data" as 1 "10.160.0.1" ...
```

From https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/63eaf168d1b8a8cbac4fbeb1d6806cebccbabdb2

> Btw, in particular "au" is bad, because we put there a big-endian
> number. There is no D-Bus type to represent big endian numbers, so "u"
> is bad because it can cause endianess problem when trying to remote
> the D-Bus communication to another host (without explicitly
> understanding which "u" properties need to swap for endinness).
> 

- https://networkmanager.dev/docs/api/latest/nm-settings-dbus.html