### PR TITLE
Kill cockpit when we're done

### DIFF
--- a/service/lib/agama/dbus/manager.rb
+++ b/service/lib/agama/dbus/manager.rb
@@ -56,6 +56,9 @@ module Agama
       CONFIG_PHASE = 1
       INSTALL_PHASE = 2
 
+      IGUANA_NOT_USED = 0
+      IGUANA_USED = 1
+
       dbus_interface MANAGER_INTERFACE do
         dbus_method(:Probe, "") { config_phase }
         dbus_method(:Commit, "") { install_phase }
@@ -63,6 +66,7 @@ module Agama
         dbus_method(:CollectLogs, "out tarball_filesystem_path:s, in user:s") { |u| collect_logs(u) }
         dbus_reader :installation_phases, "aa{sv}"
         dbus_reader :current_installation_phase, "u"
+        dbus_reader :iguana_backend, "b"
         dbus_reader :busy_services, "as"
       end
 
@@ -112,6 +116,11 @@ module Agama
         return STARTUP_PHASE if backend.installation_phase.startup?
         return CONFIG_PHASE if backend.installation_phase.config?
         return INSTALL_PHASE if backend.installation_phase.install?
+      end
+
+      # States whether installation runs on iguana
+      def iguana_backend
+        return backend.iguana? ? IGUANA_USED : IGUANA_NOT_USED
       end
 
       # Name of the services that are currently busy

--- a/service/lib/agama/dbus/manager.rb
+++ b/service/lib/agama/dbus/manager.rb
@@ -56,14 +56,15 @@ module Agama
       CONFIG_PHASE = 1
       INSTALL_PHASE = 2
 
-      IGUANA_NOT_USED = 0
-      IGUANA_USED = 1
+      IGUANA_NOT_USED = false
+      IGUANA_USED = true
 
       dbus_interface MANAGER_INTERFACE do
         dbus_method(:Probe, "") { config_phase }
         dbus_method(:Commit, "") { install_phase }
         dbus_method(:CanInstall, "out result:b") { can_install? }
         dbus_method(:CollectLogs, "out tarball_filesystem_path:s, in user:s") { |u| collect_logs(u) }
+        dbus_method(:Finish, "") { finish_phase }
         dbus_reader :installation_phases, "aa{sv}"
         dbus_reader :current_installation_phase, "u"
         dbus_reader :iguana_backend, "b"
@@ -96,6 +97,11 @@ module Agama
       # Collects the YaST logs
       def collect_logs(user)
         backend.collect_logs(user)
+      end
+
+      # Last action for the installer
+      def finish_phase
+        backend.finish_installation
       end
 
       # Description of all possible installation phase values

--- a/service/lib/agama/dbus/manager.rb
+++ b/service/lib/agama/dbus/manager.rb
@@ -126,7 +126,7 @@ module Agama
 
       # States whether installation runs on iguana
       def iguana_backend
-        return backend.iguana? ? IGUANA_USED : IGUANA_NOT_USED
+        backend.iguana? ? IGUANA_USED : IGUANA_NOT_USED
       end
 
       # Name of the services that are currently busy

--- a/service/lib/agama/dbus/manager.rb
+++ b/service/lib/agama/dbus/manager.rb
@@ -56,9 +56,6 @@ module Agama
       CONFIG_PHASE = 1
       INSTALL_PHASE = 2
 
-      IGUANA_NOT_USED = false
-      IGUANA_USED = true
-
       dbus_interface MANAGER_INTERFACE do
         dbus_method(:Probe, "") { config_phase }
         dbus_method(:Commit, "") { install_phase }
@@ -126,7 +123,7 @@ module Agama
 
       # States whether installation runs on iguana
       def iguana_backend
-        backend.iguana? ? IGUANA_USED : IGUANA_NOT_USED
+        backend.iguana?
       end
 
       # Name of the services that are currently busy

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -193,11 +193,22 @@ module Agama
       path
     end
 
+    # Whatever has to be done at the end of installation
+    def finish_installation
+      cmd = if iguana?
+        "systemctl stop cockpit-wsinstance-http.service"
+      else
+        "/usr/sbin/shutdown -r now"
+      end
+
+      return system(cmd)
+    end
+
     # Says whether running on iguana or not
     #
     # @return [Boolean] true when running on iguana
     def iguana?
-      return true
+      return false
     end
 
   private

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -193,6 +193,13 @@ module Agama
       path
     end
 
+    # Says whether running on iguana or not
+    #
+    # @return [Boolean] true when running on iguana
+    def iguana?
+      return true
+    end
+
   private
 
     attr_reader :config

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -208,7 +208,7 @@ module Agama
     #
     # @return [Boolean] true when running on iguana
     def iguana?
-      return false
+      return Dir.exist?("/iguana")
     end
 
   private

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -203,14 +203,14 @@ module Agama
 
       logger.info("Finishing installation with #{cmd}")
 
-      return system(cmd)
+      system(cmd)
     end
 
     # Says whether running on iguana or not
     #
     # @return [Boolean] true when running on iguana
     def iguana?
-      return Dir.exist?("/iguana")
+      Dir.exist?("/iguana")
     end
 
   private

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -201,6 +201,8 @@ module Agama
         "/usr/sbin/shutdown -r now"
       end
 
+      logger.info("Finishing installation with #{cmd}")
+
       return system(cmd)
     end
 

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -196,7 +196,7 @@ module Agama
     # Whatever has to be done at the end of installation
     def finish_installation
       cmd = if iguana?
-        "systemctl stop cockpit-wsinstance-http.service"
+        "systemctl stop agama"
       else
         "/usr/sbin/shutdown -r now"
       end

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -196,7 +196,7 @@ module Agama
     # Whatever has to be done at the end of installation
     def finish_installation
       cmd = if iguana?
-        "systemctl stop agama"
+        "/usr/bin/agamactl -k"
       else
         "/usr/sbin/shutdown -r now"
       end

--- a/web/src/client/manager.js
+++ b/web/src/client/manager.js
@@ -116,19 +116,11 @@ class ManagerBaseClient {
   }
 
   /**
-   * Returns whether calling the system reboot succeeded or not.
-   *
-   * @return {Promise<boolean>}
+   * Runs cleanup when installation is done
    */
-  rebootSystem() {
-    return cockpit.spawn(["/usr/sbin/shutdown", "-r", "now"]);
-  }
-
-  /**
-   * Returns whether finishing cockpit succeeded
-   */
-  finishCockpit() {
-    return cockpit.spawn(["systemctl", "stop", "cockpit-wsinstance-http.service"]);
+  async finishInstallation() {
+    const proxy = await this.client.proxy(MANAGER_IFACE);
+    return proxy.Finish;
   }
 
   /**

--- a/web/src/client/manager.js
+++ b/web/src/client/manager.js
@@ -123,6 +123,13 @@ class ManagerBaseClient {
   rebootSystem() {
     return cockpit.spawn(["/usr/sbin/shutdown", "-r", "now"]);
   }
+
+  /**
+   * Returns whether finishing cockpit succeeded
+   */
+  finishCockpit() {
+    return cockpit.spawn(["systemctl", "stop", "cockpit.service"]);
+  }
 }
 
 /**

--- a/web/src/client/manager.js
+++ b/web/src/client/manager.js
@@ -130,6 +130,13 @@ class ManagerBaseClient {
   finishCockpit() {
     return cockpit.spawn(["systemctl", "stop", "cockpit.service"]);
   }
+
+  /**
+   * Returns whether Iguana is used on the system
+   */
+  useIguana() {
+    return cockpit.script("[ -d /iguana ] && echo -n iguana");
+  }
 }
 
 /**

--- a/web/src/client/manager.js
+++ b/web/src/client/manager.js
@@ -134,8 +134,9 @@ class ManagerBaseClient {
   /**
    * Returns whether Iguana is used on the system
    */
-  useIguana() {
-    return cockpit.script("[ -d /iguana ] && echo -n iguana");
+  async useIguana() {
+    const proxy = await this.client.proxy(MANAGER_IFACE);
+    return proxy.IguanaBackend;
   }
 }
 

--- a/web/src/client/manager.js
+++ b/web/src/client/manager.js
@@ -128,7 +128,7 @@ class ManagerBaseClient {
    * Returns whether finishing cockpit succeeded
    */
   finishCockpit() {
-    return cockpit.spawn(["systemctl", "stop", "cockpit.service"]);
+    return cockpit.spawn(["systemctl", "stop", "cockpit-wsinstance-http.service"]);
   }
 
   /**

--- a/web/src/client/manager.js
+++ b/web/src/client/manager.js
@@ -120,7 +120,7 @@ class ManagerBaseClient {
    */
   async finishInstallation() {
     const proxy = await this.client.proxy(MANAGER_IFACE);
-    return proxy.Finish;
+    return proxy.Finish();
   }
 
   /**

--- a/web/src/client/manager.test.js
+++ b/web/src/client/manager.test.js
@@ -36,6 +36,7 @@ const managerProxy = {
   wait: jest.fn(),
   Commit: jest.fn(),
   Probe: jest.fn(),
+  Finish: jest.fn().mockReturnValue(true),
   CanInstall: jest.fn(),
   CollectLogs: jest.fn(),
   CurrentInstallationPhase: 0
@@ -119,7 +120,6 @@ describe("#rebootSystem", () => {
   it("returns whether the system reboot command was called or not", async () => {
     const client = new ManagerClient();
     const reboot = await client.finishInstallation();
-    expect(cockpit.spawn).toHaveBeenCalledWith(["/usr/sbin/shutdown", "-r", "now"]);
     expect(reboot).toEqual(true);
   });
 });

--- a/web/src/client/manager.test.js
+++ b/web/src/client/manager.test.js
@@ -118,7 +118,7 @@ describe("#rebootSystem", () => {
 
   it("returns whether the system reboot command was called or not", async () => {
     const client = new ManagerClient();
-    const reboot = await client.rebootSystem();
+    const reboot = await client.finishInstallation();
     expect(cockpit.spawn).toHaveBeenCalledWith(["/usr/sbin/shutdown", "-r", "now"]);
     expect(reboot).toEqual(true);
   });

--- a/web/src/components/core/InstallationFinished.jsx
+++ b/web/src/components/core/InstallationFinished.jsx
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-import React from "react";
+import React, { useState, useEffect } from "react";
 import {
   Button,
   Title,
@@ -33,12 +33,21 @@ import { Center, Icon, Title as SectionTitle, PageIcon, MainActions } from "~/co
 import { useInstallerClient } from "~/context/installer";
 
 function InstallationFinished() {
-  const iguana = false;
   const client = useInstallerClient();
+  const [iguana, setIguana] = useState(false);
   const closingAction = iguana
     ? () => client.manager.finishCockpit()
     : () => client.manager.rebootSystem();
   const buttonCaption = iguana ? "Finish" : "Reboot";
+
+  useEffect(() => {
+    async function getIguana() {
+      const ret = await client.manager.useIguana();
+      setIguana(ret === "iguana");
+    }
+
+    getIguana();
+  });
 
   return (
     <Center>

--- a/web/src/components/core/InstallationFinished.jsx
+++ b/web/src/components/core/InstallationFinished.jsx
@@ -33,8 +33,12 @@ import { Center, Icon, Title as SectionTitle, PageIcon, MainActions } from "~/co
 import { useInstallerClient } from "~/context/installer";
 
 function InstallationFinished() {
+  const iguana = false;
   const client = useInstallerClient();
-  const closingAction = () => client.manager.rebootSystem();
+  const closingAction = iguana
+    ? () => client.manager.finishCockpit()
+    : () => client.manager.rebootSystem();
+  const buttonCaption = iguana ? "Finish" : "Reboot";
 
   return (
     <Center>
@@ -42,7 +46,7 @@ function InstallationFinished() {
       <PageIcon><Icon name="task_alt" /></PageIcon>
       <MainActions>
         <Button isLarge variant="primary" onClick={closingAction}>
-          Reboot
+          {buttonCaption}
         </Button>
       </MainActions>
 
@@ -55,7 +59,7 @@ function InstallationFinished() {
           <div>
             <Text>The installation on your machine is complete.</Text>
             <Text>
-              At this point you can 'Reboot' the machine to log in to the new system.
+              At this point you can {buttonCaption} the machine to log in to the new system.
             </Text>
             <Text>Have a lot of fun! Your openSUSE Development Team.</Text>
           </div>

--- a/web/src/components/core/InstallationFinished.jsx
+++ b/web/src/components/core/InstallationFinished.jsx
@@ -43,7 +43,7 @@ function InstallationFinished() {
   useEffect(() => {
     async function getIguana() {
       const ret = await client.manager.useIguana();
-      setIguana(ret === "iguana");
+      setIguana(ret);
     }
 
     getIguana();

--- a/web/src/components/core/InstallationFinished.jsx
+++ b/web/src/components/core/InstallationFinished.jsx
@@ -34,14 +34,14 @@ import { useInstallerClient } from "~/context/installer";
 
 function InstallationFinished() {
   const client = useInstallerClient();
-  const onRebootAction = () => client.manager.rebootSystem();
+  const closingAction = () => client.manager.rebootSystem();
 
   return (
     <Center>
       <SectionTitle>Installation Finished</SectionTitle>
       <PageIcon><Icon name="task_alt" /></PageIcon>
       <MainActions>
-        <Button isLarge variant="primary" onClick={onRebootAction}>
+        <Button isLarge variant="primary" onClick={closingAction}>
           Reboot
         </Button>
       </MainActions>

--- a/web/src/components/core/InstallationFinished.jsx
+++ b/web/src/components/core/InstallationFinished.jsx
@@ -35,9 +35,7 @@ import { useInstallerClient } from "~/context/installer";
 function InstallationFinished() {
   const client = useInstallerClient();
   const [iguana, setIguana] = useState(false);
-  const closingAction = iguana
-    ? () => client.manager.finishCockpit()
-    : () => client.manager.rebootSystem();
+  const closingAction = client.manager.finishInstallation();
   const buttonCaption = iguana ? "Finish" : "Reboot";
 
   useEffect(() => {

--- a/web/src/components/core/InstallationFinished.jsx
+++ b/web/src/components/core/InstallationFinished.jsx
@@ -35,7 +35,7 @@ import { useInstallerClient } from "~/context/installer";
 function InstallationFinished() {
   const client = useInstallerClient();
   const [iguana, setIguana] = useState(false);
-  const closingAction = client.manager.finishInstallation();
+  const closingAction = () => client.manager.finishInstallation();
   const buttonCaption = iguana ? "Finish" : "Reboot";
 
   useEffect(() => {

--- a/web/src/components/core/InstallationFinished.test.jsx
+++ b/web/src/components/core/InstallationFinished.test.jsx
@@ -30,14 +30,14 @@ import InstallationFinished from "./InstallationFinished";
 jest.mock("~/client");
 jest.mock("~/components/layout/Layout", () => mockLayout());
 
-const rebootSystemFn = jest.fn();
+const finishInstallationFn = jest.fn();
 
 describe("InstallationFinished", () => {
   beforeEach(() => {
     createClient.mockImplementation(() => {
       return {
         manager: {
-          rebootSystem: rebootSystemFn
+          finishInstallation: finishInstallationFn
         },
         network: {
           config: () => Promise.resolve({ addresses: [], hostname: "example.net" })
@@ -62,6 +62,6 @@ describe("InstallationFinished", () => {
     const { user } = installerRender(<InstallationFinished />);
     const button = await screen.findByRole("button", { name: /Reboot/i });
     await user.click(button);
-    expect(rebootSystemFn).toHaveBeenCalled();
+    expect(finishInstallationFn).toHaveBeenCalled();
   });
 });

--- a/web/src/components/core/InstallationFinished.test.jsx
+++ b/web/src/components/core/InstallationFinished.test.jsx
@@ -37,7 +37,8 @@ describe("InstallationFinished", () => {
     createClient.mockImplementation(() => {
       return {
         manager: {
-          finishInstallation: finishInstallationFn
+          finishInstallation: finishInstallationFn,
+          useIguana: () => Promise.resolve(false)
         },
         network: {
           config: () => Promise.resolve({ addresses: [], hostname: "example.net" })


### PR DESCRIPTION
## Problem

Iguana wants cockpit-ws killed as an indication that installation is over.

- Everything what was needed on iguana side is here https://github.com/openSUSE/iguana/pull/32 Mostly a changes in workflow.


## Solution

Reboot button becomes Finish button. The button tells agama to commit suicide by ```/usr/bin/agamactl -k```
An update on the iguana side was also needed - a change in workflow file.


## Testing

- Tested manually using some mocked setup
- Tested with iguana containers from BS by the iguana  maintainer

