### PR TITLE
[web] Use a button for displaying the description popover

### DIFF
--- a/web/src/assets/styles/utilities.scss
+++ b/web/src/assets/styles/utilities.scss
@@ -136,7 +136,3 @@
   /** END block-size fallbacks **/
   block-size: 95dvh;
 }
-
-.cursor-pointer {
-  cursor: pointer;
-}

--- a/web/src/components/core/Description.jsx
+++ b/web/src/components/core/Description.jsx
@@ -20,7 +20,7 @@
  */
 
 import React from "react";
-import { Popover } from "@patternfly/react-core";
+import { Popover, Button } from "@patternfly/react-core";
 
 /**
  * Displays details popup after clicking the children elements
@@ -33,7 +33,7 @@ export default function Description ({ description, children, ...otherProps }) {
   if (description) {
     return (
       <Popover showClose={false} bodyContent={description} {...otherProps}>
-        <span className="cursor-pointer">{children}</span>
+        <Button variant="link" isInline>{children}</Button>
       </Popover>
     );
   }


### PR DESCRIPTION
## Problem

We're using a [`span`](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element) element, which _doesn't mean anything on its own_, for displaying a popover when the user clicks on it. It works and even hints visually to sighted users thanks to a CSS rule, but it isn't intended for user interaction.

## Solution

To use a [`button`](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element) instead, which belongs to [`interactive content`](https://html.spec.whatwg.org/multipage/dom.html#interactive-content) category and might help assistive tech to announce the element.

## Testing

- Tested manually

## Screenshots

There are no visual changes, check it below

|Before (using `span`) | After (using `button`) |
|-|-|
|![Screenshot from 2023-05-03 11-33-13](https://user-images.githubusercontent.com/1691872/235895706-56a4e5bc-7f03-48a0-bbd5-8faae9decefa.png) | ![Screenshot from 2023-05-03 11-32-46](https://user-images.githubusercontent.com/1691872/235895716-2ade80ec-25a9-42d9-a15a-93e4ca8f7d78.png) |

## Notes

Since it somehow belongs to #543 a changelog entry is not needed here.