### PR TITLE
Merge root user settings

### DIFF
--- a/rust/agama-lib/src/install_settings.rs
+++ b/rust/agama-lib/src/install_settings.rs
@@ -178,6 +178,11 @@ impl Settings for UserSettings {
             let first_user = self.first_user.get_or_insert(Default::default());
             first_user.merge(other_first_user);
         }
+
+        if let Some(other_root) = &other.root {
+            let root = self.root.get_or_insert(Default::default());
+            root.merge(other_root);
+        }
     }
 }
 
@@ -255,6 +260,26 @@ pub struct SoftwareSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_user_settings_merge() {
+        let mut user1 = UserSettings::default();
+        let user2 = UserSettings {
+            first_user: Some(FirstUserSettings {
+                full_name: Some("Jane Doe".to_string()),
+                ..Default::default()
+            }),
+            root: Some(RootUserSettings {
+                password: Some("nots3cr3t".to_string()),
+                ..Default::default()
+            }),
+        };
+        user1.merge(&user2);
+        let first_user = user1.first_user.unwrap();
+        assert_eq!(first_user.full_name, Some("Jane Doe".to_string()));
+        let root_user = user1.root.unwrap();
+        assert_eq!(root_user.password, Some("nots3cr3t".to_string()));
+    }
 
     #[test]
     fn test_merge() {

--- a/rust/agama-lib/src/store/users.rs
+++ b/rust/agama-lib/src/store/users.rs
@@ -24,12 +24,11 @@ impl<'a> UsersStore<'a> {
             full_name: Some(first_user.full_name),
             password: Some(first_user.password),
         };
-        let ssh_public_key = self.users_client.root_ssh_key().await;
-        let root_user = RootUserSettings {
-            // todo: expose the password
-            password: None,
-            ssh_public_key: ssh_public_key.ok(),
-        };
+        let mut root_user = RootUserSettings::default();
+        let ssh_public_key = self.users_client.root_ssh_key().await?;
+        if !ssh_public_key.is_empty() {
+            root_user.ssh_public_key = Some(ssh_public_key)
+        }
         Ok(UserSettings {
             first_user: Some(first_user),
             root: Some(root_user),

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu May 11 11:00:11 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Import root authentication settings when reading a Jsonnet file
+  (bsc#1211300, gh#openSUSE/agama#573).
+- Do not export the SSH public key as an empty string when it is
+  not defined.
+
+-------------------------------------------------------------------
 Fri Mar 24 14:36:36 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 0.2:


### PR DESCRIPTION
## Problem

Root user settings are not imported when reading them from a Jsonnet file.

* [bsc#1211300](https://bugzilla.suse.com/show_bug.cgi?id=1211300)

## Solution

Merge the root user settings. That kind of problem should go away when we generalize `agama-derive` to merge non-scalar fields too.

## Testing

- Added a new unit test
- Manually tested