### PR TITLE
[web] Set sidebar siblings as inert and aria-hidden when it's open

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May  8 15:20:14 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- Set sidebar siblings as aria-hiden while it's open
+  (gh#openSUSE/agama#563)
+
+-------------------------------------------------------------------
 Fri Apr 28 15:16:04 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Add issues for storage client.

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -52,12 +52,18 @@ export default function Sidebar ({ children }) {
 
   const open = () => {
     setIsOpen(true);
-    siblingsFor(asideRef.current).forEach(s => s.setAttribute('aria-hidden', true));
+    siblingsFor(asideRef.current).forEach(s => {
+      s.setAttribute('inert', '');
+      s.setAttribute('aria-hidden', true);
+    });
   };
 
   const close = () => {
     setIsOpen(false);
-    siblingsFor(asideRef.current).forEach(s => s.removeAttribute('aria-hidden'));
+    siblingsFor(asideRef.current).forEach(s => {
+      s.removeAttribute('inert');
+      s.removeAttribute('aria-hidden');
+    });
   };
 
   /**

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -26,6 +26,18 @@ import { If, NotificationMark } from "~/components/core";
 import { useNotification } from "~/context/notification";
 
 /**
+ * Returns siblings for given HTML node
+ *
+ * @param {HTMLElement} node
+ * @returns {HTMLElement[]}
+ */
+const siblingsFor = (node) => {
+  if (!node) return [];
+
+  return [...node.parentNode.children].filter(n => n !== node);
+};
+
+/**
  * Agama sidebar navigation
  * @component
  *
@@ -34,11 +46,19 @@ import { useNotification } from "~/context/notification";
  */
 export default function Sidebar ({ children }) {
   const [isOpen, setIsOpen] = useState(false);
+  const asideRef = useRef(null);
   const closeButtonRef = useRef(null);
   const [notification] = useNotification();
 
-  const open = () => setIsOpen(true);
-  const close = () => setIsOpen(false);
+  const open = () => {
+    setIsOpen(true);
+    siblingsFor(asideRef.current).forEach(s => s.setAttribute('aria-hidden', true));
+  };
+
+  const close = () => {
+    setIsOpen(false);
+    siblingsFor(asideRef.current).forEach(s => s.removeAttribute('aria-hidden'));
+  };
 
   /**
    * Handler for automatically closing the sidebar when a click bubbles from a
@@ -106,6 +126,7 @@ export default function Sidebar ({ children }) {
 
       <aside
         id="global-options"
+        ref={asideRef}
         className="wrapper sidebar"
         aria-label="Global options"
         data-state={isOpen ? "visible" : "hidden"}

--- a/web/src/components/core/Sidebar.test.jsx
+++ b/web/src/components/core/Sidebar.test.jsx
@@ -78,7 +78,7 @@ it("renders a link for hiding the sidebar", async () => {
   expect(sidebar).toHaveAttribute("data-state", "hidden");
 });
 
-it("sets siblings as aria-hidden while it's open", async () => {
+it("sets siblings as inert and aria-hidden while it's open", async () => {
   const { user } = installerRender(withNotificationProvider(
     <>
       <div>A sidebar sibling</div>
@@ -90,10 +90,13 @@ it("sets siblings as aria-hidden while it's open", async () => {
   const closeLink = await screen.findByLabelText(/Hide/i);
   const sidebarSibling = screen.getByText("A sidebar sibling");
   expect(sidebarSibling).not.toHaveAttribute("aria-hidden");
+  expect(sidebarSibling).not.toHaveAttribute("inert");
   await user.click(openLink);
   expect(sidebarSibling).toHaveAttribute("aria-hidden");
+  expect(sidebarSibling).toHaveAttribute("inert");
   await user.click(closeLink);
   expect(sidebarSibling).not.toHaveAttribute("aria-hidden");
+  expect(sidebarSibling).not.toHaveAttribute("inert");
 });
 
 it("moves the focus to the close action after opening it", async () => {

--- a/web/src/components/core/Sidebar.test.jsx
+++ b/web/src/components/core/Sidebar.test.jsx
@@ -78,6 +78,24 @@ it("renders a link for hiding the sidebar", async () => {
   expect(sidebar).toHaveAttribute("data-state", "hidden");
 });
 
+it("sets siblings as aria-hidden while it's open", async () => {
+  const { user } = installerRender(withNotificationProvider(
+    <>
+      <div>A sidebar sibling</div>
+      <Sidebar />
+    </>
+  ));
+
+  const openLink = await screen.findByLabelText(/Show/i);
+  const closeLink = await screen.findByLabelText(/Hide/i);
+  const sidebarSibling = screen.getByText("A sidebar sibling");
+  expect(sidebarSibling).not.toHaveAttribute("aria-hidden");
+  await user.click(openLink);
+  expect(sidebarSibling).toHaveAttribute("aria-hidden");
+  await user.click(closeLink);
+  expect(sidebarSibling).not.toHaveAttribute("aria-hidden");
+});
+
 it("moves the focus to the close action after opening it", async () => {
   const { user } = installerRender(withNotificationProvider(<Sidebar />));
 


### PR DESCRIPTION
## Description

Now that the sidebar is a direct descendant of `div#root`, mimics what [PatternFly Modal does](https://github.com/patternfly/patternfly-react/blob/f66b668ef3fc16098974e1ac80c94e98b02a03d2/packages/react-core/src/components/Modal/Modal.tsx#L149-L158) and set sidebar siblings as [`aria-hidden`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) while it is open.

Despite notes that can be read in the above linked MDN page, this makes sense from the perspective that the sidebar is somehow **_the content_** when it's open. In fact, at the time of writing, it partially overlaps the rest of the content making it "useless" at a certain point, the reason why the "recently adopted" [`inert`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert) attribute has been added too in order to ignore user inputs on them. Last but not least, a subsequent PR will complement this one by adding some CSS filters to the aria-hidden content, making this one more sensible.

## Testing

- Added a new unit test
- Tested manually

## Screenshots

| Sidebar closed | Sidebar open |
|-|-|
| ![Screenshot from 2023-05-08 16-48-50](https://user-images.githubusercontent.com/1691872/236870113-591254b6-ae1b-4e31-8bc3-c99a40dc874a.png) | ![Screenshot from 2023-05-08 16-48-46](https://user-images.githubusercontent.com/1691872/236870023-913fe2c1-3145-444f-be2c-c8dd2acf6fc9.png) | 
| ![Screenshot from 2023-05-08 16-49-19](https://user-images.githubusercontent.com/1691872/236870206-0c31f2d3-fec8-4e48-bc4f-c51026dda8c0.png) | ![Screenshot from 2023-05-08 16-49-26](https://user-images.githubusercontent.com/1691872/236870052-0fe4b23e-c7d7-4103-9c1e-9f7220dacc83.png) |

^^^ Not that, thanks to the `inert` attribute, now there is no pointer on the link when the sidebar is open


---

To read more about inert, 

* https://caniuse.com/?search=inert
* https://www.stefanjudis.com/blog/the-inert-attribute-is-finally-coming-to-the-web/
* https://github.com/WICG/inert/blob/main/explainer.md#use-cases 

