### PR TITLE
[web] Add @svgr/plugin-jsx

### DIFF
--- a/web/.svgrrc
+++ b/web/.svgrrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["@svgr/plugin-jsx"]
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -31,6 +31,7 @@
         "@cspell/dict-fullstack": "^3.1.4",
         "@cspell/dict-html": "^4.0.3",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
+        "@svgr/plugin-jsx": "^7.0.0",
         "@svgr/webpack": "^7.0.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "@cspell/dict-fullstack": "^3.1.4",
     "@cspell/dict-html": "^4.0.3",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
+    "@svgr/plugin-jsx": "^7.0.0",
     "@svgr/webpack": "^7.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",


### PR DESCRIPTION
To keep @svgr[1] working as it was after updating it to v7.0.0[2]

Related to dependencies update done at [3]

[1] https://github.com/gregberge/svgr
[2] https://github.com/gregberge/svgr/releases/tag/v7.0.0
[3] 


## Problem

After the latest [dependencies update](https://github.com/openSUSE/agama/pull/536), icon sizes stop working as expected due to SVGO removing their `viewBox` attribute, ignoring the [added configuration](https://github.com/openSUSE/agama/commit/7417408b502d3fb3417e006ab721a35d6e066c29#diff-cee0a08ad16a1ea6722eb9bab201b3dff647af254fe94e542b320dadc7ea0023R2-R6)

The problem looks related with a breaking change introduced in [@svgr v7.0.0](https://github.com/gregberge/svgr/releases/tag/v7.0.0):

> plugin-jsx is no longer included by default in core

## Solution

Explicitly add the plugin-jsx 

## Testing

- Tested manually


## Screenshots

| Before | After |
|-|-|
| ![Screen Shot 2023-04-18 at 13 23 19](https://user-images.githubusercontent.com/1691872/232776195-b382522d-3960-413c-8721-8210c445e657.png) | ![Screen Shot 2023-04-18 at 13 21 42](https://user-images.githubusercontent.com/1691872/232776223-f99ba2d3-a54f-4031-a311-02dcf52d6c68.png) |


