### PR TITLE
[web] Increase the z-index of the sidebar

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,9 +1,14 @@
 -------------------------------------------------------------------
+Tue May  9 22:36:12 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- Keep the sidebar on top of other elements when it's open
+  (gh#openSUSE/agama#569).
+
+-------------------------------------------------------------------
 Mon May  8 15:20:14 UTC 2023 - David Diaz <dgonzalez@suse.com>
 
 - Set sidebar siblings as aria-hiden while it's open
   (gh#openSUSE/agama#563)
-
 -------------------------------------------------------------------
 Fri Apr 28 15:16:04 UTC 2023 - José Iván López González <jlopez@suse.com>
 

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -82,7 +82,7 @@ section > .content {
   position: absolute;
   padding: 0;
   right: 0;
-  z-index: 1;
+  z-index: 1000;
   inline-size: 70%;
   box-shadow: -10px 10px 20px 0 var(--color-primary);
 }


### PR DESCRIPTION
## Problem

The component used for [displaying the page options](https://github.com/openSUSE/agama/pull/545) has a higher `z-index` than the Sidebar. This combined with the fact that [the component it isn't closed automatically when the user clicks outside](https://github.com/openSUSE/agama/issues/552) can lead to a situation of having the sidebar open but the page menu options on top.

## Solution

Use a higher value for the Sidebar `z-index`. More specifically, the `1000` value because [PatternFly uses values from 100 to 600](https://github.com/patternfly/patternfly/blob/7ddc2de5cfb96f204e62730878a9e77bed64b998/src/patternfly/sass-utilities/scss-variables.scss#L154-L160) at the time of writing. See 

Another option could be to use the PatternFly highest value, but IMHO it does not seem necessary to couple the Sidebar `z-index` to a PatternFly variable. At least for now.

## Testing

- Tested manually

## Screenshots

| Before | After |
|-|-|
|![Screenshot from 2023-05-09 23-23-58](https://github.com/openSUSE/agama/assets/1691872/021c64fb-e82c-4c55-99f1-31a45fbd099f) | ![Screenshot from 2023-05-09 23-23-25](https://github.com/openSUSE/agama/assets/1691872/afa4dea8-4e6f-46b3-901b-d88cf70093a0) |
