### PR TITLE
Update for ruby-dbus 0.23.0.beta1

### DIFF
--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       fast_gettext (~> 2.2.0)
       nokogiri (~> 1.13.1)
       rexml (~> 3.2.5)
-      ruby-dbus (~> 0.22.0)
+      ruby-dbus (>= 0.23.0.beta1, < 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -49,7 +49,7 @@ GEM
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
     ruby-augeas (0.5.0)
-    ruby-dbus (0.22.1)
+    ruby-dbus (0.23.0.beta1)
       rexml
     simplecov (0.21.2)
       docile (~> 1.1)

--- a/service/agama.gemspec
+++ b/service/agama.gemspec
@@ -48,5 +48,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fast_gettext", "~> 2.2.0"
   spec.add_dependency "nokogiri", "~> 1.13.1"
   spec.add_dependency "rexml", "~> 3.2.5"
-  spec.add_dependency "ruby-dbus", "~> 0.22.0"
+  spec.add_dependency "ruby-dbus", ">= 0.23.0.beta1", "< 1.0"
 end

--- a/service/test/agama/dbus/clients/locale_test.rb
+++ b/service/test/agama/dbus/clients/locale_test.rb
@@ -35,7 +35,7 @@ describe Agama::DBus::Clients::Locale do
   end
 
   let(:bus) { instance_double(Agama::DBus::Bus) }
-  let(:service) { instance_double(::DBus::Service) }
+  let(:service) { instance_double(::DBus::ProxyService) }
   let(:dbus_object) { instance_double(::DBus::ProxyObject) }
   let(:lang_iface) { instance_double(::DBus::ProxyObjectInterface) }
 

--- a/service/test/agama/dbus/clients/manager_test.rb
+++ b/service/test/agama/dbus/clients/manager_test.rb
@@ -41,7 +41,7 @@ describe Agama::DBus::Clients::Manager do
   end
 
   let(:bus) { instance_double(Agama::DBus::Bus) }
-  let(:service) { instance_double(::DBus::Service) }
+  let(:service) { instance_double(::DBus::ProxyService) }
   let(:dbus_object) { instance_double(::DBus::ProxyObject) }
   let(:manager_iface) { instance_double(::DBus::ProxyObjectInterface) }
   let(:properties_iface) { instance_double(::DBus::ProxyObjectInterface, on_signal: nil) }

--- a/service/test/agama/dbus/clients/network_test.rb
+++ b/service/test/agama/dbus/clients/network_test.rb
@@ -34,7 +34,7 @@ describe Agama::DBus::Clients::Network do
   end
 
   let(:bus) { instance_double(DBus::SystemBus) }
-  let(:service) { instance_double(DBus::Service) }
+  let(:service) { instance_double(DBus::ProxyService) }
   let(:dbus_object) { instance_double(DBus::ProxyObject) }
   let(:network_iface) { instance_double(DBus::ProxyObjectInterface) }
 

--- a/service/test/agama/dbus/clients/question_test.rb
+++ b/service/test/agama/dbus/clients/question_test.rb
@@ -37,7 +37,7 @@ describe Agama::DBus::Clients::Question do
   end
 
   let(:bus) { instance_double(Agama::DBus::Bus) }
-  let(:service) { instance_double(::DBus::Service) }
+  let(:service) { instance_double(::DBus::ProxyService) }
   let(:dbus_object) { instance_double(::DBus::ProxyObject) }
   let(:generic_iface) { instance_double(::DBus::ProxyObjectInterface) }
   let(:luks_iface) { instance_double(::DBus::ProxyObjectInterface) }

--- a/service/test/agama/dbus/clients/questions_test.rb
+++ b/service/test/agama/dbus/clients/questions_test.rb
@@ -38,7 +38,7 @@ describe Agama::DBus::Clients::Questions do
   let(:logger) { Logger.new($stdout, level: :warn) }
 
   let(:bus) { instance_double(Agama::DBus::Bus) }
-  let(:service) { instance_double(::DBus::Service) }
+  let(:service) { instance_double(::DBus::ProxyService) }
   let(:dbus_object) { instance_double(::DBus::ProxyObject) }
   let(:properties_iface) { instance_double(::DBus::ProxyObjectInterface) }
 

--- a/service/test/agama/dbus/clients/software_test.rb
+++ b/service/test/agama/dbus/clients/software_test.rb
@@ -43,7 +43,7 @@ describe Agama::DBus::Clients::Software do
   end
 
   let(:bus) { instance_double(Agama::DBus::Bus) }
-  let(:service) { instance_double(::DBus::Service) }
+  let(:service) { instance_double(::DBus::ProxyService) }
   let(:dbus_object) { instance_double(::DBus::ProxyObject) }
   let(:dbus_proposal) { instance_double(::DBus::ProxyObject, introspect: nil) }
   let(:software_iface) { instance_double(::DBus::ProxyObjectInterface) }

--- a/service/test/agama/dbus/clients/storage_test.rb
+++ b/service/test/agama/dbus/clients/storage_test.rb
@@ -47,7 +47,7 @@ describe Agama::DBus::Clients::Storage do
   end
 
   let(:bus) { instance_double(Agama::DBus::Bus) }
-  let(:service) { instance_double(::DBus::Service) }
+  let(:service) { instance_double(::DBus::ProxyService) }
 
   let(:dbus_object) { instance_double(::DBus::ProxyObject) }
   let(:storage_iface) { instance_double(::DBus::ProxyObjectInterface) }

--- a/service/test/agama/dbus/clients/users_test.rb
+++ b/service/test/agama/dbus/clients/users_test.rb
@@ -40,7 +40,7 @@ describe Agama::DBus::Clients::Users do
   end
 
   let(:bus) { instance_double(Agama::DBus::Bus) }
-  let(:service) { instance_double(::DBus::Service) }
+  let(:service) { instance_double(::DBus::ProxyService) }
   let(:dbus_object) { instance_double(::DBus::ProxyObject) }
   let(:users_iface) { instance_double(::DBus::ProxyObjectInterface) }
   let(:service_status_iface) { instance_double(::DBus::ProxyObjectInterface) }

--- a/service/test/agama/dbus/manager_service_test.rb
+++ b/service/test/agama/dbus/manager_service_test.rb
@@ -31,7 +31,7 @@ describe Agama::DBus::ManagerService do
   let(:manager) { Agama::Manager.new(config, logger) }
   let(:bus) { instance_double(Agama::DBus::Bus) }
   let(:bus_service) do
-    instance_double(::DBus::Service, export: nil)
+    instance_double(::DBus::ObjectServer, export: nil)
   end
   let(:cockpit) { instance_double(Agama::CockpitManager, setup: nil) }
   let(:software_client) do

--- a/service/test/agama/dbus/question_test.rb
+++ b/service/test/agama/dbus/question_test.rb
@@ -29,16 +29,19 @@ describe Agama::DBus::Question do
   subject { described_class.new(path, backend, logger) }
 
   before do
-    subject.instance_variable_set(:@service, service)
+    # ruby-dbus.0.23.0.beta2 but avoid the writer to work with beta1
+    subject.instance_variable_set(:@object_server, service)
+    # ruby-dbus.0.23.0.beta1
+    subject.instance_variable_set(:@connection, connection)
   end
 
   let(:path) { "/org/test" }
 
   let(:logger) { Logger.new($stdout, level: :warn) }
 
-  let(:service) { instance_double(DBus::Service, bus: system_bus) }
+  let(:service) { instance_double(DBus::ObjectServer, connection: connection) }
 
-  let(:system_bus) { instance_double(DBus::SystemBus, emit: nil) }
+  let(:connection) { instance_double(DBus::Connection, emit: nil) }
 
   describe ".new" do
     shared_examples "Generic interface" do

--- a/service/test/agama/dbus/questions_test.rb
+++ b/service/test/agama/dbus/questions_test.rb
@@ -34,9 +34,9 @@ describe Agama::DBus::Questions do
 
   let(:logger) { Logger.new($stdout, level: :warn) }
 
-  let(:service) { instance_double(DBus::Service, export: nil, unexport: nil, bus: system_bus) }
+  let(:service) { instance_double(DBus::ObjectServer, export: nil, unexport: nil, connection: connection) }
 
-  let(:system_bus) { instance_double(DBus::SystemBus) }
+  let(:connection) { instance_double(DBus::Connection, emit: nil) }
 
   describe "Questions interface" do
     let(:interface) { "org.opensuse.Agama.Questions1" }

--- a/service/test/agama/dbus/storage/dasds_tree_test.rb
+++ b/service/test/agama/dbus/storage/dasds_tree_test.rb
@@ -27,7 +27,7 @@ require "dbus"
 describe Agama::DBus::Storage::DasdsTree do
   subject { described_class.new(service, logger: logger) }
 
-  let(:service) { instance_double(::DBus::Service) }
+  let(:service) { instance_double(::DBus::ObjectServer) }
   let(:root_node) { instance_double(::DBus::Node) }
   let(:logger) { Logger.new($stdout, level: :warn) }
 

--- a/service/test/agama/dbus/storage/devices_tree_test.rb
+++ b/service/test/agama/dbus/storage/devices_tree_test.rb
@@ -54,7 +54,7 @@ describe Agama::DBus::Storage::DevicesTree do
 
   subject { described_class.new(service, root_path, logger: logger) }
 
-  let(:service) { instance_double(::DBus::Service) }
+  let(:service) { instance_double(::DBus::ObjectServer) }
 
   let(:root_path) { "/test/system" }
 

--- a/service/test/agama/dbus/storage/iscsi_nodes_tree_test.rb
+++ b/service/test/agama/dbus/storage/iscsi_nodes_tree_test.rb
@@ -29,7 +29,7 @@ require "dbus"
 describe Agama::DBus::Storage::ISCSINodesTree do
   subject { described_class.new(service, iscsi_manager, logger: logger) }
 
-  let(:service) { instance_double(::DBus::Service) }
+  let(:service) { instance_double(::DBus::ObjectServer) }
 
   let(:iscsi_manager) { Agama::Storage::ISCSI::Manager.new }
 

--- a/service/test/agama/dbus/storage/jobs_tree_test.rb
+++ b/service/test/agama/dbus/storage/jobs_tree_test.rb
@@ -27,7 +27,7 @@ require "dbus"
 describe Agama::DBus::Storage::JobsTree do
   subject { described_class.new(service, logger: logger) }
 
-  let(:service) { instance_double(::DBus::Service) }
+  let(:service) { instance_double(::DBus::ObjectServer) }
   let(:dasds_root_node) { instance_double(::DBus::Node) }
   let(:logger) { Logger.new($stdout, level: :warn) }
 


### PR DESCRIPTION
## Problem

With a new ruby-dbus in OBS, it turns out I only ran manual Agama tests, not the RSpec tests, which relied on ruby-dbus internals, so more fixes are needed

(Where exactly is is failing?)

## Solution

In tests, replace `DBus::Service` by one of its successors, `ProxyService` or `ObjectServer`

For Questions which have a more complex test, fix more.

## Testing

`cd service; bundle exec rspec`
