### PR TITLE
Install cargo only when it is missing

### DIFF
--- a/setup-service.sh
+++ b/setup-service.sh
@@ -38,9 +38,12 @@ sudosed() {
 test -f /etc/zypp/repos.d/d_l_python.repo || \
   $SUDO zypper --non-interactive \
     addrepo https://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Tumbleweed/ d_l_python
-$SUDO zypper --non-interactive --gpg-auto-import-keys install cargo gcc gcc-c++ make openssl-devel ruby-devel \
+$SUDO zypper --non-interactive --gpg-auto-import-keys install gcc gcc-c++ make openssl-devel ruby-devel \
   python-langtable-data \
   git augeas-devel jemalloc-devel || exit 1
+
+# only install cargo if it is not available (avoid conflicts with rustup)
+test -f /usr/bin/cargo || $SUDO zypper --non-interactive install cargo
 
 # - Install service rubygem dependencies
 (

--- a/setup-service.sh
+++ b/setup-service.sh
@@ -43,7 +43,7 @@ $SUDO zypper --non-interactive --gpg-auto-import-keys install gcc gcc-c++ make o
   git augeas-devel jemalloc-devel || exit 1
 
 # only install cargo if it is not available (avoid conflicts with rustup)
-test -f /usr/bin/cargo || $SUDO zypper --non-interactive install cargo
+which cargo || $SUDO zypper --non-interactive install cargo
 
 # - Install service rubygem dependencies
 (


### PR DESCRIPTION
## Problem

If you install your Rust toolchain using `rustup`, running the `setup-service.sh` will fail with the following error:

```
Problem: the installed rustup-1.25.2~0-4.1.x86_64 conflicts with 'rust+cargo' provided by the to be installed cargo-1.69.0-1.1.x86_64
 Solution 1: deinstallation of rustup-1.25.2~0-4.1.x86_64
 Solution 2: do not install cargo-1.69.0-1.1.x86_64
```

## Solution

Do not install `cargo` unless it is missing.
