### PR TITLE
[web] Adjust CSS filters for inert/aria-hidden div nodes

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
+Wed May 24 11:01:24 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- UI: Ensure that blur and grayscale CSS filters are not applied to
+  any nodes other than <body> direct children (gh#openSUSE/agama#588).
+
 -------------------------------------------------------------------
+
 Tue May 23 11:51:26 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - Version 2.1

--- a/web/src/assets/styles/composition.scss
+++ b/web/src/assets/styles/composition.scss
@@ -24,7 +24,7 @@
   flex-direction: row-reverse;
 }
 
-div[inert],
-div[aria-hidden="true"] {
+body > div[inert],
+body > div[aria-hidden="true"] {
   filter: grayscale(1) blur(2px);
 }


### PR DESCRIPTION
## Problem

https://github.com/openSUSE/agama/pull/564 added some CSS filters for grayscale and blurring  `aria-hidden` and `inert` _div_ nodes. The idea was to make visually evident these nodes that should not be interactive when the UI is focusing the user attention in another area. I.e., to strongly focus the user attention in the content of the modal dialogs or the sidebar.

However, we have noticed that there are some `<div>` nodes hidden from the accessibility API that should not be affected by these effects, like the labels of PF4/Progress component, used during the installation progress.

## Solution

Ideally, that should be done only with `inert` nodes, but we are relaying in `aria-hidden` too because of PF4/Modal and the not fully adoption of `inert` yet. In a long term, only `inert` nodes will be affected by these UI effects. Meanwhile, let's do the selector more specific to affect only `<div>`s that are direct children of `<body>`.


## Testing

- *Tested manually*


## Screenshots

| Before | After |
|-|-|
|![Screen Shot 2023-05-24 at 11 32 23](https://github.com/openSUSE/agama/assets/1691872/26e0b533-4072-49f4-98ea-8eb90fcb938d) | ![Screen Shot 2023-05-24 at 11 31 50](https://github.com/openSUSE/agama/assets/1691872/eed61731-8c68-4ab2-b54f-1c9a348865e8) |


