### PR TITLE
Update ruby-dbus dependency to 0.22.x

### DIFF
--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       fast_gettext (~> 2.2.0)
       nokogiri (~> 1.13.1)
       rexml (~> 3.2.5)
-      ruby-dbus (~> 0.21.0)
+      ruby-dbus (~> 0.22.0)
 
 GEM
   remote: https://rubygems.org/
@@ -49,7 +49,7 @@ GEM
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
     ruby-augeas (0.5.0)
-    ruby-dbus (0.21.0)
+    ruby-dbus (0.22.1)
       rexml
     simplecov (0.21.2)
       docile (~> 1.1)

--- a/service/agama.gemspec
+++ b/service/agama.gemspec
@@ -48,5 +48,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fast_gettext", "~> 2.2.0"
   spec.add_dependency "nokogiri", "~> 1.13.1"
   spec.add_dependency "rexml", "~> 3.2.5"
-  spec.add_dependency "ruby-dbus", "~> 0.21.0"
+  spec.add_dependency "ruby-dbus", "~> 0.22.0"
 end

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu May 18 12:19:49 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Update ruby-dbus dependency to 0.22.x (gh#openSUSE/agama#581)
+
+-------------------------------------------------------------------
 Tue May 16 13:42:18 UTC 2023 - Knut Alejandro Anderssen González <kanderssen@suse.com>
 
 - Added ppc64le repositories for ALP Bedrock and ALP Micro products


### PR DESCRIPTION
## Problem

With a new ruby-dbus in OBS, the old version on which agama depends is gone. Agama containers in OBS no longer build

## Solution

Update the dependency, until the next change.

Next time I will consider making a looser dependency, like ">= 0.23", "< 1.0", which could be less work fixing the breaking changes than bumping the harmless changes more often.

## Testing

OBS will start building, for sure

## Screenshots

no
