### PR TITLE
Fix the initialization of the Locale1 service

### DIFF
--- a/rust/agama-dbus-server/src/locale.rs
+++ b/rust/agama-dbus-server/src/locale.rs
@@ -2,7 +2,7 @@ use crate::error::Error;
 use agama_lib::connection_to;
 use anyhow::Context;
 use std::process::Command;
-use zbus::dbus_interface;
+use zbus::{dbus_interface, Connection};
 
 pub struct Locale {
     locales: Vec<String>,
@@ -187,7 +187,7 @@ impl Locale {
     }
 }
 
-pub async fn start_service(address: &str) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn start_service(address: &str) -> Result<Connection, Box<dyn std::error::Error>> {
     const SERVICE_NAME: &str = "org.opensuse.Agama.Locale1";
     const SERVICE_PATH: &str = "/org/opensuse/Agama/Locale1";
 
@@ -203,5 +203,5 @@ pub async fn start_service(address: &str) -> Result<(), Box<dyn std::error::Erro
         .await
         .context(format!("Requesting name {SERVICE_NAME}"))?;
 
-    Ok(())
+    Ok(connection)
 }

--- a/rust/agama-dbus-server/src/main.rs
+++ b/rust/agama-dbus-server/src/main.rs
@@ -11,7 +11,7 @@ const ADDRESS: &str = "unix:path=/run/agama/bus";
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // When adding more services here, the order might be important.
     crate::questions::start_service(ADDRESS).await?;
-    crate::locale::start_service(ADDRESS).await?;
+    let _conn = crate::locale::start_service(ADDRESS).await?;
     NetworkService::start(ADDRESS).await?;
 
     // Do other things or go to wait forever


### PR DESCRIPTION
Until we find a better way, we need to keep the connection around. Otherwise, it will get dropped.

A better solution might be to pass a copy of the connection instead of the address to each service. But, today, let's keep the API as it is.