### PR TITLE
[web] Update PatternFly packages

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,9 +8,9 @@
       "license": "LGPL-2.1",
       "dependencies": {
         "@material-symbols/svg-400": "^0.5.5",
-        "@patternfly/patternfly": "^4.219.2",
-        "@patternfly/react-core": "^4.261.0",
-        "@patternfly/react-table": "^4.111.33",
+        "@patternfly/patternfly": "^4.224.2",
+        "@patternfly/react-core": "^4.276.8",
+        "@patternfly/react-table": "^4.113.0",
         "core-js": "^3.21.1",
         "fast-sort": "^3.2.1",
         "filesize": "^10.0.5",

--- a/web/package.json
+++ b/web/package.json
@@ -96,9 +96,9 @@
   },
   "dependencies": {
     "@material-symbols/svg-400": "^0.5.5",
-    "@patternfly/patternfly": "^4.219.2",
-    "@patternfly/react-core": "^4.261.0",
-    "@patternfly/react-table": "^4.111.33",
+    "@patternfly/patternfly": "^4.224.2",
+    "@patternfly/react-core": "^4.276.8",
+    "@patternfly/react-table": "^4.113.0",
     "core-js": "^3.21.1",
     "fast-sort": "^3.2.1",
     "filesize": "^10.0.5",


### PR DESCRIPTION
## Problem


For some reason, the `npm outdated` output didn't include the outdated PatternFly packages in https://github.com/openSUSE/agama/pull/536 :man_shrugging: . But we want to keep them up to date.

## Solution

Update PatternFly related packages to their latest versions.

## Testing

- Tested manually, everything seems to work as expected.