### PR TITLE
[web] Ensure Sidebar siblings do not remain inert forever 

### DIFF
--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -101,7 +101,7 @@ export default function Sidebar ({ children }) {
   }, [isOpen]);
 
   useLayoutEffect(() => {
-    // Ensure siblings do not remain inert when the component is unmount.
+    // Ensure siblings do not remain inert when the component is unmounted.
     // Using useLayoutEffect over useEffect for allowing the cleanup function to
     // be executed immediately BEFORE unmounting the component and still having
     // access to siblings.

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Button, Text } from "@patternfly/react-core";
 import { Icon, AppActions } from "~/components/layout";
 import { If, NotificationMark } from "~/components/core";
@@ -32,7 +32,7 @@ import { useNotification } from "~/context/notification";
  * @returns {HTMLElement[]}
  */
 const siblingsFor = (node) => {
-  if (!node) return [];
+  if (!node?.parentNode) return [];
 
   return [...node.parentNode.children].filter(n => n !== node);
 };
@@ -85,6 +85,18 @@ export default function Sidebar ({ children }) {
   useEffect(() => {
     if (isOpen) closeButtonRef.current.focus();
   }, [isOpen]);
+
+  // Ensure not keeping siblings nodes as inert in case the component is unmount
+  useLayoutEffect(() => {
+    const aside = asideRef.current;
+
+    return () => {
+      siblingsFor(aside).forEach(s => {
+        s.removeAttribute('inert');
+        s.removeAttribute('aria-hidden');
+      });
+    };
+  }, []);
 
   // display additional info when running in a development server
   let targetInfo = null;

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -51,7 +51,7 @@ export default function Sidebar ({ children }) {
   const [notification] = useNotification();
 
   /**
-   * Set siblings as not discoverable and not interactive
+   * Set siblings as not interactive and not discoverable
    */
   const makeSiblingsInert = () => {
     siblingsFor(asideRef.current).forEach(s => {
@@ -61,7 +61,7 @@ export default function Sidebar ({ children }) {
   };
 
   /**
-   * Set siblings as discoverable and interactive
+   * Set siblings as interactive and discoverable
    */
   const makeSiblingsAlive = () => {
     siblingsFor(asideRef.current).forEach(s => {

--- a/web/src/components/core/Sidebar.test.jsx
+++ b/web/src/components/core/Sidebar.test.jsx
@@ -198,7 +198,7 @@ describe("side effects on siblings", () => {
     expect(sidebarSibling).not.toHaveAttribute("inert");
   });
 
-  it("removes inert and aria-hidden siblings attributes if it's unmount", async () => {
+  it("removes inert and aria-hidden siblings attributes if it's unmounted", async () => {
     const { user } = installerRender(withNotificationProvider(<SidebarWithSiblings />));
 
     const openLink = await screen.findByLabelText(/Show/i);

--- a/web/src/components/core/Sidebar.test.jsx
+++ b/web/src/components/core/Sidebar.test.jsx
@@ -22,7 +22,7 @@
 import React from "react";
 import { screen, within } from "@testing-library/react";
 import { installerRender, mockLayout, mockComponent, withNotificationProvider } from "~/test-utils";
-import { Sidebar } from "~/components/core";
+import { If, Sidebar } from "~/components/core";
 import { createClient } from "~/client";
 
 // Mock layout
@@ -76,27 +76,6 @@ it("renders a link for hiding the sidebar", async () => {
   expect(sidebar).toHaveAttribute("data-state", "visible");
   await user.click(closeLink);
   expect(sidebar).toHaveAttribute("data-state", "hidden");
-});
-
-it("sets siblings as inert and aria-hidden while it's open", async () => {
-  const { user } = installerRender(withNotificationProvider(
-    <>
-      <div>A sidebar sibling</div>
-      <Sidebar />
-    </>
-  ));
-
-  const openLink = await screen.findByLabelText(/Show/i);
-  const closeLink = await screen.findByLabelText(/Hide/i);
-  const sidebarSibling = screen.getByText("A sidebar sibling");
-  expect(sidebarSibling).not.toHaveAttribute("aria-hidden");
-  expect(sidebarSibling).not.toHaveAttribute("inert");
-  await user.click(openLink);
-  expect(sidebarSibling).toHaveAttribute("aria-hidden");
-  expect(sidebarSibling).toHaveAttribute("inert");
-  await user.click(closeLink);
-  expect(sidebarSibling).not.toHaveAttribute("aria-hidden");
-  expect(sidebarSibling).not.toHaveAttribute("inert");
 });
 
 it("moves the focus to the close action after opening it", async () => {
@@ -180,5 +159,58 @@ describe("if there are not issues", () => {
     const link = await screen.findByLabelText(/Show/i);
     const mark = within(link).queryByRole("status", { name: /New issues/ });
     expect(mark).toBeNull();
+  });
+});
+
+describe("side effects on siblings", () => {
+  const SidebarWithSiblings = () => {
+    const [isSidebarMount, setIsSidebarMount] = React.useState(true);
+
+    // NOTE: using the "data-keep-sidebar-open" to avoid triggering the #close
+    // function before unmounting the component.
+    const Content = () => (
+      <button data-keep-sidebar-open onClick={() => setIsSidebarMount(false)}>
+        Unmount Sidebar
+      </button>
+    );
+
+    return (
+      <>
+        <article>A sidebar sibling</article>
+        <If condition={isSidebarMount} then={<Sidebar><Content /></Sidebar>} />
+      </>
+    );
+  };
+
+  it("sets siblings as inert and aria-hidden while it's open", async () => {
+    const { user } = installerRender(withNotificationProvider(<SidebarWithSiblings />));
+
+    const openLink = await screen.findByLabelText(/Show/i);
+    const closeLink = await screen.findByLabelText(/Hide/i);
+    const sidebarSibling = screen.getByText("A sidebar sibling");
+    expect(sidebarSibling).not.toHaveAttribute("aria-hidden");
+    expect(sidebarSibling).not.toHaveAttribute("inert");
+    await user.click(openLink);
+    expect(sidebarSibling).toHaveAttribute("aria-hidden");
+    expect(sidebarSibling).toHaveAttribute("inert");
+    await user.click(closeLink);
+    expect(sidebarSibling).not.toHaveAttribute("aria-hidden");
+    expect(sidebarSibling).not.toHaveAttribute("inert");
+  });
+
+  it("removes inert and aria-hidden siblings attributes if it's unmount", async () => {
+    const { user } = installerRender(withNotificationProvider(<SidebarWithSiblings />));
+
+    const openLink = await screen.findByLabelText(/Show/i);
+    const unmountButton = await screen.getByRole("button", { name: "Unmount Sidebar" });
+    const sidebarSibling = screen.getByText("A sidebar sibling");
+    expect(sidebarSibling).not.toHaveAttribute("aria-hidden");
+    expect(sidebarSibling).not.toHaveAttribute("inert");
+    await user.click(openLink);
+    expect(sidebarSibling).toHaveAttribute("aria-hidden");
+    expect(sidebarSibling).toHaveAttribute("inert");
+    await user.click(unmountButton);
+    expect(sidebarSibling).not.toHaveAttribute("aria-hidden");
+    expect(sidebarSibling).not.toHaveAttribute("inert");
   });
 });


### PR DESCRIPTION
## Problem

As mentioned in https://github.com/patternfly/patternfly-react/pull/9096, #564 revealed that unmounting a PF4/Modal component results in its siblings remaining hidden from the accessibility API.

Since #563 followed the same pattern of hiding the Sidebar siblings, it may suffer the same problem if it is unmounted (although it is not supposed to happen). Therefore, it would be better to minimize the risk of keeping siblings inert if the Sidebar is unmounted in the future.

## Solution

To remove the `inert` and `aria-hidden` attributes from its siblings **BEFORE** the Sidebar is unmounted. Note the use of [`useLayoutEffect`](https://react.dev/reference/react/useLayoutEffect) for doing so while the component still having access to the parent and its children.

## Testing

- Added another unit test

- Tested manually

## Notes

* Consider this PR as an extension or improvement of #563. I.e., no entry in the changelog needed.
* I was tempted to drop the `aria-hidden` attribute and use only `inert`, which [should do both](https://html.spec.whatwg.org/multipage/interaction.html#inert-subtrees), make the element not interactive and remove it from the accessibility tree

  > Inert nodes generally cannot be focused, and user agents do not expose the inert nodes to accessibility APIs or assistive technologies.

  But I have left there meanwhile to be _in sync_ with PF4/Modal. We can drop it in the future, once `inert` is more adopted.

  To know more, read https://developer.chrome.com/articles/inert/

* We started doing this in #563 for _mimicking_ PF4/Modal **and** to be ready for #564. Now I have realized that all of this is well described in the [Dialog (Modal) pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) available at [ARIA Authoring Practices Guide (APG) ](https://www.w3.org/WAI/ARIA/apg/). So, looks like we're in the right path :wink: (and doing _almost the same_ that the modal version of the native [`dialog`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) element, which would be nice to start using at some point in the future).
* Worth mentioning/reminding that for now the component is just adding/removing these attributes, but not tracking if they were already there (which is unlikely) for restoring them instead of removing. Related to #565.

## Screenshots

N/A