### PR TITLE
Fix Locale1 D-Bus docs

### DIFF
--- a/doc/dbus/org.opensuse.Agama.Locale1.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Locale1.doc.xml
@@ -1,7 +1,7 @@
 
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/org/opensuse/Agama/Locale1">
+<node>
   <!--
       org.opensuse.Agama.Locale1:
 


### PR DESCRIPTION
Remove a hand-made change that caused the documentation generation to fail. Manually tested with `make -C doc check`.