### PR TITLE
Adapt storage client

### DIFF
--- a/service/lib/agama/dbus/storage/devices_tree.rb
+++ b/service/lib/agama/dbus/storage/devices_tree.rb
@@ -38,6 +38,14 @@ module Agama
           @logger = logger
         end
 
+        # Object path for the D-Bus object representing the given device
+        #
+        # @param device [Y2Storage::Device]
+        # @return [::DBus::ObjectPath]
+        def path_for(device)
+          ::DBus::ObjectPath.new(File.join(root_path, device.sid.to_s))
+        end
+
         # Updates the D-Bus tree according to the given devicegraph
         #
         # The current D-Bus nodes are all unexported.
@@ -82,14 +90,6 @@ module Agama
         # Unexports the currently exported D-Bus objects
         def unexport_devices
           dbus_objects.each { |n| service.unexport(n) }
-        end
-
-        # Object path for the D-Bus object representing the given device
-        #
-        # @param device [Y2Storage::Device]
-        # @return [::DBus::ObjectPath]
-        def path_for(device)
-          ::DBus::ObjectPath.new(File.join(root_path, device.sid.to_s))
         end
 
         # All exported D-Bus objects

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -115,11 +115,9 @@ module Agama
         # Each device is represented by an array containing the name of the device and the label to
         # represent that device in the UI when further information is needed.
         #
-        # @return [Array<String, String, Hash>]
+        # @return [Array<::DBus::ObjectPath>]
         def available_devices
-          proposal.available_devices.map do |dev|
-            [dev.name, proposal.device_label(dev), {}]
-          end
+          proposal.available_devices.map { |d| system_devices_tree.path_for(d) }
         end
 
         # Volumes used as template for creating a new proposal
@@ -151,7 +149,7 @@ module Agama
         end
 
         dbus_interface PROPOSAL_CALCULATOR_INTERFACE do
-          dbus_reader :available_devices, "a(ssa{sv})"
+          dbus_reader :available_devices, "ao"
 
           dbus_reader :volume_templates, "aa{sv}"
 

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -112,15 +112,15 @@ describe Agama::DBus::Storage::Manager do
 
       let(:devices) { [device1, device2] }
 
-      let(:device1) { instance_double(Y2Storage::Disk, name: "/dev/vda") }
-      let(:device2) { instance_double(Y2Storage::Disk, name: "/dev/vdb") }
+      let(:device1) { instance_double(Y2Storage::Disk, name: "/dev/vda", sid: 95) }
+      let(:device2) { instance_double(Y2Storage::Disk, name: "/dev/vdb", sid: 96) }
 
-      it "retuns the device name and label for each device" do
+      it "retuns the path of each device" do
         result = subject.available_devices
 
         expect(result).to contain_exactly(
-          ["/dev/vda", "Device 1", {}],
-          ["/dev/vdb", "Device 2", {}]
+          /system\/95/,
+          /system\/96/
         )
       end
     end

--- a/web/cspell.json
+++ b/web/cspell.json
@@ -38,10 +38,12 @@
         "localdomain",
         "luks",
         "mgmt",
+        "multipath",
         "onboot",
         "partitioner",
         "patternfly",
         "rfkill",
+        "sata",
         "screenreader",
         "ssid",
         "ssids",
@@ -54,7 +56,8 @@
         "testfile",
         "testsuite",
         "textinput",
-        "tkip"
+        "tkip",
+        "udev"
       ]
     }
   ],

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -20,6 +20,7 @@
  */
 
 // @ts-check
+// cspell:ignore ptable
 
 import DBusClient from "./dbus";
 import { WithIssues, WithStatus, WithProgress } from "./mixins";
@@ -38,6 +39,7 @@ const PROPOSAL_IFACE = "org.opensuse.Agama.Storage1.Proposal";
 const STORAGE_OBJECT = "/org/opensuse/Agama/Storage1";
 const STORAGE_JOB_IFACE = "org.opensuse.Agama.Storage1.Job";
 const STORAGE_JOBS_NAMESPACE = "/org/opensuse/Agama/Storage1/jobs";
+const STORAGE_SYSTEM_NAMESPACE = "/org/opensuse/Agama/Storage1/system";
 
 /**
  * Removes properties with undefined value
@@ -59,24 +61,139 @@ const removeUndefinedCockpitProperties = (cockpitObject) => {
 };
 
 /**
+ * Class providing an API for managing a devices tree through D-Bus
+ */
+class DevicesManager {
+  /**
+   * @param {DBusClient} client
+   * @param {string} rootPath - Root path of the devices tree
+   */
+  constructor(client, rootPath) {
+    this.client = client;
+    this.rootPath = rootPath;
+  }
+
+  /**
+   * Gets all the exported devices
+   *
+   * @returns {Promise<StorageDevice[]>}
+   *
+   * @typedef {object} StorageDevice
+   * @property {string} sid - Internal id that is used as D-Bus object basename
+   * @property {string} type - Type of device ("disk", "raid", "multipath", "dasd", "md")
+   * @property {string} [vendor]
+   * @property {string} [model]
+   * @property {string[]} [driver]
+   * @property {string} [bus]
+   * @property {string} [transport]
+   * @property {boolean} [sdCard]
+   * @property {boolean} [dellBOOS]
+   * @property {string[]} [devices] - RAID devices (only for "raid" type)
+   * @property {string} [level] - MD RAID level (only for "md" type)
+   * @property {string} [uuid]
+   * @property {string[]} [members] - Member devices for a MD RAID (only for "md" type)
+   * @property {boolean} [active]
+   * @property {string} [name] - Block device name
+   * @property {number} [size]
+   * @property {string[]} [systems] - Name of the installed systems
+   * @property {string[]} [udevIds]
+   * @property {string[]} [udevPaths]
+   * @property {PartitionTableData} [partitionTable]
+   *
+   * @typedef {object} PartitionTableData
+   * @property {string} type
+   */
+  async getDevices() {
+    const buildDevice = (path, dbusDevice) => {
+      const addDriveProperties = (device, dbusProperties) => {
+        device.type = dbusProperties.Type.v;
+        device.vendor = dbusProperties.Vendor.v;
+        device.model = dbusProperties.Model.v;
+        device.driver = dbusProperties.Driver.v;
+        device.bus = dbusProperties.Bus.v;
+        device.transport = dbusProperties.Transport.v;
+        device.sdCard = dbusProperties.Info.v.SDCard.v;
+        device.dellBOSS = dbusProperties.Info.v.DellBOSS.v;
+      };
+
+      const addRAIDProperties = (device, raidProperties) => {
+        device.devices = raidProperties.Devices.v;
+      };
+
+      const addMDProperties = (device, mdProperties) => {
+        device.type = "md";
+        device.level = mdProperties.Level.v;
+        device.uuid = mdProperties.UUID.v;
+        device.members = mdProperties.Members.v;
+      };
+
+      const addBlockProperties = (device, blockProperties) => {
+        device.active = blockProperties.Active.v;
+        device.name = blockProperties.Name.v;
+        device.size = blockProperties.Size.v;
+        device.systems = blockProperties.Systems.v;
+        device.udevIds = blockProperties.UdevIds.v;
+        device.udevPaths = blockProperties.UdevPaths.v;
+      };
+
+      const addPtableProperties = (device, ptableProperties) => {
+        device.partitionTable = { type: ptableProperties.Type.v };
+      };
+
+      const device = {
+        sid: path.split("/").pop(),
+        type: ""
+      };
+
+      const driveProperties = dbusDevice["org.opensuse.Agama.Storage1.Drive"];
+      if (driveProperties !== undefined) addDriveProperties(device, driveProperties);
+
+      const raidProperties = dbusDevice["org.opensuse.Agama.Storage1.RAID"];
+      if (raidProperties !== undefined) addRAIDProperties(device, raidProperties);
+
+      const mdProperties = dbusDevice["org.opensuse.Agama.Storage1.MD"];
+      if (mdProperties !== undefined) addMDProperties(device, mdProperties);
+
+      const blockProperties = dbusDevice["org.opensuse.Agama.Storage1.Block"];
+      if (blockProperties !== undefined) addBlockProperties(device, blockProperties);
+
+      const ptableProperties = dbusDevice["org.opensuse.Agama.Storage1.PartitionTable"];
+      if (ptableProperties !== undefined) addPtableProperties(device, ptableProperties);
+
+      return device;
+    };
+
+    const managedObjects = await this.client.call(
+      STORAGE_OBJECT,
+      "org.freedesktop.DBus.ObjectManager",
+      "GetManagedObjects",
+      null
+    );
+
+    const dbusObjects = managedObjects.shift();
+    const systemPaths = Object.keys(dbusObjects).filter(k => k.startsWith(this.rootPath));
+
+    return systemPaths.map(p => buildDevice(p, dbusObjects[p]));
+  }
+}
+
+/**
  * Class providing an API for managing the storage proposal through D-Bus
  */
 class ProposalManager {
   /**
    * @param {DBusClient} client
+   * @param {DevicesManager} system
    */
-  constructor(client) {
+  constructor(client, system) {
     this.client = client;
+    this.system = system;
     this.proxies = {
       proposalCalculator: this.client.proxy(PROPOSAL_CALCULATOR_IFACE, STORAGE_OBJECT)
     };
   }
 
   /**
-   * @typedef {object} AvailableDevice
-   * @property {string} id - Device kernel name
-   * @property {string} label - Device description
-   *
    * @typedef {object} Volume
    * @property {string|undefined} [mountPoint]
    * @property {string|undefined} [deviceType]
@@ -112,7 +229,7 @@ class ProposalManager {
    * @returns {Promise<ProposalData>}
    *
    * @typedef {object} ProposalData
-   * @property {AvailableDevice[]} availableDevices
+   * @property {StorageDevice[]} availableDevices
    * @property {Volume[]} volumeTemplates
    * @property {Result|undefined} result
    */
@@ -127,18 +244,22 @@ class ProposalManager {
   /**
    * Gets the list of available devices
    *
-   * @returns {Promise<AvailableDevice[]>}
+   * @returns {Promise<StorageDevice[]>}
    */
   async getAvailableDevices() {
-    const buildDevice = dbusDevice => {
-      return {
-        id: dbusDevice[0],
-        label: dbusDevice[1]
-      };
+    const findDevice = (devices, path) => {
+      const sid = path.split("/").pop();
+      const device = devices.find(d => d.sid === sid);
+
+      if (device === undefined) console.log("D-Bus object not found: ", path);
+
+      return device;
     };
 
+    const systemDevices = await this.system.getDevices();
+
     const proxy = await this.proxies.proposalCalculator;
-    return proxy.AvailableDevices.map(buildDevice);
+    return proxy.AvailableDevices.map(path => findDevice(systemDevices, path)).filter(d => d);
   }
 
   /**
@@ -820,7 +941,8 @@ class StorageBaseClient {
    */
   constructor(address = undefined) {
     this.client = new DBusClient(StorageBaseClient.SERVICE, address);
-    this.proposal = new ProposalManager(this.client);
+    this.system = new DevicesManager(this.client, STORAGE_SYSTEM_NAMESPACE);
+    this.proposal = new ProposalManager(this.client, this.system);
     this.iscsi = new ISCSIManager(StorageBaseClient.SERVICE, address);
     this.dasd = new DASDManager(StorageBaseClient.SERVICE, address);
     this.proxies = {

--- a/web/src/components/overview/StorageSection.jsx
+++ b/web/src/components/overview/StorageSection.jsx
@@ -25,6 +25,7 @@ import { Text } from "@patternfly/react-core";
 import { toValidationError, useCancellablePromise } from "~/utils";
 import { useInstallerClient } from "~/context/installer";
 import { BUSY } from "~/client/status";
+import { deviceLabel } from "~/components/storage/utils";
 import { Em, ProgressText, Section } from "~/components/core";
 
 const ProposalSummary = ({ proposal }) => {
@@ -33,13 +34,13 @@ const ProposalSummary = ({ proposal }) => {
   if (result === undefined) return <Text>Device not selected yet</Text>;
 
   const [candidateDevice] = result.candidateDevices;
-  const device = proposal.availableDevices.find(d => d.id === candidateDevice);
+  const device = proposal.availableDevices.find(d => d.name === candidateDevice);
 
-  const deviceLabel = device?.label || candidateDevice;
+  const label = device ? deviceLabel(device) : candidateDevice;
 
   return (
     <Text>
-      Install using device <Em>{deviceLabel}</Em> and deleting all its content
+      Install using device <Em>{label}</Em> and deleting all its content
     </Text>
   );
 };

--- a/web/src/components/overview/StorageSection.test.jsx
+++ b/web/src/components/overview/StorageSection.test.jsx
@@ -33,8 +33,8 @@ jest.mock("~/components/core/SectionSkeleton", () => mockComponent("Loading stor
 let status = IDLE;
 let proposal = {
   availableDevices: [
-    { id: "/dev/sda", label: "/dev/sda, 500 GiB" },
-    { id: "/dev/sdb", label: "/dev/sdb, 650 GiB" }
+    { name: "/dev/sda", size: 536870912000 },
+    { name: "/dev/sdb", size: 697932185600 }
   ],
   result: {
     candidateDevices: ["/dev/sda"],

--- a/web/src/components/storage/ProposalSettingsSection.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.jsx
@@ -29,7 +29,13 @@ import {
 import { If, PasswordAndConfirmationInput, Section, Popup } from "~/components/core";
 import { ProposalVolumes } from "~/components/storage";
 import { Icon } from "~/components/layout";
+import { deviceLabel } from "~/components/storage/utils";
 import { noop } from "~/utils";
+
+/**
+ * @typedef {import ("~/clients/storage").StorageDevice} StorageDevice
+ * @typedef {import ("~/clients/storage").Volume} Volume
+ */
 
 /**
  * Form for selecting the installation device
@@ -38,7 +44,7 @@ import { noop } from "~/utils";
  * @param {object} props
  * @param {string} props.id - Form ID
  * @param {string|undefined} props.current - Device name, if any
- * @param {object[]} props.devices - Available devices for the selection
+ * @param {StorageDevice[]} props.devices - Available devices for the selection
  * @param {onSubmitFn} props.onSubmit - On submit callback
  *
  * @callback onSubmitFn
@@ -49,10 +55,10 @@ const InstallationDeviceForm = ({ id, current, devices, onSubmit }) => {
 
   useEffect(() => {
     const isCurrentValid = () => {
-      return devices.find(d => d.id === current) !== undefined;
+      return devices.find(d => d.name === current) !== undefined;
     };
 
-    if (!isCurrentValid()) setDevice(devices[0]?.id);
+    if (!isCurrentValid()) setDevice(devices[0]?.name);
   }, [current, devices]);
 
   const submitForm = (e) => {
@@ -65,7 +71,7 @@ const InstallationDeviceForm = ({ id, current, devices, onSubmit }) => {
   const DeviceSelector = ({ current, devices, onChange }) => {
     const DeviceOptions = () => {
       const options = devices.map(device => {
-        return <FormSelectOption key={device.id} value={device.id} label={device.label} />;
+        return <FormSelectOption key={device.name} value={device.name} label={deviceLabel(device)} />;
       });
 
       return options;
@@ -103,7 +109,7 @@ const InstallationDeviceForm = ({ id, current, devices, onSubmit }) => {
  *
  * @param {object} props
  * @param {string|undefined} props.current - Device name, if any
- * @param {object[]} props.devices - Available devices for the selection
+ * @param {StorageDevice[]} props.devices - Available devices for the selection
  * @param {boolean} props.isLoading - Whether to show the selector as loading
  * @param {onChangeFn} props.onChange - On change callback
  *
@@ -344,8 +350,8 @@ const EncryptionPasswordField = ({ selected: selectedProp, password: passwordPro
  * @component
  *
  * @param {object} props
- * @param {object[]} [props.availableDevices=[]]
- * @param {object[]} [props.volumeTemplates=[]]
+ * @param {StorageDevice[]} [props.availableDevices=[]]
+ * @param {Volume[]} [props.volumeTemplates=[]]
  * @param {object} [props.settings={}]
  * @param {boolean} [isLoading=false]
  * @param {onChangeFn} [props.onChange=noop]

--- a/web/src/components/storage/ProposalSettingsSection.test.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.test.jsx
@@ -99,7 +99,7 @@ describe("Installation device field", () => {
 
   it("allows selecting a device when clicking on the device name", async () => {
     props = {
-      availableDevices: [{ id: "/dev/vda", label: "/dev/vda" }],
+      availableDevices: [{ name: "/dev/vda" }],
       settings: { candidateDevices: ["/dev/vda"] },
       onChange: jest.fn()
     };
@@ -121,7 +121,7 @@ describe("Installation device field", () => {
 
   it("allows canceling the selection of the device", async () => {
     props = {
-      availableDevices: [{ id: "/dev/vda", label: "/dev/vda" }],
+      availableDevices: [{ name: "/dev/vda" }],
       settings: { candidateDevices: ["/dev/vda"] },
       onChange: jest.fn()
     };

--- a/web/src/components/storage/ProposalVolumes.jsx
+++ b/web/src/components/storage/ProposalVolumes.jsx
@@ -19,8 +19,6 @@
  * find current contact information at www.suse.com.
  */
 
-// cspell:ignore filesize
-
 import React, { useState } from "react";
 import {
   Dropdown, DropdownToggle, DropdownItem,
@@ -31,31 +29,11 @@ import {
   Toolbar, ToolbarContent, ToolbarItem
 } from "@patternfly/react-core";
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
-import { filesize } from "filesize";
 
 import { Em, If, Popup, RowActions, Tip } from '~/components/core';
 import { Icon } from '~/components/layout';
+import { deviceSize } from '~/components/storage/utils';
 import { noop } from "~/utils";
-
-/**
- * Generates a disk size representation
- * @function
- *
- * @example
- * sizeText(1024)
- * // returns "1 kiB"
- *
- * sizeText(-1)
- * // returns "Unlimited"
- *
- * @param {number} size - Number of bytes. The value -1 represents an unlimited size.
- * @returns {string}
- */
-const sizeText = (size) => {
-  if (size === -1) return "Unlimited";
-
-  return filesize(size, { base: 2 });
-};
 
 /**
  * Generates an hint describing which attributes affect the auto-calculated limits.
@@ -147,7 +125,7 @@ const VolumeForm = ({ id, templates, onSubmit }) => {
           id="minSize"
           name="minSize"
           aria-label="Min size"
-          value={sizeText(volume.minSize)}
+          value={deviceSize(volume.minSize)}
           label="Minimum Size"
           isDisabled
         />
@@ -160,7 +138,7 @@ const VolumeForm = ({ id, templates, onSubmit }) => {
           id="maxSize"
           name="maxSize"
           aria-label="Max size"
-          value={sizeText(volume.maxSize)}
+          value={deviceSize(volume.maxSize)}
           label="Maximum Size"
           isDisabled
         />
@@ -264,7 +242,7 @@ const GeneralActions = ({ templates, onAdd, onReset }) => {
  */
 const VolumeRow = ({ columns, volume, isLoading, onDelete }) => {
   const SizeLimits = ({ volume }) => {
-    const limits = `${sizeText(volume.minSize)} - ${sizeText(volume.maxSize)}`;
+    const limits = `${deviceSize(volume.minSize)} - ${deviceSize(volume.maxSize)}`;
     const isAuto = volume.adaptiveSizes && !volume.fixedSizeLimits;
 
     return (

--- a/web/src/components/storage/utils.js
+++ b/web/src/components/storage/utils.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// cspell:ignore filesize
+
+import { filesize } from "filesize";
+
+/**
+ * Generates a disk size representation
+ * @function
+ *
+ * @example
+ * deviceSize(1024)
+ * // returns "1 kiB"
+ *
+ * deviceSize(-1)
+ * // returns "Unlimited"
+ *
+ * @param {number} size - Number of bytes. The value -1 represents an unlimited size.
+ * @returns {string}
+ */
+const deviceSize = (size) => {
+  if (size === -1) return "Unlimited";
+
+  return filesize(size, { base: 2 });
+};
+
+/**
+ * Generates the label for the given device
+ *
+ * @param {import(~/clients/storage).StorageDevice} device
+ * @returns {string}
+ */
+const deviceLabel = (device) => {
+  const name = device.name;
+  const size = device.size;
+
+  return size ? `${name}, ${deviceSize(size)}` : name;
+};
+
+export { deviceSize, deviceLabel };

--- a/web/src/components/storage/utils.test.js
+++ b/web/src/components/storage/utils.test.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { deviceSize, deviceLabel } from "./utils";
+
+describe("deviceSize", () => {
+  it("returns unlimited is size is -1", () => {
+    const result = deviceSize(-1);
+    expect(result).toEqual("Unlimited");
+  });
+
+  it("returns the size with units", () => {
+    const result = deviceSize(1024);
+    expect(result).toEqual("1 KiB");
+  });
+});
+
+describe("deviceLabel", () => {
+  it("returns the device name and size", () => {
+    const result = deviceLabel({ name: "/dev/sda", size: 1024 });
+    expect(result).toEqual("/dev/sda, 1 KiB");
+  });
+
+  it("returns only the device name if the device has no size", () => {
+    const result = deviceLabel({ name: "/dev/sda" });
+    expect(result).toEqual("/dev/sda");
+  });
+});


### PR DESCRIPTION
## Problem

The UI for the device selector should show more information, for example, the systems installed into each device, its model, etc. The information exposed on D-Bus was extended to provide all the required info, see https://github.com/openSUSE/agama/pull/574. But the UI is not adapted yet. 

Part of https://trello.com/c/zpweLQMI/3347-3-agama-selection-of-boot-disk.

## Solution

Adapt the storage client to read the new information from D-Bus. Components are also adapted to work with the new device objects.

## Testing

* Added new tests
* Tested manually
