### PR TITLE
Adapt the yupdate scripts to the new "Agama" name

### DIFF
--- a/.yupdate.post
+++ b/.yupdate.post
@@ -5,27 +5,27 @@
 # after running "rake install" command.
 #
 # The script does several tasks:
-# - it restarts the DBus service when any file in the d-installer ruby gem
-#   was updated
+# - it restarts the DBus service when any file in the ruby gem was updated
 # - saves the installed NPM packages to a cache so they can be reused in the
 #   next yupdate run
 #
 
-# restart the D-Installer service if needed
+SERVICE_NAME="agama"
+
+# restart the installer service if needed
 function restart_service() {
   # get the service start time
-  SERVICE_START=$(systemctl show d-installer | grep "^ExecMainStartTimestamp=" | sed -e "s/^ExecMainStartTimestamp=\(.*\)\$/\\1/")
+  SERVICE_START=$(systemctl show "$SERVICE_NAME" | grep "^ExecMainStartTimestamp=" | sed -e "s/^ExecMainStartTimestamp=\(.*\)\$/\\1/")
 
   if [ -n "$SERVICE_START" ]; then
     SERVICE_START_UNIX_TIME=$(date -d "$SERVICE_START" +"%s")
-    # find the date of the latest file in the d-installer gem
-    # the regexp is used to ignore the d-installer-cli files
-    NEWEST_FILE_TIME=$(find /usr/lib*/ruby/gems/*/gems -type f -regex '\(.*/\)?d-installer-[0-9].*\(/.*\)?' -exec stat --format '%Y' "{}" \; | sort -nr | head -n 1)
+    # find the date of the latest file in the gem
+    NEWEST_FILE_TIME=$(find /usr/lib*/ruby/gems/*/gems/$SERVICE_NAME-* -exec stat --format %Y "{}" \; | sort -nr | head -n 1)
 
     # when a file is newer than the start time then restart the service
     if [ -n "$NEWEST_FILE_TIME" ] && [ "$SERVICE_START_UNIX_TIME" -lt "$NEWEST_FILE_TIME" ]; then
-      echo "Restarting D-Installer service..."
-      systemctl restart d-installer
+      echo "Restarting $SERVICE_NAME service..."
+      systemctl restart "$SERVICE_NAME"
     fi
   fi
 }
@@ -33,7 +33,7 @@ function restart_service() {
 # copy installed NPM packages to cache
 function save_npm_cache() {
   echo "Saving NPM cache..."
-  CACHEDIR="$HOME/.cache/d-installer-devel/"
+  CACHEDIR="$HOME/.cache/$SERVICE_NAME-devel/"
   mkdir -p "$CACHEDIR"
 
   MYDIR=$(realpath "$(dirname "$0")")

--- a/.yupdate.pre
+++ b/.yupdate.pre
@@ -4,8 +4,7 @@
 # This is a hook script for the yupdate tool, it is automatically executed
 # before running "rake install" command.
 #
-# This script prepares the live system for compiling and installing new
-# D-Installer code.
+# This script prepares the live system for compiling and installing new code.
 #
 # The script does several tasks:
 # - it checks if there is enough RAM, if there is not enough RAM the system
@@ -21,8 +20,10 @@ if [ "$YUPDATE_SKIP_FRONTEND" == "1" ]; then
   exit 0
 fi
 
-# the needed packages for compiling the d-installer cockpit module
+# the needed packages for compiling the cockpit module
 PACKAGES=(appstream-glib-devel make npm)
+# name of the service
+SERVICE_NAME="agama"
 
 # add repositories
 function add_repos() {
@@ -52,7 +53,7 @@ function install_packages() {
 
 # restore the NPM cache if it is present
 function load_npm_cache() {
-  CACHEDIR="$HOME/.cache/d-installer-devel/"
+  CACHEDIR="$HOME/.cache/$SERVICE_NAME-devel/"
 
   if [ -d "$CACHEDIR/node_modules" ]; then
     echo "Restoring NPM cache..."


### PR DESCRIPTION
## Problem

- Restarting the `agama` service after patching it via `yupdate` does not work anymore
- It misses the `d-installer` -> `agama` rename

## Notes

- The Agama CLI is now implemented in Rust so we can simplify the file search, that regexp filter in `find`  is not needed anymore

## Testing

- Tested manually
