### PR TITLE
Fixes in configuration

### DIFF
--- a/service/etc/agama.yaml
+++ b/service/etc/agama.yaml
@@ -121,12 +121,14 @@ Tumbleweed:
       fs_type: xfs
       min_size: 10 GiB
       max_size: unlimited
+      max_size_lvm: unlimited
       weight: 1
 
       proposed: false
       proposed_configurable: true
       disable_order: 1
       fallback_for_max_size: "/"
+      fallback_for_max_size_lvm: "/"
 
     - mount_point: "swap"
       fs_type: swap

--- a/service/etc/agama.yaml
+++ b/service/etc/agama.yaml
@@ -1,7 +1,7 @@
 products:
   ALP-Bedrock:
-    name: SUSE ALP Bedrock
-    description: 'SUSE ALP Bedrock is a flexible, secure, customizable and
+    name: SUSE ALP Server
+    description: 'SUSE ALP Server is a flexible, secure, customizable and
       modular Server allowing an enterprise to run a variety of services,
       workloads and application in a compartmentalized form. Based on an
       immutable root filesystem, security has been built into it from the ground.'

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 24 15:43:41 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adjust volume definitions for Tumbleweed (related to bsc#1075990)
+- Display "ALP Server" instead of "ALP Bedrock"
+
+-------------------------------------------------------------------
 Tue May 23 11:51:26 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - Version 2.1


### PR DESCRIPTION
## Problem 1

The fallback for max size doesn't seem to be working properly for Tumbleweed when LVM is selected.

There was indeed a historical problem with that, but theoretically it was fixed by https://github.com/yast/yast-storage-ng/pull/1015.

Despite that old fix, I still observe inconsistent behavior between partitions and LVM with the current configuration.

## Solution 1

Add some extra configuration parameters to the volume to ensure a consistent behavior.

## Problem 2

The upcoming ALP Server is still called ALP Bedrock in the repositories, patterns, etc. So we honor that name.

But since we already know that name is gonna change (it even conflicts with a recent Amazon product), it may be confusing if we contribute to spread the discontinued name.

## Solution 2

Change to ALP Server but only in the user visible strings. Not in the internal keys (ie. not even in the CLI).