### PR TITLE
D-Bus API docs inside introspection XML, part2

### DIFF
--- a/doc/dbus/Makefile
+++ b/doc/dbus/Makefile
@@ -4,6 +4,7 @@ tmpdir=./tmp
 # build HTML for GitHub pages
 all: ${distdir} ${tmpdir}
 	for f in org.opensuse.Agama*.doc.xml; do \
+	  echo $$f; \
 	  gdbus-codegen \
 	    --interface-prefix=org.opensuse.Agama. \
 	    --output-directory=${tmpdir} \

--- a/doc/dbus/index.html
+++ b/doc/dbus/index.html
@@ -3,4 +3,6 @@
 href="ref-org.opensuse.Agama1.Manager.html">org.opensuse.Agama1.Manager</a></li>
 <li><a
 href="ref-org.opensuse.Agama.Language1.html">org.opensuse.Agama.Language1</a></li>
+<li><a
+href="ref-org.opensuse.Agama.Users1.html">org.opensuse.Agama.Users1</a></li>
 </ul>

--- a/doc/dbus/index.html
+++ b/doc/dbus/index.html
@@ -1,8 +1,26 @@
+<!--
+echo "<ul>" ;\
+for F in tmp/ref-*.xml; do
+  F=${F#tmp/}
+  F=${F%.xml}
+  echo "<li><a href=\"${F}.html\""
+  echo "                >${F#ref-}</a></li>"
+done; \
+echo "</ul>"
+-->
 <ul>
-<li><a
-href="ref-org.opensuse.Agama1.Manager.html">org.opensuse.Agama1.Manager</a></li>
-<li><a
-href="ref-org.opensuse.Agama.Language1.html">org.opensuse.Agama.Language1</a></li>
-<li><a
-href="ref-org.opensuse.Agama.Users1.html">org.opensuse.Agama.Users1</a></li>
+<li><a href="ref-org.opensuse.Agama.Language1.html"
+                >org.opensuse.Agama.Language1</a></li>
+<li><a href="ref-org.opensuse.Agama.Questions1.html"
+                >org.opensuse.Agama.Questions1</a></li>
+<li><a href="ref-org.opensuse.Agama.Users1.html"
+                >org.opensuse.Agama.Users1</a></li>
+<li><a href="ref-org.opensuse.Agama1.Manager.html"
+                >org.opensuse.Agama1.Manager</a></li>
+<li><a href="ref-org.opensuse.Agama1.Progress.html"
+                >org.opensuse.Agama1.Progress</a></li>
+<li><a href="ref-org.opensuse.Agama1.ServiceStatus.html"
+                >org.opensuse.Agama1.ServiceStatus</a></li>
+<li><a href="ref-org.opensuse.Agama1.Validation.html"
+                >org.opensuse.Agama1.Validation</a></li>
 </ul>

--- a/doc/dbus/org.opensuse.Agama.Language1.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Language1.doc.xml
@@ -13,7 +13,7 @@
   <interface name="org.opensuse.Agama.Language1">
     <!--
         ToInstall:
-        @short_description: Set list of languages to install
+        Set list of languages to install
         @LangIDs: List of language IDs from #org.opensuse.Agama.Language1:AvailableLanguages
 
         Example:
@@ -26,7 +26,8 @@
     </method>
     <!--
         AvailableLanguages:
-        @short_description: List of all available languages to install on target system.
+        List of all available languages to install on target system.
+
         Elements are triples:
              language ID, human readable language name, and
              a dictionary for future extensions to provide more data
@@ -38,7 +39,7 @@ AvailableLanguages -&gt; [["cs_CZ", "Czech", {}]]
     <property type="a(ssa{sv})" name="AvailableLanguages" access="read"/>
     <!--
         MarkedForInstall:
-        @short_description: List of languages to install. Same format as ToInstall
+        List of languages to install. Same format as ToInstall
     -->
     <property type="as" name="MarkedForInstall" access="read"/>
   </interface>

--- a/doc/dbus/org.opensuse.Agama.Questions1.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Questions1.doc.xml
@@ -1,0 +1,42 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/Agama/Questions1">
+  <!--
+      org.opensuse.Agama.Questions1:
+
+Agama offers a mechanism to communicate with clients. The D-Bus service exports a *Questions*
+object that implements the *org.freedesktop.DBus.ObjectManager* interface. Individual questions are
+dynamically exported in a tree under the */org/opensuse/Agama/Questions1* path, for example:
+
+~~~
+/org/opensuse/Agama/Questions1
+  /org/opensuse/Agama/Questions1/1
+  /org/opensuse/Agama/Questions1/2
+  /org/opensuse/Agama/Questions1/4
+~~~
+
+Each D-Bus question implements its own set of interfaces, depending on the type of question. For
+example, a generic question implements *org.opensuse.Agama.Question1*. And a question asking
+for the activation of a LUKS device also implements *org.opensuse.Agama.Questions1.LuksActivation*.
+Questions can be "unexported" from the ObjectManager tree. The service typically unexports a question
+when the question is answered.
+  -->
+  <interface name="org.opensuse.Agama.Questions1">
+    <method name="New">
+      <arg name="text" direction="in" type="s"/>
+      <arg name="options" direction="in" type="as"/>
+      <arg name="default_option" direction="in" type="as"/>
+      <arg name="q" direction="out" type="o"/>
+    </method>
+    <method name="NewLuksActivation">
+      <arg name="device" direction="in" type="s"/>
+      <arg name="label" direction="in" type="s"/>
+      <arg name="size" direction="in" type="s"/>
+      <arg name="attempt" direction="in" type="y"/>
+      <arg name="q" direction="out" type="o"/>
+    </method>
+    <method name="Delete">
+      <arg name="question" direction="in" type="o"/>
+    </method>
+  </interface>
+</node>

--- a/doc/dbus/org.opensuse.Agama.Users1.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Users1.doc.xml
@@ -1,0 +1,78 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/Agama/Users1">
+  <interface name="org.opensuse.Agama.Users1">
+    <!--
+        SetRootPassword:
+
+        If @Encrypted is set to true, it means that already encrypted password is sent
+
+        Example:
+        <programlisting>SetRootPassword("test", false)</programlisting>
+    -->
+    <method name="SetRootPassword">
+      <arg name="Value" direction="in" type="s"/>
+      <arg name="Encrypted" direction="in" type="b"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+
+    <method name="RemoveRootPassword">
+      <arg name="result" direction="out" type="u"/>
+    </method>
+
+    <!--
+        SetRootSSHKey:
+
+        Set root ssh public keys. Use empty string to unset it.
+
+        Example:
+        <programlisting>SetRootSSHKey("idrsa long key")</programlisting>
+    -->
+    <method name="SetRootSSHKey">
+      <arg name="Value" direction="in" type="s"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+
+    <!--
+        SetFirstUser:
+
+        Sets one non root user after installation.
+        @FullName and @UserName have to follow restrictions
+        for respective /etc/passwd entry. To unset it use empty @UserName.
+    -->
+    <method name="SetFirstUser">
+      <arg name="FullName" direction="in" type="s"/>
+      <arg name="UserName" direction="in" type="s"/>
+      <arg name="Password" direction="in" type="s"/>
+      <arg name="AutoLogin" direction="in" type="b"/>
+      <arg name="data" direction="in" type="a{sv}"/>
+      <arg name="result" direction="out" type="(bas)"/>
+    </method>
+    <method name="RemoveFirstUser">
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <method name="Write">
+      <arg name="result" direction="out" type="u"/>
+    </method>
+
+    <!--
+        RootPasswordSet:
+        whenever root password will be set by installer
+    -->
+    <property type="b" name="RootPasswordSet" access="read"/>
+
+    <!--
+        RootSSHKey:
+        Root public ssh key that can be used to login to machine.
+        Can be empty which means not set
+    -->
+    <property type="s" name="RootSSHKey" access="read"/>
+
+    <!--
+        FirstUser:
+        struct( string FullName, string UserName, string Password, boolean AutoLogin, map AdditionalData)
+        Info about first user to set. if Username is empty, it means not set and other values can be ignored
+    -->
+    <property type="(sssba{sv})" name="FirstUser" access="read"/>
+  </interface>
+</node>

--- a/doc/dbus/org.opensuse.Agama1.Manager.doc.xml
+++ b/doc/dbus/org.opensuse.Agama1.Manager.doc.xml
@@ -56,13 +56,13 @@ installed.
 
     <!--
         CurrentInstallationPhase:
-        @short_description: Id of the current phase.
+        Id of the current phase.
     -->
     <property type="u" name="CurrentInstallationPhase" access="read"/>
 
     <!--
         CurrentInstallationPhase:
-        @short_description: List of names of the currently busy services.
+        List of names of the currently busy services.
 
         Note that the services are blocked meanwhile they are performing a long task. For this
         reason, the *manager* service will store the status of each service and the clients will ask to

--- a/doc/dbus/org.opensuse.Agama1.Progress.doc.xml
+++ b/doc/dbus/org.opensuse.Agama1.Progress.doc.xml
@@ -1,0 +1,27 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/Agama/Software1">
+  <!--
+      org.opensuse.Agama1.Progress:
+      The main object of a service implements the Progress interface
+  -->
+  <interface name="org.opensuse.Agama1.Progress">
+    <!--
+        TotalSteps:
+        Number of steps
+    -->
+    <property type="u" name="TotalSteps" access="read"/>
+
+    <!--
+        CurrentStep:
+        Number of the current step and its description.
+    -->
+    <property type="(us)" name="CurrentStep" access="read"/>
+
+    <!--
+        Finished:
+        Whether the progress has finished.
+    -->
+    <property type="b" name="Finished" access="read"/>
+  </interface>
+</node>

--- a/doc/dbus/org.opensuse.Agama1.ServiceStatus.doc.xml
+++ b/doc/dbus/org.opensuse.Agama1.ServiceStatus.doc.xml
@@ -1,0 +1,35 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/Agama/Users1">
+  <!--
+      org.opensuse.Agama1.ServiceStatus:
+
+Each service will have an status (*idle* or *busy*). The service should change its status to *busy*
+when it is going to start an expensive tasks. The status should be set back to *idle* once the long
+task is done.
+
+The main object of a service implements the following interface:
+  -->
+  <interface name="org.opensuse.Agama1.ServiceStatus">
+    <!--
+        All:
+
+        All possible statuses:
+
+<programlisting>
+[
+    {"id" => 0, "label" => "idle"},
+    {"id" => 1, "label" => "busy"}
+]
+</programlisting>
+    -->
+    <property type="aa{sv}" name="All" access="read"/>
+
+    <!--
+        Current:
+
+        Id of the current status.
+    -->
+    <property type="u" name="Current" access="read"/>
+  </interface>
+</node>

--- a/doc/dbus/org.opensuse.Agama1.Validation.doc.xml
+++ b/doc/dbus/org.opensuse.Agama1.Validation.doc.xml
@@ -1,0 +1,24 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/Agama/Users1">
+  <!--
+      org.opensuse.Agama1.Validation:
+
+The main object of a service may implement the validation interface. It reports
+any issue that might block the installation.
+  -->
+  <interface name="org.opensuse.Agama1.Validation">
+    <!--
+        Errors:
+        List of validation errors.
+    -->
+    <property type="as" name="Errors" access="read"/>
+
+    <!--
+        Valid:
+Whether there are validation errors. It is a way to check whether a service
+is ready for installation without having to retrieve the list of errors.
+    -->
+    <property type="b" name="Valid" access="read"/>
+  </interface>
+</node>

--- a/doc/dbus_api.md
+++ b/doc/dbus_api.md
@@ -630,42 +630,10 @@ Summary readable a{s(uub)}
 
 ## Users
 
-### iface o.o.Agama.Users1
+See the new-style [reference][usr-ref] ([source][usr-src]).
 
-#### methods:
-
--  SetRootPassword(string value, boolean encrypted) -> void
-    sets root password. If encrypted is set to true, it means that already encrypted password
-    is send.
-    example:
-
-      SetRootPassword("test", false) -> ()
-
--  SetRootSSHKey(string value) -> void
-    set root ssh public keys. Use empty string to unset it.
-    example:
-
-      SetRootSSHKey("idrsa long key") -> ()
-
-- SetFirstUser(string FullName, string UserName, string Password, boolean AutoLogin, map AdditionalData) -> void
-    sets one non root user after installation. FullName and UserName has to follow restrictions
-    for respective passwd entry. To unset it use empty UserName.
-    example:
-
-      SetRootSSHKey("idrsa long key") -> ()
-
-#### Properties (all read only):
-
-- RootPasswordSet -> boolean
-  whenever root password will be set by installer
-
-- RootSSHKey -> string
-  root public ssh key that can be used to login to machine
-  Can be empty which means not set
-
-- FirstUser -> struct( string FullName, string UserName, string Password, boolean AutoLogin, map AdditionalData)
-  info about first user to set. if Username is empty, it means not set and other values can be ignored
-
+[usr-ref]: https://opensuse.github.io/agama/dbus/ref-org.opensuse.Agama.Users1.html
+[usr-src]: dbus/org.opensuse.Agama.Users1.doc.xml
 
 ## Questions
 

--- a/doc/dbus_api.md
+++ b/doc/dbus_api.md
@@ -688,20 +688,6 @@ The main object of a service implements the following interface:
 - Finished: b (r)
   Whether the progress has finished.
 
-## Validation
-
-The main object of a service may implement the validation interface. It reports
-any issue that might block the installation.
-
-### org.opensuse.Agama1.Validation
-
-- Errors: array of strings (as)
-  List of validation errors.
-
-- Valid: boolean (b)
-  Whether there are validation errors. It is a way to check whether a service
-  is ready for installation without having to retrieve the list of errors.
-
 ## Manager
 
 See the new-style [reference][mgr-ref] ([source][mgr-src]).

--- a/doc/dbus_api.md
+++ b/doc/dbus_api.md
@@ -673,33 +673,6 @@ TODO: seed a question object and a luks question object
   question is asked again (i.e., when the provided password did not work).
 
 
-## ServiceStatus
-
-Each service will have an status (*idle* or *busy*). The service should change its status to *busy*
-when it is going to start an expensive tasks. The status should be set back to *idle* once the long
-task is done.
-
-The main object of a service implements the following interface:
-
-### org.opensuse.Agama1.ServiceStatus
-
-#### Properties
-
-- All -> array(array(dict(string, variant))) (r)
-
-  All possible statuses:
-  ~~~
-  [
-    {"id" => 0, "label" => "idle"},
-    {"id" => 1, "label" => "busy"}
-  ]
-  ~~~
-
-- Current -> unsigned 32-bit integer (r)
-
-  Id of the current status.
-
-
 ## Progress
 
 The main object of a service implements the following interface:

--- a/doc/dbus_api.md
+++ b/doc/dbus_api.md
@@ -637,25 +637,12 @@ See the new-style [reference][usr-ref] ([source][usr-src]).
 
 ## Questions
 
-Agamas offers a mechanism to communicate with clients. The D-Bus service exports a *Questions*
-object that implements the *org.freedesktop.DBus.ObjectManager* interface. Individual questions are
-dynamically exported in a tree under the */org/opensuse/Agama/Questions1* path, for example:
-
-~~~
-/org/opensuse/Agama/Questions1
-  /org/opensuse/Agama/Questions1/1
-  /org/opensuse/Agama/Questions1/2
-  /org/opensuse/Agama/Questions1/4
-~~~
-
-Each D-Bus question implements its own set of interfaces, depending on the type of question. For
-example, a generic question implements *org.opensuse.Agama.Question1*. And a question asking
-for the activation of a LUKS device also implements *org.opensuse.Agama.Questions1.LuksActivation*.
-Questions can be "unexported" from the ObjectManager tree. The service typically unexports a question
-when the question is answered.
 
 ### org.opensuse.Agama.Questions1
 
+<!--
+TODO: seed a question object and a luks question object
+-->
 #### Properties
 
 - Id -> unsigned 32-bit integer (r)

--- a/doc/dbus_api.md
+++ b/doc/dbus_api.md
@@ -672,22 +672,6 @@ TODO: seed a question object and a luks question object
   Current attempt to decrypt the device. This value is useful for clients to know if the very same
   question is asked again (i.e., when the provided password did not work).
 
-
-## Progress
-
-The main object of a service implements the following interface:
-
-### org.opensuse.Agama1.Progress
-
-- TotalSteps: unsigned 32-bit integer (r)
-  Number of steps.
-
-- CurrentStep: struct(unsigned 32-bit integer, string) (r)
-  Number of the current step and its description.
-
-- Finished: b (r)
-  Whether the progress has finished.
-
 ## Manager
 
 See the new-style [reference][mgr-ref] ([source][mgr-src]).


### PR DESCRIPTION
## Problem

- https://trello.com/c/LN220ePd/23-document-d-bus-api-in-sync-with-code

## Solution

- continuation of #415
- fixed some markup, with a better understanding how the format works

migrating these interfaces:
<ul>
<li>org.opensuse.Agama.Questions1</li>
<li>org.opensuse.Agama.Users1</li>
<li>org.opensuse.Agama1.Progress</li>
<li>org.opensuse.Agama1.ServiceStatus</li>
<li>org.opensuse.Agama1.Validation</li>
</ul>

Still TODO, for a next PR: the  **Storage** gorilla