### PR TITLE
Fix questions

### DIFF
--- a/service/lib/agama/dbus/clients/question.rb
+++ b/service/lib/agama/dbus/clients/question.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022] SUSE LLC
+# Copyright (c) [2022-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -37,7 +37,7 @@ module Agama
           super()
 
           @dbus_object = service[object_path]
-          @dbus_iface = @dbus_object["org.opensuse.Agama.Questions1"]
+          @dbus_iface = @dbus_object["org.opensuse.Agama.Questions1.Generic"]
           # one D-Bus client for all kinds of questions
           return unless @dbus_object.has_iface?(LUKS_ACTIVATION_IFACE)
 

--- a/service/lib/agama/dbus/question.rb
+++ b/service/lib/agama/dbus/question.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022] SUSE LLC
+# Copyright (c) [2022-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -38,9 +38,9 @@ module Agama
       # D-Bus question.
       module Interfaces
         # Generic interface for a question
-        module Question
-          QUESTION_INTERFACE = "org.opensuse.Agama.Questions1"
-          private_constant :QUESTION_INTERFACE
+        module Generic
+          GENERIC_INTERFACE = "org.opensuse.Agama.Questions1.Generic"
+          private_constant :GENERIC_INTERFACE
 
           # @!method backend
           #   @note Classes including this mixin must define a #backend method
@@ -92,7 +92,7 @@ module Agama
 
           def self.included(base)
             base.class_eval do
-              dbus_interface QUESTION_INTERFACE do
+              dbus_interface GENERIC_INTERFACE do
                 dbus_reader :id, "u"
                 dbus_reader :text, "s"
                 dbus_reader :options, "as"
@@ -146,8 +146,8 @@ module Agama
 
       # Defines the interfaces to implement according to the backend type
       INTERFACES_TO_INCLUDE = {
-        Agama::Question               => [Interfaces::Question],
-        Agama::LuksActivationQuestion => [Interfaces::Question, Interfaces::LuksActivation]
+        Agama::Question               => [Interfaces::Generic],
+        Agama::LuksActivationQuestion => [Interfaces::Generic, Interfaces::LuksActivation]
       }.freeze
       private_constant :INTERFACES_TO_INCLUDE
 

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr  5 14:12:51 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Rename D-Bus interface for generic questions
+  (gh@openSUSE/agama#524).
+
+-------------------------------------------------------------------
 Wed Mar 29 11:31:12 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Rename D-Installer to Agama (gh#openSUSE/agama#507).

--- a/service/test/agama/dbus/clients/question_test.rb
+++ b/service/test/agama/dbus/clients/question_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022] SUSE LLC
+# Copyright (c) [2022-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -29,8 +29,8 @@ describe Agama::DBus::Clients::Question do
     allow(bus).to receive(:service).with("org.opensuse.Agama.Questions1").and_return(service)
     allow(service).to receive(:[]).with("/org/opensuse/Agama/Questions1/23")
       .and_return(dbus_object)
-    allow(dbus_object).to receive(:[]).with("org.opensuse.Agama.Questions1")
-      .and_return(question_iface)
+    allow(dbus_object).to receive(:[]).with("org.opensuse.Agama.Questions1.Generic")
+      .and_return(generic_iface)
     allow(dbus_object).to receive(:[]).with("org.opensuse.Agama.Questions1.LuksActivation")
       .and_return(luks_iface)
     allow(dbus_object).to receive(:has_iface?).with(/LuksActivation/).and_return(luks_iface?)
@@ -39,7 +39,7 @@ describe Agama::DBus::Clients::Question do
   let(:bus) { instance_double(Agama::DBus::Bus) }
   let(:service) { instance_double(::DBus::Service) }
   let(:dbus_object) { instance_double(::DBus::ProxyObject) }
-  let(:question_iface) { instance_double(::DBus::ProxyObjectInterface) }
+  let(:generic_iface) { instance_double(::DBus::ProxyObjectInterface) }
   let(:luks_iface) { instance_double(::DBus::ProxyObjectInterface) }
   let(:luks_iface?) { true }
 
@@ -47,14 +47,14 @@ describe Agama::DBus::Clients::Question do
 
   describe "#answered?" do
     it "returns false if there is no answer" do
-      expect(question_iface).to receive(:[]).with("Answer").and_return("")
+      expect(generic_iface).to receive(:[]).with("Answer").and_return("")
       expect(subject.answered?).to eq false
     end
   end
 
   describe "#text" do
     it "returns the appropriate property" do
-      expect(question_iface).to receive(:[]).with("Text").and_return("the text")
+      expect(generic_iface).to receive(:[]).with("Text").and_return("the text")
       expect(subject.text).to eq "the text"
     end
   end

--- a/service/test/agama/dbus/question_test.rb
+++ b/service/test/agama/dbus/question_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022] SUSE LLC
+# Copyright (c) [2022-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -41,7 +41,7 @@ describe Agama::DBus::Question do
   let(:system_bus) { instance_double(DBus::SystemBus, emit: nil) }
 
   describe ".new" do
-    shared_examples "Question interface" do
+    shared_examples "Generic interface" do
       it "defines #id, #text, #options, #default_option, #answer" do
         expect(subject).to respond_to(:id, :text, :options, :default_option, :answer)
       end
@@ -142,7 +142,7 @@ describe Agama::DBus::Question do
 
       let(:default_option) { nil }
 
-      include_examples "Question interface"
+      include_examples "Generic interface"
 
       describe "#options" do
         it "returns the question options as strings" do
@@ -172,7 +172,7 @@ describe Agama::DBus::Question do
     context "for a question to activate a LUKS device" do
       let(:backend) { Agama::LuksActivationQuestion.new("/dev/sda1") }
 
-      include_examples "Question interface"
+      include_examples "Generic interface"
       include_examples "LuksActivation interface"
 
       describe "#options" do

--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Apr  5 14:14:32 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Fix issues with questions client (gh#openSUSE/agama#524).
+
+-------------------------------------------------------------------
 Mon Apr  3 08:13:55 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix DNS handling by using ipv4.dns-data instead of ipv4.dns (gh#openSUSE/agama#518).

--- a/web/src/client/questions.js
+++ b/web/src/client/questions.js
@@ -195,7 +195,7 @@ class QuestionsClient {
   onQuestionRemoved(handler) {
     return this.onObjectsChanged("InterfacesRemoved", path => {
       const id = path.split("/").at(-1);
-      handler(id);
+      handler(Number(id));
     });
   }
 }

--- a/web/src/client/questions.js
+++ b/web/src/client/questions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022] SUSE LLC
+ * Copyright (c) [2022-2023] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -34,7 +34,7 @@ const DBUS_CONFIG = {
   },
   question: {
     ifaces: {
-      question: "org.opensuse.Agama.Questions1",
+      generic: "org.opensuse.Agama.Questions1.Generic",
       luksActivation: "org.opensuse.Agama.Questions1.LuksActivation"
     }
   }
@@ -85,8 +85,8 @@ function buildQuestion(dbusQuestion) {
   const ifaces = getIfaces(dbusQuestion);
   const ifacesAndProperties = getIfacesAndProperties(dbusQuestion);
 
-  if (ifaces.includes(DBUS_CONFIG.question.ifaces.question)) {
-    const dbusProperties = ifacesAndProperties[DBUS_CONFIG.question.ifaces.question];
+  if (ifaces.includes(DBUS_CONFIG.question.ifaces.generic)) {
+    const dbusProperties = ifacesAndProperties[DBUS_CONFIG.question.ifaces.generic];
 
     question.type = QUESTION_TYPES.generic;
     question.id = fetchValue(dbusProperties, "Id");
@@ -148,7 +148,7 @@ class QuestionsClient {
       proxy.Password = question.password;
     }
 
-    const proxy = await this.client.proxy(DBUS_CONFIG.question.ifaces.question, path);
+    const proxy = await this.client.proxy(DBUS_CONFIG.question.ifaces.generic, path);
     proxy.Answer = question.answer;
   }
 

--- a/web/src/client/questions.test.js
+++ b/web/src/client/questions.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022] SUSE LLC
+ * Copyright (c) [2022-2023] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -25,10 +25,10 @@ import { QuestionsClient } from "./questions";
 jest.mock("./dbus");
 
 // NOTE: should we export them?
-const QUESTION_IFACE = "org.opensuse.Agama.Questions1";
+const GENERIC_IFACE = "org.opensuse.Agama.Questions1.Generic";
 const LUKS_ACTIVATION_IFACE = "org.opensuse.Agama.Questions1.LuksActivation";
 
-const questionsProxy = {
+const questionProxy = {
   wait: jest.fn(),
   Answer: ""
 };
@@ -41,7 +41,7 @@ const luksActivationProxy = {
 const questionPath = "/org/opensuse/Agama/Questions1/432";
 const ifacesAndProperties = {
   "org.freedesktop.DBus.Properties": {},
-  "org.opensuse.Agama.Questions1": {
+  "org.opensuse.Agama.Questions1.Generic": {
     Id: {
       t: "u",
       v: 432
@@ -96,7 +96,7 @@ const expectedQuestions = [
 ];
 
 const proxies = {
-  [QUESTION_IFACE]: questionsProxy,
+  [GENERIC_IFACE]: questionProxy,
   [LUKS_ACTIVATION_IFACE]: luksActivationProxy
 };
 
@@ -128,7 +128,7 @@ describe("#answer", () => {
     const client = new QuestionsClient();
     await client.answer(question);
 
-    expect(questionsProxy).toMatchObject({ Answer: 'the-answer' });
+    expect(questionProxy).toMatchObject({ Answer: 'the-answer' });
   });
 
   describe("when answering a question implementing the LUKS activation interface", () => {


### PR DESCRIPTION
## Problem

Two issues have been detected:

* a) Answering probing questions from the web UI does not work. The question popup is properly closed but the answer is not sent to the D-Bus service.

* b) Answering probing question from `busctl` does not work either. The answer is correctly sent to the D-Bus service, but the question popup is not closed.   

## Solution

For the issue a) the problem comes from the D-Bus interface name, which was modified with the Agama renaming. The main object `/org/opensuse/Agama/Questions1` implements an interface called `org.opensuse.Agama.Questions1`. And the objects for each individual question also implement an interface called `org.opensuse.Agama.Questions1`. This seems to confuse to cockpit D-Bus client, but I am not sure why. Using another name for the question interface (`org.opensuse.Agama.Questions1.Generic`) works as expected.

Note: In the issue a), the cockpit client works fine after reloading the page (F5). Probably because the question object is already exported when the questions client is created. 

For the issue b), there was a bug when requesting to remove the question. Basically, the question id was passed as an string but an integer was expeced.

## Testing

- Adapted unit test
- Tested manually
