### PR TITLE
Move DASD manager interface

### DIFF
--- a/service/lib/agama/dbus/storage/dasd_manager_interface.rb
+++ b/service/lib/agama/dbus/storage/dasd_manager_interface.rb
@@ -23,7 +23,7 @@ require "dbus"
 
 module Agama
   module DBus
-    module Interfaces
+    module Storage
       # Mixin to define the D-Bus interface to manage DASD devices
       #
       # @note This mixin is expected to be included in a class inherited from
@@ -31,7 +31,7 @@ module Agama
       #
       # @note This mixin is expected to be included only if the namespace Y2S390 (which
       # traditionally lives in the yast2-s390 package) is available.
-      module Dasd
+      module DasdManagerInterface
         DASD_MANAGER_INTERFACE = "org.opensuse.Agama.Storage1.DASD.Manager"
         private_constant :DASD_MANAGER_INTERFACE
 

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -26,7 +26,7 @@ require "agama/dbus/with_service_status"
 require "agama/dbus/interfaces/progress"
 require "agama/dbus/interfaces/service_status"
 require "agama/dbus/interfaces/validation"
-require "agama/dbus/interfaces/dasd"
+require "agama/dbus/storage/dasd_manager_interface"
 require "agama/dbus/storage/proposal"
 require "agama/dbus/storage/proposal_settings_converter"
 require "agama/dbus/storage/volume_converter"
@@ -64,7 +64,7 @@ module Agama
           register_software_callbacks
           return unless Yast::Arch.s390
 
-          singleton_class.include DBus::Interfaces::Dasd
+          singleton_class.include DasdManagerInterface
           register_and_extend_dasd_callbacks
         end
 


### PR DESCRIPTION
## Problem

The DASD manager D-Bus interface was defined under `Agama::DBus::Interfaces` namespace, which is the namespace for generic interfaces. Generic interfaces can be defined for different objects, but that is not the case of the DASD manager interface. 

## Solution

Move the DASD manager interface to `Agama::DBus::Storage` namespace.
