### PR TITLE
[web] Blur and grayscale `aria-hidden` and `inert` div nodes

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May 19 09:29:50 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- UI: grayscale and blur not accessible div nodes
+  (gh#openSUSE/agama#564)
+
+-------------------------------------------------------------------
 Wed May 17 15:42:31 UTC 2023 - David Diaz <dgonzalez@suse.com>
 
 - Ensure siblings of an open modal dialog do not remain hidden from

--- a/web/src/assets/styles/composition.scss
+++ b/web/src/assets/styles/composition.scss
@@ -23,3 +23,8 @@
 [data-state="reversed"] {
   flex-direction: row-reverse;
 }
+
+div[inert],
+div[aria-hidden="true"] {
+  filter: grayscale(1) blur(2px);
+}


### PR DESCRIPTION
## Problem

While the sidebar is open, the rest of the content is _inert_ and _aria hidden_. This on purpose, done in https://github.com/openSUSE/agama/pull/563.

But there is no is not enough visual hints about this neither, when the Agama sidebar is open nor a PatternFly Modal is displayed.

## Solution

To use some [CSS filters](https://developer.mozilla.org/en-US/docs/Web/CSS/filter) to make more evident what is going on. Grayscale and blur, to be more precise.

## Testing

- Tested manually

## Notes

There were some issues with modal dialogs. See comments marked as outdated and/or read https://github.com/openSUSE/agama/pull/580 to know more.

## Screenshots

<details>
<summary>Click to show/hide screenshots</summary>

---

|Sidebar closed | Sidebar open |
|-|-|
|![Screen Shot 2023-05-08 at 16 59 06](https://user-images.githubusercontent.com/1691872/236872826-5844144b-15d8-42e3-bea9-819581855c15.png) | ![Screen Shot 2023-05-08 at 16 59 01](https://user-images.githubusercontent.com/1691872/236872861-289349da-f4e4-464d-bef5-20b6d914ab49.png) |
| ![Screen Shot 2023-05-08 at 17 17 13](https://user-images.githubusercontent.com/1691872/236876152-171f656b-319c-4030-8e66-a8591e5773d2.png) | ![Screen Shot 2023-05-08 at 17 17 00](https://user-images.githubusercontent.com/1691872/236876191-30de69c1-78e5-4a4a-bed6-2854170c0ee2.png) |



|Modal closed | Modal open |
|-|-|
|![Screen Shot 2023-05-08 at 17 01 20](https://user-images.githubusercontent.com/1691872/236872991-4fff8121-a2e9-4096-8d64-44f6943ce68e.png) | ![Screen Shot 2023-05-08 at 17 01 35](https://user-images.githubusercontent.com/1691872/236873011-65747f4a-596e-4544-a6d8-5286f56b9c7f.png) |
| ![Screen Shot 2023-05-08 at 17 17 13](https://user-images.githubusercontent.com/1691872/236876306-071c57cb-3c39-4c9c-b44e-b32bfc0bc748.png) | ![Screen Shot 2023-05-08 at 17 17 09](https://user-images.githubusercontent.com/1691872/236876329-cad86b7c-ff4a-4df4-9092-e74e8091ef91.png) |
</details>