### PR TITLE
[web] Add a the initial version of a notification mark

### DIFF
--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -218,3 +218,16 @@ section > .content {
     }
   }
 }
+
+span.notification-mark {
+  --border-width: 2px;
+  --size: calc(var(--fs-base) + var(--border-width));
+
+  position: absolute;
+  right: 0;
+  background: var(--color-primary-lighter);
+  border: var(--border-width) solid var(--color-primary);
+  width: var(--size);
+  height: var(--size);
+  border-radius: 999px;
+}

--- a/web/src/assets/styles/utilities.scss
+++ b/web/src/assets/styles/utilities.scss
@@ -114,6 +114,7 @@
 }
 
 .plain-control {
+  position: relative;
   background: none;
   border: none;
 }

--- a/web/src/components/core/NotificationMark.jsx
+++ b/web/src/components/core/NotificationMark.jsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+
+/**
+ * A notification mark that  icon for catching the users attention when there is
+ * something that can be interesting for them but not urgent enough to use a
+ * (blocking) Popup.
+ *
+ * @component
+ *
+ * Initially though to be displayed on top of the Sidebar icon.
+ *
+ * Use only when the information to show might be overlooked without risk and/or
+ * when the information will be displayed sooner or later in other way (in a
+ * confirmation dialog, for example).
+ *
+ * @param {object} props
+ * @param {string} props.label - the label to be announced by screen readers
+ */
+export default function NotificationMark ({ label }) {
+  return <span className="notification-mark" role="status" aria-label={label} />;
+}

--- a/web/src/components/core/NotificationMark.test.jsx
+++ b/web/src/components/core/NotificationMark.test.jsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import { plainRender } from "~/test-utils";
+import { NotificationMark } from "~/components/core";
+
+it("renders a span with status role", async () => {
+  plainRender(<NotificationMark label="Some issues detected, please have a look" />);
+  screen.getByRole("status", { name: "Some issues detected, please have a look" });
+});

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -22,6 +22,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Button, Text } from "@patternfly/react-core";
 import { Icon, AppActions } from "~/components/layout";
+import { NotificationMark } from "~/components/core";
 
 /**
  * Agama sidebar navigation
@@ -93,6 +94,7 @@ export default function Sidebar ({ children }) {
           aria-controls="navigation-and-options"
           aria-expanded={isOpen}
         >
+          <NotificationMark />
           <Icon name="menu" />
         </button>
       </AppActions>

--- a/web/src/components/core/index.js
+++ b/web/src/components/core/index.js
@@ -47,3 +47,4 @@ export { default as ProgressText } from "./ProgressText";
 export { default as ValidationErrors } from "./ValidationErrors";
 export { default as Terminal } from "./Terminal";
 export { default as ShowTerminalButton } from "./ShowTerminalButton";
+export { default as NotificationMark } from "./NotificationMark";


### PR DESCRIPTION
A simple component for rendering a notification/status mark, consisting of an absolute right positioned circle on top of a relative positioned element.

The idea is to catch the users' attention for clicking on the element presenting the mark, but having in mind that they can continue with the installation without doing so.


| Overview w/o notifications | Overview with notifications |
|-|-|
| ![Overview w/o notifications](https://user-images.githubusercontent.com/1691872/234221678-821e0696-7f15-4d66-850f-9a51caf69072.png) | ![Overview with notifications](https://user-images.githubusercontent.com/1691872/234221699-e62b2664-916c-432d-aaf7-ce12c26aad66.png) |


## Problem

*Short description of the original problem.*

- *Bugzilla link*
- *openQA link*
- *Links to other related pull requests*


## Solution

*Short description of the fix.*


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

