### PR TITLE
[web] CSS adjustments and cleanup

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "d-installer",
+  "name": "agama",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "d-installer",
+      "name": "agama",
       "license": "LGPL-2.1",
       "dependencies": {
         "@material-symbols/svg-400": "^0.4.2",

--- a/web/src/assets/styles/app.scss
+++ b/web/src/assets/styles/app.scss
@@ -1,10 +1,5 @@
-.loading-screen-icon {
-  text-align: center;
-
-  svg {
-    block-size: 10rem;
-    inline-size: 10rem;
-  }
+#root {
+  height: 100%;
 }
 
 // Make proposal actions compact
@@ -25,10 +20,6 @@
 
 .expandable-actions > div {
   margin-block-start: 0;
-}
-
-.overview-users > div {
-  margin-block-start: 0.5ex;
 }
 
 // Using a "selected-product" CSS class because sadly we cannot use
@@ -53,36 +44,6 @@
 
   .pf-c-radio__description {
     color: var(--color-primary-darkest);
-  }
-}
-
-.collapsed {
-  height: 0;
-  overflow: hidden;
-}
-
-.hidden {
-  visibility: hidden;
-}
-
-.host-ip {
-  vertical-align: middle;
-  color: var(--color-gray);
-}
-
-ul.connections-datalist {
-  border: 0;
-
-  li {
-    border: 0;
-    // TODO: get rid of this nested overrides once the network overview UI is better defined
-    .pf-c-data-list__item-row {
-      padding-inline: 0;
-
-      .pf-c-data-list__item-content {
-        padding-block-end: 0;
-      }
-    }
   }
 }
 
@@ -113,22 +74,6 @@ button.remove-link:hover {
   color: var(--pf-c-button--m-danger--BackgroundColor);
 }
 
-// Custom styles for summary warnings
-.warning-text {
-  color: var(--pf-global--warning-color--200);
-  font-size: calc(var(--fs-base) - 2px);
-
-  a, small {
-    text-decoration: underline;
-    margin-inline: 4px;
-    color: var(--pf-global--warning-color--200);
-    font-size: calc(var(--fs-base) - 2px);
-  }
-
-  svg {
-    fill: var(--pf-global--warning-color--200);
-  }
-}
 
 button.hidden-popover-button {
   visibility: hidden;
@@ -167,8 +112,4 @@ button.hidden-popover-button {
   .pf-c-label {
     margin-inline-end: 5px;
   }
-}
-
-#root {
-  height: 100%;
 }

--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -116,12 +116,6 @@ table td > .pf-c-empty-state {
   --pf-c-data-list--BorderTopWidth: 2px;
 }
 
-section .pf-c-toolbar {
-  --stack-gutter: 0;
-  --pf-c-toolbar--PaddingBottom: 0;
-  --pf-c-toolbar--PaddingTop: 0;
-}
-
 .pf-c-toolbar {
   border-block-end: 1px solid var(--color-gray-light);
 }

--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -123,3 +123,15 @@ table td > .pf-c-empty-state {
 .pf-c-text-input-group__utilities .pf-c-button {
   padding: 0;
 }
+
+.pf-m-grid-md {
+  &.pf-c-table {
+    tbody:first-of-type {
+      --pf-c-table--tbody--responsive--border-width--base: 4px;
+    }
+
+    tr:not(.pf-c-table__expandable-row) {
+      --pf-c-table-tr--responsive--border-width--base: 4px;
+    }
+  }
+}

--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -106,6 +106,11 @@ table td > .pf-c-empty-state {
   --pf-c-form__label--m-disabled--hover--Cursor: default;
 }
 
+// Do not show top border for empty data lists
+.pf-c-data-list:empty {
+  --pf-c-data-list--BorderTopWidth: 0;
+}
+
 // Do not use thick border-top for data lists
 .pf-c-data-list {
   --pf-c-data-list--BorderTopWidth: 2px;

--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -116,11 +116,6 @@ table td > .pf-c-empty-state {
   --pf-c-data-list--BorderTopWidth: 2px;
 }
 
-// Toolbar content aligned to the right (alignment prop seems to be ignored)
-.pf-c-toolbar__content-section {
-  justify-content: flex-end;
-}
-
 section .pf-c-toolbar {
   --stack-gutter: 0;
   --pf-c-toolbar--PaddingBottom: 0;

--- a/web/src/assets/styles/utilities.scss
+++ b/web/src/assets/styles/utilities.scss
@@ -121,6 +121,10 @@
   padding: 0;
 }
 
+.no-stack-gutter {
+  --stack-gutter: 0;
+}
+
 .tallest {
   /** block-size fallbacks **/
   height: 95dvh;

--- a/web/src/components/network/ConnectionsTable.jsx
+++ b/web/src/components/network/ConnectionsTable.jsx
@@ -70,7 +70,7 @@ export default function ConnectionsTable ({
   if (connections.length === 0) return null;
 
   return (
-    <TableComposable gridBreakPoint="grid-sm" variant="compact">
+    <TableComposable variant="compact">
       <Thead>
         <Tr>
           <Th width={25}>Name</Th>
@@ -97,8 +97,8 @@ export default function ConnectionsTable ({
 
           return (
             <Tr key={connection.id}>
-              <Td>{connection.name}</Td>
-              <Td>{connection.addresses.map(formatIp).join(", ")}</Td>
+              <Td dataLabel="Name">{connection.name}</Td>
+              <Td dataLabel="Ip addresses">{connection.addresses.map(formatIp).join(", ")}</Td>
               <Td isActionCell>
                 <RowActions actions={actions} connection={connection} />
               </Td>

--- a/web/src/components/network/DnsDataList.jsx
+++ b/web/src/components/network/DnsDataList.jsx
@@ -93,10 +93,12 @@ export default function DnsDataList({ servers: originalServers, updateDnsServers
 
   return (
     <>
-      <FormLabel>DNS</FormLabel>
-      <Button isSmall variant="secondary" onClick={addServer}>
-        {newDnsButtonText}
-      </Button>
+      <div className="split justify-between">
+        <FormLabel>DNS</FormLabel>
+        <Button isSmall variant="secondary" onClick={addServer}>
+          {newDnsButtonText}
+        </Button>
+      </div>
       <DataList isCompact gridBreakpoint="none" title="Addresses data list">
         {servers.map(server => renderDns(server))}
       </DataList>

--- a/web/src/components/storage/DASDTable.jsx
+++ b/web/src/components/storage/DASDTable.jsx
@@ -179,7 +179,7 @@ export default function DASDTable({ state, dispatch }) {
     <>
       <Toolbar>
         <ToolbarContent>
-          <ToolbarGroup>
+          <ToolbarGroup alignment={{ default: "alignRight" }}>
             <ToolbarItem>
               <TextInputGroup>
                 <TextInputGroupMain

--- a/web/src/components/storage/iscsi/InitiatorPresenter.jsx
+++ b/web/src/components/storage/iscsi/InitiatorPresenter.jsx
@@ -86,9 +86,9 @@ export default function InitiatorPresenter({ initiator, client }) {
 
     return (
       <Tr>
-        <Td>{initiator.name}</Td>
-        <Td>{initiator.ibft ? "Yes" : "No"}</Td>
-        <Td>{initiator.offloadCard || "None"}</Td>
+        <Td dataLabel="Name">{initiator.name}</Td>
+        <Td dataLabel="iBFT">{initiator.ibft ? "Yes" : "No"}</Td>
+        <Td dataLabel="Offload card">{initiator.offloadCard || "None"}</Td>
         <Td isActionCell>
           <RowActions actions={initiatorActions()} id="actions-for-initiator" />
         </Td>
@@ -98,7 +98,7 @@ export default function InitiatorPresenter({ initiator, client }) {
 
   return (
     <>
-      <TableComposable gridBreakPoint="grid-sm" variant="compact">
+      <TableComposable variant="compact">
         <Thead>
           <Tr>
             <Th width={50}>Name</Th>

--- a/web/src/components/storage/iscsi/InitiatorPresenter.jsx
+++ b/web/src/components/storage/iscsi/InitiatorPresenter.jsx
@@ -98,7 +98,7 @@ export default function InitiatorPresenter({ initiator, client }) {
 
   return (
     <>
-      <TableComposable gridBreakPoint="grid-sm" variant="compact" className="users">
+      <TableComposable gridBreakPoint="grid-sm" variant="compact">
         <Thead>
           <Tr>
             <Th width={50}>Name</Th>

--- a/web/src/components/storage/iscsi/InitiatorSection.jsx
+++ b/web/src/components/storage/iscsi/InitiatorSection.jsx
@@ -45,7 +45,7 @@ export default function InitiatorSection() {
   }, [cancellablePromise, client.iscsi]);
 
   return (
-    <Section title="Initiator" iconName="settings">
+    <Section title="Initiator">
       <InitiatorPresenter
         initiator={initiator}
         client={client}

--- a/web/src/components/storage/iscsi/NodesPresenter.jsx
+++ b/web/src/components/storage/iscsi/NodesPresenter.jsx
@@ -116,11 +116,11 @@ export default function NodesPresenter ({ nodes, client }) {
   const NodeRow = ({ node }) => {
     return (
       <Tr>
-        <Td>{node.target}</Td>
-        <Td>{node.address + ":" + node.port}</Td>
-        <Td>{node.interface}</Td>
-        <Td>{node.ibft ? "Yes" : "No"}</Td>
-        <Td>{nodeStatus(node)}</Td>
+        <Td dataLabel="Name">{node.target}</Td>
+        <Td dataLabel="Portal">{node.address + ":" + node.port}</Td>
+        <Td dataLabel="Interface">{node.interface}</Td>
+        <Td dataLabel="iBFT">{node.ibft ? "Yes" : "No"}</Td>
+        <Td dataLabel="Status">{nodeStatus(node)}</Td>
         <Td isActionCell>
           <RowActions actions={nodeActions(node)} id={`actions-for-node${node.id}`} />
         </Td>
@@ -134,7 +134,7 @@ export default function NodesPresenter ({ nodes, client }) {
 
   return (
     <>
-      <TableComposable gridBreakPoint="grid-sm" variant="compact">
+      <TableComposable variant="compact">
         <Thead>
           <Tr>
             <Th>Name</Th>

--- a/web/src/components/storage/iscsi/NodesPresenter.jsx
+++ b/web/src/components/storage/iscsi/NodesPresenter.jsx
@@ -134,7 +134,7 @@ export default function NodesPresenter ({ nodes, client }) {
 
   return (
     <>
-      <TableComposable gridBreakPoint="grid-sm" variant="compact" className="users">
+      <TableComposable gridBreakPoint="grid-sm" variant="compact">
         <Thead>
           <Tr>
             <Th>Name</Th>

--- a/web/src/components/storage/iscsi/TargetsSection.jsx
+++ b/web/src/components/storage/iscsi/TargetsSection.jsx
@@ -160,7 +160,7 @@ export default function TargetsSection() {
   };
 
   return (
-    <Section title="Targets" iconName="lan">
+    <Section title="Targets">
       <SectionContent />
       { state.isDiscoverFormOpen &&
         <DiscoverForm

--- a/web/src/components/storage/iscsi/TargetsSection.jsx
+++ b/web/src/components/storage/iscsi/TargetsSection.jsx
@@ -144,7 +144,7 @@ export default function TargetsSection() {
 
     return (
       <>
-        <Toolbar>
+        <Toolbar className="no-stack-gutter">
           <ToolbarContent alignment="alignRight">
             <ToolbarItem alignment={{ default: "alignRight" }}>
               <Button onClick={openDiscoverForm}>Discover</Button>

--- a/web/src/components/storage/iscsi/TargetsSection.jsx
+++ b/web/src/components/storage/iscsi/TargetsSection.jsx
@@ -146,7 +146,7 @@ export default function TargetsSection() {
       <>
         <Toolbar>
           <ToolbarContent alignment="alignRight">
-            <ToolbarItem>
+            <ToolbarItem alignment={{ default: "alignRight" }}>
               <Button onClick={openDiscoverForm}>Discover</Button>
             </ToolbarItem>
           </ToolbarContent>

--- a/web/src/components/users/FirstUser.jsx
+++ b/web/src/components/users/FirstUser.jsx
@@ -73,7 +73,7 @@ const UserNotDefined = ({ actionCb }) => {
 
 const UserData = ({ user, actions }) => {
   return (
-    <TableComposable gridBreakPoint="grid-sm" variant="compact" className="users">
+    <TableComposable gridBreakPoint="grid-sm" variant="compact">
       <Thead>
         <Tr>
           <Th width={25}>Fullname</Th>

--- a/web/src/components/users/FirstUser.jsx
+++ b/web/src/components/users/FirstUser.jsx
@@ -73,7 +73,7 @@ const UserNotDefined = ({ actionCb }) => {
 
 const UserData = ({ user, actions }) => {
   return (
-    <TableComposable gridBreakPoint="grid-sm" variant="compact">
+    <TableComposable variant="compact">
       <Thead>
         <Tr>
           <Th width={25}>Fullname</Th>
@@ -83,8 +83,8 @@ const UserData = ({ user, actions }) => {
       </Thead>
       <Tbody>
         <Tr>
-          <Td>{user.fullName}</Td>
-          <Td>{user.userName}</Td>
+          <Td dataLabel="Fullname">{user.fullName}</Td>
+          <Td dataLabel="Username">{user.userName}</Td>
           <Td isActionCell>
             <RowActions actions={actions} id={`actions-for-${user.userName}`} />
           </Td>

--- a/web/src/components/users/RootAuthMethods.jsx
+++ b/web/src/components/users/RootAuthMethods.jsx
@@ -146,7 +146,7 @@ export default function RootAuthMethods() {
 
   return (
     <>
-      <TableComposable gridBreakPoint="grid-sm" variant="compact">
+      <TableComposable variant="compact" gridBreakPoint="grid-md">
         <Thead>
           <Tr>
             <Th width={25}>Method</Th>
@@ -156,15 +156,15 @@ export default function RootAuthMethods() {
         </Thead>
         <Tbody>
           <Tr>
-            <Td>Password</Td>
-            <Td><PasswordLabel /></Td>
+            <Td dataLabel="Method">Password</Td>
+            <Td dataLabel="Status"><PasswordLabel /></Td>
             <Td isActionCell>
               <RowActions actions={passwordActions} id="actions-for-root-password" />
             </Td>
           </Tr>
           <Tr>
-            <Td>SSH Key</Td>
-            <Td><SSHKeyLabel /></Td>
+            <Td dataLabel="Method">SSH Key</Td>
+            <Td dataLabel="Status"><SSHKeyLabel /></Td>
             <Td isActionCell>
               <RowActions actions={sshKeyActions} id="actions-for-root-sshKey" />
             </Td>

--- a/web/src/components/users/RootAuthMethods.jsx
+++ b/web/src/components/users/RootAuthMethods.jsx
@@ -146,7 +146,7 @@ export default function RootAuthMethods() {
 
   return (
     <>
-      <TableComposable gridBreakPoint="grid-sm" variant="compact" className="users">
+      <TableComposable gridBreakPoint="grid-sm" variant="compact">
         <Thead>
           <Tr>
             <Th width={25}>Method</Th>

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -57,10 +57,12 @@ import { NetworkPage } from "~/components/network";
  */
 import "~/assets/styles/index.scss";
 
-// When running in the development server add a special login wrapper which
-// checks whether the user is authenticated. When building the code outside
-// the development server an empty fragment (<></>) is used which is no-op.
-// In the production builds the DevServerWrapper code is completely omitted.
+/**
+ * When running in the development server add a special login wrapper which
+ * checks whether the user is authenticated. When building the code outside
+ * the development server an empty fragment (<></>) is used which is no-op.
+ * In the production builds the DevServerWrapper code is completely omitted.
+ */
 const LoginWrapper = (process.env.WEBPACK_SERVE) ? DevServerWrapper : React.Fragment;
 
 const container = document.getElementById("root");

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -29,8 +29,11 @@ import { InstallerClientProvider } from "~/context/installer";
 import { SoftwareProvider } from "~/context/software";
 import { createClient } from "~/client";
 
+/**
+ * Import PF4 base styles before any JSX since components coming from PF4 may
+ * import styles dependent on variables and rules previously defined there.
+ */
 import "@patternfly/patternfly/patternfly-base.scss";
-import "~/assets/styles/index.scss";
 
 import App from "~/App";
 import Main from "~/Main";
@@ -41,6 +44,18 @@ import { ProposalPage as StoragePage, DASDPage, ISCSIPage } from "~/components/s
 import { UsersPage } from "~/components/users";
 import { L10nPage } from "~/components/l10n";
 import { NetworkPage } from "~/components/network";
+
+/**
+ * As JSX components might import CSS stylesheets, our styles must be imported
+ * after them to preserve our overrides (e.g., PF4 overrides).
+ *
+ * Because mini-css-extract-plugin maintains the order of the imported CSS,
+ * adding the overrides here ensures the overrides will be placed appropriately
+ * at the end of our stylesheet when it extracts the CSS from dist/index.js
+ *
+ * See https://github.com/cockpit-project/starter-kit/blob/aeb81718e75b54e5d50ee450fe2abfbcfa58f5e6/src/index.js
+ */
+import "~/assets/styles/index.scss";
 
 // When running in the development server add a special login wrapper which
 // checks whether the user is authenticated. When building the code outside


### PR DESCRIPTION
As a result of the evolving nature of the project, the internal parts involved in the UI build are not polished enough.  For example, there is a misuse of some components, the CSS kept piling up and it's getting a bit confusing, etc.

I'd like to mitigate progressively in combination with my work in other areas. So, Instead of creating a lengthy PR, I would rather make little changes to avoid conflicts and make sure the code base is up-to-date.

This particular PR focuses on four main things.

* Fix CSS imports to ensure the right order

* Make unused CSS cleanup

* Fix how the [Toolbar children](https://www.patternfly.org/v4/components/toolbar#toolbarcontent) are aligned

* Fix/Make better use of the [PF4 TableComposable](https://www.patternfly.org/v4/components/table) component by adding missing [dataLabel cell](https://www.patternfly.org/v4/components/table#td) props and fixing the [gridBreakpoint value](https://www.patternfly.org/v4/components/table#tablecomposable). Sadly, that component does not have a break point for using the "grid" version of the table only in small devices.

As a bonus, it updates the package-lock.json file too, previously forgotten when [renaming the project](https://github.com/openSUSE/agama/pull/509).

IMHO, since visually everything remains the same, this kind of improvement does not deserve an entry in the changelog. It would be more noisy than helpful.