### PR TITLE
[PoC]: Stop rendering unmounting modals directly

### DIFF
--- a/web/src/components/core/InstallButton.jsx
+++ b/web/src/components/core/InstallButton.jsx
@@ -27,7 +27,7 @@ import { useNavigate } from "react-router-dom";
 
 import { If, Popup } from "~/components/core";
 
-const InstallConfirmationPopup = ({ hasIssues, onAccept, onClose }) => {
+const InstallConfirmationPopup = React.memo(({ isOpen, hasIssues, onAccept, onClose }) => {
   const navigate = useNavigate();
 
   const IssuesWarning = () => {
@@ -49,8 +49,8 @@ const InstallConfirmationPopup = ({ hasIssues, onAccept, onClose }) => {
 
   return (
     <Popup
+      isOpen={isOpen}
       title="Confirm Installation"
-      isOpen
     >
       <div className="stack">
         <If condition={hasIssues} then={<IssuesWarning />} />
@@ -68,12 +68,12 @@ const InstallConfirmationPopup = ({ hasIssues, onAccept, onClose }) => {
       </Popup.Actions>
     </Popup>
   );
-};
+});
 
-const CannotInstallPopup = ({ onClose }) => (
+const CannotInstallPopup = React.memo(({ isOpen, onClose }) => (
   <Popup
+    isOpen={isOpen}
     title="Problems Found"
-    isOpen
   >
     <p>
       Some problems were found when trying to start the installation.
@@ -84,15 +84,7 @@ const CannotInstallPopup = ({ onClose }) => (
       <Popup.Cancel onClick={onClose} autoFocus>Accept</Popup.Cancel>
     </Popup.Actions>
   </Popup>
-);
-
-const renderPopup = (error, hasIssues, { onAccept, onClose }) => {
-  if (error) {
-    return <CannotInstallPopup onClose={onClose} />;
-  } else {
-    return <InstallConfirmationPopup onClose={onClose} onAccept={onAccept} hasIssues={hasIssues} />;
-  }
-};
+));
 
 /**
  * Installation button
@@ -121,8 +113,9 @@ const InstallButton = ({ onClick }) => {
     setIsOpen(true);
     setError(!canInstall);
   };
-  const close = () => setIsOpen(false);
-  const install = () => client.manager.startInstallation();
+
+  const close = React.useCallback(() => setIsOpen(false), []);
+  const install = React.useCallback(() => client.manager.startInstallation(), [client.manager]);
 
   return (
     <>
@@ -130,7 +123,8 @@ const InstallButton = ({ onClick }) => {
         Install
       </Button>
 
-      { isOpen && renderPopup(error, hasIssues, { onAccept: install, onClose: close }) }
+      <CannotInstallPopup isOpen={isOpen && !error} onClose={close} />;
+      <InstallConfirmationPopup isOpen={isOpen && error} onClose={close} onAccept={install} hasIssues={hasIssues} />;
     </>
   );
 };

--- a/web/src/components/core/ShowTerminalButton.jsx
+++ b/web/src/components/core/ShowTerminalButton.jsx
@@ -46,8 +46,7 @@ const ShowTerminalButton = () => {
         Open Terminal
       </Button>
 
-      { isTermDisplayed &&
-        <Terminal onCloseCallback={onClose} /> }
+      <Terminal onCloseCallback={onClose} isOpen={isTermDisplayed} />
     </>
   );
 };

--- a/web/src/components/core/Terminal.jsx
+++ b/web/src/components/core/Terminal.jsx
@@ -19,15 +19,11 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useState } from "react";
+import React from "react";
 import { Popup } from "~/components/core";
 
-export default function Terminal({ onCloseCallback }) {
-  // the popup is visible
-  const [isOpen, setIsOpen] = useState(true);
-
+export default function Terminal({ isOpen = false, onCloseCallback }) {
   const close = () => {
-    setIsOpen(false);
     if (onCloseCallback) onCloseCallback();
   };
 

--- a/web/src/components/network/NetworkPage.jsx
+++ b/web/src/components/network/NetworkPage.jsx
@@ -24,7 +24,7 @@ import { Button, Skeleton } from "@patternfly/react-core";
 import { Icon } from "~/components/layout";
 import { useInstallerClient } from "~/context/installer";
 import { ConnectionTypes, NetworkEventTypes } from "~/client/network";
-import { If, Page, Section } from "~/components/core";
+import { If, Page, Popup, Section } from "~/components/core";
 import { ConnectionsTable, IpSettingsForm, NetworkPageOptions, WifiSelector } from "~/components/network";
 
 /**
@@ -89,6 +89,7 @@ export default function NetworkPage() {
 
   const openWifiSelector = () => setWifiSelectorOpen(true);
   const closeWifiSelector = () => setWifiSelectorOpen(false);
+  const unselectConnection = () => setSelectedConnection(null);
 
   useEffect(() => {
     client.setUp().then(() => setInitialized(true));
@@ -133,7 +134,7 @@ export default function NetworkPage() {
     });
   });
 
-  const selectConnection = ({ id }) => {
+  const selectConnection = async ({ id }) => {
     client.getConnection(id).then(setSelectedConnection);
   };
 
@@ -175,15 +176,18 @@ export default function NetworkPage() {
 
       <NetworkPageOptions wifiScanSupported={wifiScanSupported} openWifiSelector={openWifiSelector} />
 
+      { /* TODO: improve the connections edition */ }
+      <Popup isOpen={selectedConnection !== null} height="medium" title={`Edit "${selectedConnection?.name}" connection`}>
+        <IpSettingsForm connection={selectedConnection} onClose={unselectConnection} />
+        <Popup.Actions>
+          <Popup.Confirm form="edit-connection" type="submit" />
+          <Popup.Cancel onClick={unselectConnection} />
+        </Popup.Actions>
+      </Popup>
+
       <If
         condition={wifiScanSupported}
         then={<WifiSelector isOpen={wifiSelectorOpen} onClose={closeWifiSelector} />}
-      />
-
-      { /* TODO: improve the connections edition */ }
-      <If
-        condition={selectedConnection}
-        then=<IpSettingsForm connection={selectedConnection} onClose={() => setSelectedConnection(null)} />
       />
     </Page>
   );

--- a/web/src/components/users/FirstUser.jsx
+++ b/web/src/components/users/FirstUser.jsx
@@ -185,75 +185,74 @@ export default function FirstUser() {
     <>
       { isUserDefined ? <UserData user={user} actions={actions} /> : <UserNotDefined actionCb={openForm} /> }
       { /* TODO: Extract this form to a component, if possible */ }
-      { isFormOpen &&
-        <Popup isOpen height="medium" title={isEditing ? "Edit user account" : "Create user account"}>
-          <Form id="createUser" onSubmit={(e) => accept("createUser", e)}>
-            { showErrors() &&
-              <Alert variant="warning" isInline title="Something went wrong">
-                { errors.map((e, i) => <p key={`error_${i}`}>{e}</p>) }
-              </Alert> }
+      <Popup isOpen={isFormOpen} height="medium" title={isEditing ? "Edit user account" : "Create user account"}>
+        <Form id="createUser" onSubmit={(e) => accept("createUser", e)}>
+          { showErrors() &&
+            <Alert variant="warning" isInline title="Something went wrong">
+              { errors.map((e, i) => <p key={`error_${i}`}>{e}</p>) }
+            </Alert> }
 
-            <FormGroup fieldId="userFullName" label="Full name">
-              <TextInput
-                id="userFullName"
-                name="fullName"
-                aria-label="User fullname"
-                value={formValues.fullName}
-                label="User full name"
-                onChange={handleInputChange}
-              />
-            </FormGroup>
-
-            <FormGroup fieldId="userName" label="Username" isRequired>
-              <TextInput
-                id="userName"
-                name="userName"
-                aria-label="Username"
-                value={formValues.userName}
-                label="Username"
-                isRequired
-                onChange={handleInputChange}
-              />
-            </FormGroup>
-
-            { isEditing &&
-              <Checkbox
-                aria-label="Edit password too"
-                id="edit-password"
-                name="edit-password"
-                label="Edit password too"
-                isChecked={isSettingPassword}
-                onChange={toggleShowPasswordField}
-              /> }
-
-            { isSettingPassword &&
-              <PasswordAndConfirmationInput
-                value={formValues.password}
-                onChange={(value, event) => {
-                  handleInputChange(value, event);
-                }}
-                onValidation={isValid => setIsValidPassword(isValid)}
-              /> }
-
-            <Checkbox
-              aria-label="user autologin"
-              id="autologin"
-              name="autologin"
-              label="Auto-login"
-              isChecked={formValues.autologin}
+          <FormGroup fieldId="userFullName" label="Full name">
+            <TextInput
+              id="userFullName"
+              name="fullName"
+              aria-label="User fullname"
+              value={formValues.fullName}
+              label="User full name"
               onChange={handleInputChange}
             />
-          </Form>
+          </FormGroup>
 
-          <Popup.Actions>
-            <Popup.Confirm
-              form="createUser"
-              type="submit"
-              isDisabled={submitDisable}
+          <FormGroup fieldId="userName" label="Username" isRequired>
+            <TextInput
+              id="userName"
+              name="userName"
+              aria-label="Username"
+              value={formValues.userName}
+              label="Username"
+              isRequired
+              onChange={handleInputChange}
             />
-            <Popup.Cancel onClick={closeForm} />
-          </Popup.Actions>
-        </Popup> }
+          </FormGroup>
+
+          { isEditing &&
+            <Checkbox
+              aria-label="Edit password too"
+              id="edit-password"
+              name="edit-password"
+              label="Edit password too"
+              isChecked={isSettingPassword}
+              onChange={toggleShowPasswordField}
+            /> }
+
+          { isSettingPassword &&
+            <PasswordAndConfirmationInput
+              value={formValues.password}
+              onChange={(value, event) => {
+                handleInputChange(value, event);
+              }}
+              onValidation={isValid => setIsValidPassword(isValid)}
+            /> }
+
+          <Checkbox
+            aria-label="user autologin"
+            id="autologin"
+            name="autologin"
+            label="Auto-login"
+            isChecked={formValues.autologin}
+            onChange={handleInputChange}
+          />
+        </Form>
+
+        <Popup.Actions>
+          <Popup.Confirm
+            form="createUser"
+            type="submit"
+            isDisabled={submitDisable}
+          />
+          <Popup.Cancel onClick={closeForm} />
+        </Popup.Actions>
+      </Popup>
     </>
   );
 }


### PR DESCRIPTION
## Problem

The Agama/Popup is layered over PF4/Modal, which has the prop `isOpen` for managing whether the dialog should be displayed or not.

Behind the scenes, the [PF4/Modal creates a container div DOM node and store it in its internal state](https://github.com/patternfly/patternfly-react/blob/a0f857c4de39dd415792a8701e7c6ac7fd853024/packages/react-core/src/components/Modal/Modal.tsx#L170-L173). Then, the [PF4/ModalContent renders or not](https://github.com/patternfly/patternfly-react/blob/a0f857c4de39dd415792a8701e7c6ac7fd853024/packages/react-core/src/components/Modal/ModalContent.tsx#L120-L122)  the expected content based on the `isOpen` prop.

So far, so good.

However, we often mount the Agama/Popup as `isOpen` and then unmount it instead of switching `isOpen` to false. That led us to find a noteworthy issue related to accessibility: The PF4/Modal adds the `aria-hidden` attribute to its siblings when _`isOpen = true`_ and removes it when _`isOpen = false`_. But it **does not** remove it when the component is unmounted without transitioning from the first value to the latest.

This PR is (perhaps was) an attempt to fix the issue by using the `isOpen` prop to close the dialog instead of just unmounting it.

Sadly, it is not as direct as it could seem at first. Specially in cases where a parent component mounts more than one modal dialog: _React normally re-renders a component whenever its parent re-renders_. No matter if the child's props had changed or not. The problem at this point might be not so evident: when the user opens the first rendered (and until now hidden) dialog, it will toggle its siblings as aria-hidden. BUT, the second dialog, which has been re-rendered too but kept hidden, will remove the aria-hidden attribute from its siblings, which are the same siblings as the other dialog since all of them are children of the body element (unless using the `appendTo` prop, but this is another story).

The `RootAuthMethods` component is one of the examples of the above. It also happens with the `InstallButton` and in a similar way with `NetworkPage`.

And I fear the adaptation of `Questions` would be more challenging because they are not always there as in the other cases. They just appear if needed and disappears when answered. But this is just a speculation, maybe they will be easier than I'm anticipating at the time of writing.

## Solution

The idea of this PR is/was to solve the issue by using the `isOpen` prop. But, as explained above, it is not so easy because the structure of quite some components has to be rethought (lift some children, change where bits of internal state lives, use `React.memo`  in some particular cases, etc). Not a big deal at the end, but might be a time-consuming task that I fear we cannot afford in the short term.

Thus, this can be taken as a starting point for re-evaluating if we should (or not) stop unmounting modals.

Meanwhile, I'd wait to see what happens with the fix proposed to upstream and/or use a workaround at the Agama/Popup level: to ensure its siblings are exposed to the accessibility API again BEFORE it is unmounted, as we already did in Agama/Sidebar

## Testing

Currently, test suits are failing.

## Screenshots

N/A

## Related to 

https://github.com/openSUSE/agama/pull/564