### PR TITLE
[web] Do not show group options name until needed

### DIFF
--- a/web/src/components/storage/ProposalPageOptions.jsx
+++ b/web/src/components/storage/ProposalPageOptions.jsx
@@ -74,10 +74,7 @@ export default function ProposalPageOptions () {
 
   return (
     <PageOptions>
-      <PageOptions.Group
-        label="Configure"
-        key="devices-options"
-      >
+      <PageOptions.Group key="devices-options">
         <If condition={showDasdLink} then={<DASDLink />} />
         <ISCSILink />
       </PageOptions.Group>

--- a/web/src/components/storage/ProposalPageOptions.test.jsx
+++ b/web/src/components/storage/ProposalPageOptions.test.jsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import { installerRender, mockLayout } from "~/test-utils";
+import { createClient } from "~/client";
+import { ProposalPageOptions } from "~/components/storage";
+
+jest.mock("~/client");
+jest.mock("~/components/layout/Layout", () => mockLayout());
+
+const isDASDSupportedFn = jest.fn();
+
+const dasd = {
+  isSupported: isDASDSupportedFn
+};
+
+beforeEach(() => {
+  isDASDSupportedFn.mockResolvedValue(false);
+
+  createClient.mockImplementation(() => {
+    return {
+      storage: { dasd }
+    };
+  });
+});
+
+it("contains an entry for configuring iSCSI", async () => {
+  const { user } = installerRender(<ProposalPageOptions />);
+  const toggler = screen.getByRole("button");
+  await user.click(toggler);
+  screen.getByRole("menuitem", { name: /iSCSI/ });
+});
+
+it("contains an entry for configuring DASD when is supported", async () => {
+  isDASDSupportedFn.mockResolvedValue(true);
+  const { user } = installerRender(<ProposalPageOptions />);
+  const toggler = screen.getByRole("button");
+  await user.click(toggler);
+  screen.getByRole("menuitem", { name: /DASD/ });
+});
+
+it("does not contain an entry for configuring DASD when is NOT supported", async () => {
+  isDASDSupportedFn.mockResolvedValue(false);
+  const { user } = installerRender(<ProposalPageOptions />);
+  const toggler = screen.getByRole("button");
+  await user.click(toggler);
+  expect(screen.queryByRole("menuitem", { name: /DASD/ })).toBeNull();
+});


### PR DESCRIPTION
## Problem

During a review meeting, we've spot that displaying the _group options name_ when there is only a single group of options can be more confusing than helpful. 


## Solution

Display the group name only when needed. I.e., when really having more than one group of actions for a set of page options.

## Testing

- Added a new unit test
- Tested manually

## Notes

Since it's related with https://github.com/openSUSE/agama/pull/545 and it has not been merged to master yet, this PR belongs to the same changelog entry. No extra one needed, IMHO.

## Screenshots

| Before | After |
|-|-|
| ![Screenshot from 2023-05-02 10-10-53](https://user-images.githubusercontent.com/1691872/235627357-da2c5862-a454-496e-b087-a292113e42b2.png) |![Screenshot from 2023-05-02 10-10-45](https://user-images.githubusercontent.com/1691872/235627379-604400d8-1b8e-43d0-bbf3-da03500620ea.png) |


