### PR TITLE
[web] Do not "ignore" `:hover` styles when a button is applying `:focus` styles too

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 20 12:44:44 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- Make styles consistent when the user is hovering a button,
+  no matter if it is a focus state or not (gh#openSUSE/agama#544).
+
+-------------------------------------------------------------------
 Fri Apr 14 13:08:05 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - First steps for redesigning storage proposal UI:

--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -44,6 +44,11 @@
   --pf-c-button--m-primary--hover--BackgroundColor: var(--color-button-primary-hover);
 }
 
+// Make :hover style visible when the button is in a :focus state too
+.pf-c-button.pf-m-primary:focus:hover {
+  --pf-c-button--m-primary--BackgroundColor: var(--color-button-primary-hover);
+}
+
 .pf-c-button.pf-m-link {
   // Colors for buttons modifiers
   --pf-c-button--m-link--Color: var(--color-link);
@@ -59,6 +64,12 @@
 .pf-c-button.pf-m-secondary {
   --pf-c-button--m-secondary--hover--after--BorderColor: var(--color-link-hover);
   --pf-c-button--m-secondary--hover--Color: var(--color-link-hover);
+}
+
+// Make :hover style visible when the button is in a :focus state too
+.pf-c-button.pf-m-secondary:focus:hover {
+  --pf-c-button--after--BorderColor: var(--color-link-hover);
+  --pf-c-button--m-secondary--Color: var(--color-link-hover);
 }
 
 // SVG icons does not obey font-size


### PR DESCRIPTION
## Problem

For some time now, I have been noticing that `:hover` styles for buttons are not applied when a `Popup` only has one focusable element. At least, not until the element loses the [activeElement](https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement) _role_ and, consequently, the `:focus` state :exploding_head: 

Actually, it's not an issue at all, rather it's the _expected_ behavior of the [user action pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes#user_action_pseudo-classes) obeying the [order of appearance of Cascading algorithm](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade#cascading_order). Note that styles of PatternFly buttons are following a [:hover, :focus, :active](https://github.com/patternfly/patternfly/blob/a74a6a1aa30a05ce897a97e1dc16be4bf02b7ae3/src/patternfly/components/Button/button.scss#L233-L246) order.

I, however, get the impression that something is wrong when I reach a modal dialog that does not highlight the action when my mouse pointer hovers over it... unless I click somewhere else and hover over it again. That's odd enough.


<details>
<summary>Click to show/hide some videos</summary>

---

<table>
<tr>
<th>Popup with only one focusable element</th>
<th>Popup with more than one focusable element</th>
</tr>
<tr>
<td>


https://user-images.githubusercontent.com/1691872/233367468-21a79cf2-4363-4e5f-a75c-5fc055800e56.mp4

Note that the user is hovering the button four times, but for the first three the button was not styled. Before the fourth time, a click was performed in the dialog itself (not visible in the video).

</td>
<td>


https://user-images.githubusercontent.com/1691872/233368354-2b03a04c-56e2-46c4-9216-0446b93d93c9.mp4

Note the first input focused and all buttons applying the :hover styles because they are not focused.

</td>
</table>
</details>

## Solution

IMHO, the solution here is to apply `:hover` styles to _focused_ buttons as well. While a bit hacky, it is possible to accomplish this by redefining some PatternFly CSS custom properties when the button is in `:focus:hover` mode, which is what this PR aims to do. And it works because, remember, [order matters](https://web.dev/learn/css/pseudo-classes/#order-matters) and we're defining these rules after the PatternFly button styles.

<details>
<summary>Click to show/hide a video</summary>

---


https://user-images.githubusercontent.com/1691872/233369193-959a07c5-0c58-474b-9351-913bc693cd8b.mp4


The `:hover` styles are applied from the very beginning without needed to click outside to make the button "not focused".


</details>