### PR TITLE
Install cargo as part of setup-service.sh

### DIFF
--- a/setup-service.sh
+++ b/setup-service.sh
@@ -38,7 +38,7 @@ sudosed() {
 test -f /etc/zypp/repos.d/d_l_python.repo || \
   $SUDO zypper --non-interactive \
     addrepo https://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Tumbleweed/ d_l_python
-$SUDO zypper --non-interactive --gpg-auto-import-keys install gcc gcc-c++ make openssl-devel ruby-devel \
+$SUDO zypper --non-interactive --gpg-auto-import-keys install cargo gcc gcc-c++ make openssl-devel ruby-devel \
   python-langtable-data \
   git augeas-devel jemalloc-devel || exit 1
 


### PR DESCRIPTION
* cargo is not availble on fresh [distrobox](https://en.opensuse.org/Distrobox) installation but the setup-service.sh is expecting it to be present