### PR TITLE
Fix netmask handling (bsc#1210104)

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Apr 11 14:02:31 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix netmask handling (bsc#1210104).
+
+-------------------------------------------------------------------
 Wed Apr  5 14:14:32 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Fix issues with questions client (gh#openSUSE/agama#524).

--- a/web/src/client/network/network_manager.js
+++ b/web/src/client/network/network_manager.js
@@ -25,6 +25,7 @@ import DBusClient from "../dbus";
 import cockpit from "../../lib/cockpit";
 import { NetworkEventTypes } from "./index";
 import { createAccessPoint, createConnection, SecurityProtocols } from "./model";
+import { ipPrefixFor } from "./utils";
 
 /**
  * @typedef {import("./model").NetworkSettings} NetworkSettings
@@ -107,7 +108,7 @@ const connectionToCockpit = (connection) => {
       "address-data": cockpit.variant("aa{sv}", ipv4.addresses.map(addr => (
         {
           address: cockpit.variant("s", addr.address),
-          prefix: cockpit.variant("u", parseInt(addr.prefix.toString()))
+          prefix: cockpit.variant("u", ipPrefixFor(addr.prefix.toString()))
         }
       ))),
       "dns-data": cockpit.variant("as", ipv4.nameServers),

--- a/web/src/client/network/network_manager.test.js
+++ b/web/src/client/network/network_manager.test.js
@@ -349,7 +349,7 @@ describe("NetworkManagerAdapter", () => {
       const connection = await client.getConnection("uuid-wifi-1");
       connection.ipv4 = {
         ...connection.ipv4,
-        addresses: [{ address: "192.168.1.2", prefix: 24 }],
+        addresses: [{ address: "192.168.1.2", prefix: "255.255.255.0" }],
         gateway: "192.168.1.1",
         nameServers: ["1.2.3.4"]
       };

--- a/web/src/client/network/utils.js
+++ b/web/src/client/network/utils.js
@@ -54,6 +54,22 @@ const isValidIpPrefix = (value) => {
 };
 
 /**
+ * Prefix for the given prefix or netmask
+ *
+ * By now, only IPv4 is supported.
+ *
+ * @param {string} value - An netmask or a network prefix
+ * @return {number} prefix for the given netmask or prefix
+ */
+const ipPrefixFor = (value) => {
+  if (value.match(/^\d+$/)) {
+    return parseInt(value);
+  } else {
+    return ipaddr.IPv4.parse(value).prefixLengthFromSubnetMask();
+  }
+};
+
+/**
  *  Converts an IP given in decimal format to text format
  *
  * FIXME: IPv6 is not supported yet.
@@ -104,5 +120,6 @@ export {
   isValidIpPrefix,
   intToIPString,
   stringToIPInt,
-  formatIp
+  formatIp,
+  ipPrefixFor
 };

--- a/web/src/client/network/utils.test.js
+++ b/web/src/client/network/utils.test.js
@@ -21,7 +21,7 @@
 
 // @ts-check
 
-import { isValidIp, isValidIpPrefix, intToIPString, stringToIPInt, formatIp } from "./utils";
+import { isValidIp, isValidIpPrefix, intToIPString, stringToIPInt, formatIp, ipPrefixFor } from "./utils";
 
 describe("#isValidIp", () => {
   it("returns true when the IP is valid", () => {
@@ -46,6 +46,13 @@ describe("#isValidIpPrefix", () => {
   it("returns false when it is not neither a valid netmask nor a network prefix", () => {
     expect(isValidIpPrefix("88")).toEqual(false);
     expect(isValidIpPrefix("not-an-netmask")).toEqual(false);
+  });
+});
+
+describe("#ipPrefixFor", () => {
+  it("returns the prefix as an integer for the given netmask or prefix", () => {
+    expect(ipPrefixFor("255.255.0.0")).toEqual(16);
+    expect(ipPrefixFor("24")).toEqual(24);
   });
 });
 


### PR DESCRIPTION
## Problem

Agama does not handle correctly the IP address **netmask** but works fine when a **prefix length** is used.

- https://bugzilla.suse.com/show_bug.cgi?id=1210104

## Solution

When a connection is updated it always expect a prefix length but in the IP Input form it is allowed to use a netmask or a prefix length.

![Screenshot from 2023-04-11 14-51-38](https://user-images.githubusercontent.com/7056681/231184673-b3315f3f-23e1-4d75-a85a-73f2031af7d8.png)

Therefore, the code has been adapted converting the **netmask** to a **prefix length** when needed.

![netmask](https://user-images.githubusercontent.com/7056681/231187664-ca78076c-58c0-40b6-b1be-785759512835.gif)


## Testing

- *Added a new unit test*
- *Tested manually*


