### PR TITLE
Added ppc64le repositories

### DIFF
--- a/service/etc/agama.yaml
+++ b/service/etc/agama.yaml
@@ -150,6 +150,8 @@ ALP-Bedrock:
         archs: aarch64
       - url: https://download.opensuse.org/repositories/SUSE:/ALP:/Products:/Bedrock:/0.1/images/repo/ALP-Bedrock-0.1-s390x-Media1/
         archs: s390
+      - url: https://download.opensuse.org/repositories/SUSE:/ALP:/Products:/Bedrock:/0.1/images/repo/ALP-Bedrock-0.1-ppc64le-Media1/
+        archs: ppc
 
     mandatory_patterns:
       - alp-bedrock-base
@@ -224,6 +226,8 @@ ALP-Micro:
         archs: aarch64
       - url: https://download.opensuse.org/repositories/SUSE:/ALP:/Products:/Micro:/0.1/images/repo/ALP-Micro-0.1-s390x-Media1/
         archs: s390
+      - url: https://download.opensuse.org/repositories/SUSE:/ALP:/Products:/Micro:/0.1/images/repo/ALP-Micro-0.1-ppc64le-Media1/
+        archs: ppc
 
     mandatory_patterns:
       - alp-micro-base

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 16 13:42:18 UTC 2023 - Knut Alejandro Anderssen González <kanderssen@suse.com>
+
+- Added ppc64le repositories for ALP Bedrock and ALP Micro products
+- gh#openSUSE/agama#577
+
+-------------------------------------------------------------------
 Fri May  5 15:20:25 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Add callbacks for storage commit errors (gh#openSUSE/agama/558).


### PR DESCRIPTION
## Problem

There are no **ppc64le** architecture repositories defined for the ALP Bedrock and ALP Micro products

- https://trello.com/c/yvjUFE4R/3352-5-agama-initial-ppc-support

## Solution

Added ppc64le architecture repositories
