### PR TITLE
Storage commit callbacks

### DIFF
--- a/service/lib/agama/storage/callbacks.rb
+++ b/service/lib/agama/storage/callbacks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022] SUSE LLC
+# Copyright (c) [2022-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -28,3 +28,4 @@ module Agama
 end
 
 require "agama/storage/callbacks/activate"
+require "agama/storage/callbacks/commit"

--- a/service/lib/agama/storage/callbacks/commit.rb
+++ b/service/lib/agama/storage/callbacks/commit.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "storage"
+require "agama/storage/callbacks/commit_error"
+
+module Agama
+  module Storage
+    module Callbacks
+      # Callbacks used during the storage commit
+      class Commit < ::Storage::CommitCallbacks
+        # Constructor
+        #
+        # @param questions_client [Agama::DBus::Clients::Questions]
+        # @param logger [Logger, nil]
+        def initialize(questions_client, logger: nil)
+          super()
+
+          @questions_client = questions_client
+          @logger = logger || Logger.new($stdout)
+        end
+
+        # Messages are ignored
+        #
+        # Commit messages are used to report the progress of the commit actions.
+        def message(_message); end
+
+        # Callback to report an error to the user.
+        #
+        # @param message [String] error title coming from libstorage-ng
+        #   (in the ASCII-8BIT encoding! see https://sourceforge.net/p/swig/feature-requests/89/)
+        # @param what [String] details coming from libstorage-ng (in the ASCII-8BIT encoding!)
+        # @return [Boolean] true for ignoring the error and continue, false to abort the rest of
+        #   storage actions.
+        def error(message, what)
+          # force the UTF-8 encoding to avoid Encoding::CompatibilityError exception (bsc#1096758)
+          message = message.dup.force_encoding("UTF-8")
+          details = what.dup.force_encoding("UTF-8")
+
+          error_callback = CommitError.new(questions_client, logger: logger)
+          error_callback.call(message, details)
+        end
+
+      private
+
+        # @return [Agama::DBus::Clients::Questions]
+        attr_reader :questions_client
+
+        # @return [Logger]
+        attr_reader :logger
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/callbacks/commit_error.rb
+++ b/service/lib/agama/storage/callbacks/commit_error.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/question"
+
+module Agama
+  module Storage
+    module Callbacks
+      # Callback for a storage commit error
+      class CommitError
+        # Constructor
+        #
+        # @param questions_client [Agama::DBus::Clients::Questions]
+        # @param logger [Logger, nil]
+        def initialize(questions_client, logger: nil)
+          @questions_client = questions_client
+          @logger = logger || Logger.new($stdout)
+        end
+
+        # Generates a question to display the error and to ask to the user whether to ignore the
+        # error and continue.
+        #
+        # @note The process waits until the question is answered.
+        #
+        # @param message [string] Error message
+        # @param details [string] Error details
+        #
+        # @return [Boolean] true to ignore the error and continue
+        def call(message, details)
+          logger.info "Storage commit error, asking to the user whether to continue"
+          logger.info "Error message: #{message}"
+          logger.info "Error details: #{details}"
+
+          question = question(message, details)
+
+          questions_client.ask(question) do |question_client|
+            answer = question_client.answer
+            logger.info "User answer: #{answer}"
+            answer == :yes
+          end
+        end
+
+      private
+
+        # @return [Agama::DBus::Clients::Questions]
+        attr_reader :questions_client
+
+        # @return [Logger]
+        attr_reader :logger
+
+        # Question to ask to continue
+        #
+        # @return [Question]
+        def question(message, _details)
+          text = "There was an error performing the following action: #{message}. " \
+                 "Do you want to continue with the rest of storage actions?"
+
+          Question.new(text, options: [:yes, :no])
+        end
+      end
+    end
+  end
+end

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -23,7 +23,7 @@
     Requires:       yast2-installation
     Requires:       yast2-network
     Requires:       yast2-proxy
-    Requires:       yast2-storage-ng
+    Requires:       yast2-storage-ng >= 4.6.8
     Requires:       open-iscsi
     Requires:       yast2-iscsi-client >= 4.5.7
     Requires:       yast2-users

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri May  5 15:20:25 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Add callbacks for storage commit errors (gh#openSUSE/agama/558).
+
+-------------------------------------------------------------------
 Wed Apr 26 15:48:41 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Add D-Bus API for managing issues.

--- a/service/test/agama/storage/callbacks/commit_error_test.rb
+++ b/service/test/agama/storage/callbacks/commit_error_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "agama/storage/callbacks/commit_error"
+require "agama/dbus/clients/questions"
+require "agama/dbus/clients/question"
+
+describe Agama::Storage::Callbacks::CommitError do
+  subject { described_class.new(questions_client, logger: logger) }
+
+  let(:questions_client) { instance_double(Agama::DBus::Clients::Questions) }
+
+  let(:logger) { Logger.new($stdout, level: :warn) }
+
+  describe "#call" do
+    before do
+      allow(questions_client).to receive(:ask).and_yield(question_client)
+    end
+
+    let(:question_client) { instance_double(Agama::DBus::Clients::Question) }
+
+    it "reports the error and ask whether to continue" do
+      expect(questions_client).to receive(:ask) do |question|
+        expect(question.text).to match(/There was an error/)
+        expect(question.text).to match(/Do you want to continue/)
+      end
+
+      subject.call("test", "details")
+    end
+
+    context "and the question is answered as :yes" do
+      before do
+        allow(question_client).to receive(:answer).and_return(:yes)
+      end
+
+      it "returns true" do
+        expect(subject.call("test", "details")).to eq(true)
+      end
+    end
+
+    context "and the question is answered as :no" do
+      before do
+        allow(question_client).to receive(:answer).and_return(:no)
+      end
+
+      it "returns false" do
+        expect(subject.call("test", "details")).to eq(false)
+      end
+    end
+  end
+end

--- a/service/test/agama/storage/callbacks/commit_test.rb
+++ b/service/test/agama/storage/callbacks/commit_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "agama/storage/callbacks/commit"
+require "agama/dbus/clients/questions"
+
+describe Agama::Storage::Callbacks::Commit do
+  subject { described_class.new(questions_client, logger: logger) }
+
+  let(:questions_client) { instance_double(Agama::DBus::Clients::Questions) }
+
+  let(:logger) { Logger.new($stdout, level: :warn) }
+
+  describe "#error" do
+    before do
+      allow(Agama::Storage::Callbacks::CommitError)
+        .to receive(:new).and_return(error_callback)
+    end
+
+    let(:error_callback) { instance_double(Agama::Storage::Callbacks::CommitError) }
+
+    it "calls the callback for error" do
+      expect(error_callback).to receive(:call)
+
+      subject.error("test", "details")
+    end
+
+    context "when the callback returns true" do
+      before do
+        allow(error_callback).to receive(:call).and_return(true)
+      end
+
+      it "returns true" do
+        expect(subject.error("test", "detail")).to eq(true)
+      end
+    end
+
+    context "when the callback returns false" do
+      before do
+        allow(error_callback).to receive(:call).and_return(false)
+      end
+
+      it "returns false" do
+        expect(subject.error("test", "detail")).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Errors in the storage commit are managed by the default callback provided by YaST. Such a callback reports the error in the YaST UI, which means a failure in Agama.  

## Solution

Now Agama provides its own callback for commit errors. The callback raises a question to ask to the user whether to continue with the rest of storage actions.

This solution requires https://github.com/yast/yast-storage-ng/pull/1336.

Note this is a minimal admisible solution and there still are some improvements to address (follow-up):

* The details of the problem are not reported: https://github.com/openSUSE/agama/issues/560.
* There is no way to stop the installation process yet: https://github.com/openSUSE/agama/issues/561.

## Testing

* Added new unit tests
* Tested manually


## Screenshots

<details>
<summary>Show/hide</summary>

![Screenshot from 2023-05-05 16-43-26](https://user-images.githubusercontent.com/1112304/236505100-fc8db597-0b02-4178-a86e-03eb5540c6e9.png)

</details>

