### PR TITLE
[web] Fix header and footer block-size

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon May 22 10:42:35 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- UI: Fix header and footer block size (gh#openSUSE/agama#583)
+
+-------------------------------------------------------------------
 Fri May 19 09:29:50 UTC 2023 - David Diaz <dgonzalez@suse.com>
 
 - UI: grayscale and blur not accessible div nodes

--- a/web/src/assets/styles/variables.scss
+++ b/web/src/assets/styles/variables.scss
@@ -62,6 +62,6 @@
 
   --icon-size-m: 32px;
 
-  --header-block-size: 6vh;
-  --footer-block-size: 8vh;
+  --header-block-size: auto;
+  --footer-block-size: auto;
 }


### PR DESCRIPTION
## Problem

The Web UI header and footer were using [viewport relative units](https://www.w3.org/TR/css-values-3/#viewport-relative-lengths) for calculating their block-size (aka height), which make them looks broken and ugly in small screen.

## Solution

Use [`auto`](https://www.w3.org/TR/css-sizing-3/#automatic-size) instead.

## Testing

- Tested manually


## Screenshots

| Before | After |
|-|-|
| ![agama_header_and_footer_before](https://github.com/openSUSE/agama/assets/1691872/9b9df3b8-2b21-4c79-8106-b9ad9f46a889) | ![agama_header_and_footer_after](https://github.com/openSUSE/agama/assets/1691872/cec0d071-b1f0-4f66-99d4-be5c1b4522c7) |

