### PR TITLE
Improve the yupdate scripts

### DIFF
--- a/.yupdate.post
+++ b/.yupdate.post
@@ -10,6 +10,12 @@
 #   next yupdate run
 #
 
+set -e
+
+if [ "$DEBUG" == "1" ]; then
+  set -x
+fi
+
 SERVICE_NAME="agama"
 
 # restart the installer service if needed

--- a/.yupdate.pre
+++ b/.yupdate.pre
@@ -16,6 +16,12 @@
 #   run the yupdate script several times
 #
 
+set -e
+
+if [ "$DEBUG" == "1" ]; then
+  set -x
+fi
+
 if [ "$YUPDATE_SKIP_FRONTEND" == "1" ]; then
   exit 0
 fi
@@ -47,8 +53,13 @@ function add_repos() {
 }
 
 function install_packages() {
+  # stop the service, it might hold the libzypp lock preventing from installing the packages
+  systemctl stop "$SERVICE_NAME"
+
   add_repos
   zypper --non-interactive install --no-recommends "${PACKAGES[@]}"
+
+  systemctl start "$SERVICE_NAME"
 }
 
 # restore the NPM cache if it is present


### PR DESCRIPTION
## Problem

- The `yupdate` script might fail when installing the missing packages because the Agama service can hold the libzypp lock

## Solution

- Stop the Agama service to possibly release the libzypp lock, start it back after installing the packages

## Additional Fixes

- Use `set -e` to fail on error
- Use `set -x` when $DEBUG is set to `1` for debugging

## Testing

- Tested manually
