### PR TITLE
[web] Users: improve the root auth section

### DIFF
--- a/web/src/components/users/RootAuthMethods.jsx
+++ b/web/src/components/users/RootAuthMethods.jsx
@@ -20,7 +20,7 @@
  */
 
 import React, { useState, useEffect } from "react";
-import { Skeleton, Truncate } from "@patternfly/react-core";
+import { Button, Skeleton, Truncate } from "@patternfly/react-core";
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { Em, RowActions } from '~/components/core';
 import { RootPasswordPopup, RootSSHKeyPopup } from '~/components/users';
@@ -28,6 +28,18 @@ import { RootPasswordPopup, RootSSHKeyPopup } from '~/components/users';
 import { useCancellablePromise } from "~/utils";
 import { useInstallerClient } from "~/context/installer";
 
+const MethodsNotDefined = ({ setPassword, setSSHKey }) => {
+  return (
+    <div className="stack">
+      <div className="bold">No root auth method defined yet</div>
+      <div>Please, define at least one root authentication method for being able to log into the system as administrative user.</div>
+      <div className="split">
+        <Button variant="primary" onClick={setPassword}>Set a password</Button>
+        <Button variant="secondary" onClick={setSSHKey}>Upload a SSH Public Key</Button>
+      </div>
+    </div>
+  );
+};
 export default function RootAuthMethods() {
   const { users: client } = useInstallerClient();
   const { cancellablePromise } = useCancellablePromise();
@@ -65,10 +77,15 @@ export default function RootAuthMethods() {
 
   const isSSHKeyDefined = sshKey !== "";
 
+  const openPasswordForm = () => setIsPasswordFormOpen(true);
+  const openSSHKeyForm = () => setIsSSHKeyFormOpen(true);
+  const closePasswordForm = () => setIsPasswordFormOpen(false);
+  const closeSSHKeyForm = () => setIsSSHKeyFormOpen(false);
+
   const passwordActions = [
     {
       title: isPasswordDefined ? "Change" : "Set",
-      onClick: () => setIsPasswordFormOpen(true),
+      onClick: openPasswordForm
 
     },
     isPasswordDefined && {
@@ -81,7 +98,7 @@ export default function RootAuthMethods() {
   const sshKeyActions = [
     {
       title: isSSHKeyDefined ? "Change" : "Set",
-      onClick: () => setIsSSHKeyFormOpen(true),
+      onClick: openSSHKeyForm
     },
     sshKey && {
       title: "Discard",
@@ -99,9 +116,6 @@ export default function RootAuthMethods() {
       </>
     );
   }
-
-  const closePasswordForm = () => setIsPasswordFormOpen(false);
-  const closeSSHKeyForm = () => setIsSSHKeyFormOpen(false);
 
   const PasswordLabel = () => {
     return isPasswordDefined
@@ -121,8 +135,12 @@ export default function RootAuthMethods() {
     );
   };
 
-  return (
-    <>
+  const Content = () => {
+    if (!isPasswordDefined && !isSSHKeyDefined) {
+      return <MethodsNotDefined setPassword={openPasswordForm} setSSHKey={openSSHKeyForm} />;
+    }
+
+    return (
       <TableComposable variant="compact" gridBreakPoint="grid-md">
         <Thead>
           <Tr>
@@ -148,7 +166,12 @@ export default function RootAuthMethods() {
           </Tr>
         </Tbody>
       </TableComposable>
+    );
+  };
 
+  return (
+    <>
+      <Content />
       { isPasswordFormOpen &&
         <RootPasswordPopup
           isOpen

--- a/web/src/components/users/RootAuthMethods.test.jsx
+++ b/web/src/components/users/RootAuthMethods.test.jsx
@@ -70,12 +70,50 @@ describe("when loading initial data", () => {
 });
 
 describe("when ready", () => {
-  it("renders a table holding available methods", async () => {
-    installerRender(<RootAuthMethods />);
+  describe("and none method is defined", () => {
+    it("renders a text inviting the user to define at least one", async () => {
+      installerRender(<RootAuthMethods />);
 
-    const table = await screen.findByRole("grid");
-    within(table).getByText("Password");
-    within(table).getByText("SSH Key");
+      await screen.findByText("No root auth method defined yet");
+      screen.getByText(/at least one/);
+    });
+
+    it("renders buttons for setting either, a password or a SSH Public Key", async () => {
+      installerRender(<RootAuthMethods />);
+
+      await screen.findByRole("button", { name: "Set a password" });
+      screen.getByRole("button", { name: "Upload a SSH Public Key" });
+    });
+
+    it("allows setting the password", async () => {
+      const { user } = installerRender(<RootAuthMethods />);
+
+      const button = await screen.findByRole("button", { name: "Set a password" });
+      await user.click(button);
+
+      screen.getByRole("dialog", { name: "Set a root password" });
+    });
+
+    it("allows setting the SSH Public Key", async () => {
+      const { user } = installerRender(<RootAuthMethods />);
+
+      const button = await screen.findByRole("button", { name: "Upload a SSH Public Key" });
+      await user.click(button);
+
+      screen.getByRole("dialog", { name: "Add a SSH Public Key for root" });
+    });
+  });
+
+  describe("and at least one method is already defined", () => {
+    beforeEach(() => isRootPasswordSetFn.mockResolvedValue(true));
+
+    it("renders a table with available methods", async () => {
+      installerRender(<RootAuthMethods />);
+
+      const table = await screen.findByRole("grid");
+      within(table).getByText("Password");
+      within(table).getByText("SSH Key");
+    });
   });
 
   describe("and the password has been set", () => {
@@ -132,6 +170,9 @@ describe("when ready", () => {
   });
 
   describe("but the password is not set yet", () => {
+    // Mock another auth method for reaching the table
+    beforeEach(() => getRootSSHKeyFn.mockResolvedValue("Fake"));
+
     it("renders the 'Not set' status", async () => {
       installerRender(<RootAuthMethods />);
 
@@ -226,6 +267,9 @@ describe("when ready", () => {
   });
 
   describe("but the SSH Key is not set yet", () => {
+    // Mock another auth method for reaching the table
+    beforeEach(() => isRootPasswordSetFn.mockResolvedValue(true));
+
     it("renders the 'Not set' status", async () => {
       installerRender(<RootAuthMethods />);
 
@@ -266,6 +310,9 @@ describe("when ready", () => {
   });
 
   describe("and user settings changes", () => {
+    // Mock an auth method for reaching the table
+    beforeEach(() => isRootPasswordSetFn.mockResolvedValue(true));
+
     it("updates the UI accordingly", async () => {
       const [mockFunction, callbacks] = createCallbackMock();
       onUsersChangeFn = mockFunction;


### PR DESCRIPTION
## Problem

The current way Agama is rendering the _Root Authentication_ section in the _Users_ page do not make evident that there is none auth method defined, and it's easy to overlook the button for displaying the actions available for each method.

## Solution

Provide the user more comprehensive information if there is no authentication method for the root user, which may result in a system without administrative access.

For that, the _empty state_ pattern we already have in the user section is used when there is none auth method defined. Once the user define one, the table listing the auth methods, their state and the actions is show _again_. The idea is to improve this too, but in a subsequent PR once we have more clear how to really improve it.

## Testing

- Added a new unit test
- Tested manually

## Screenshots

_Note: screenshots below might have change because minor changes asked during the review, specially in regard to the wording_

### Before

| No auth method defined | At least one auth method defined |
|-|-|
|![Screen Shot 2023-06-12 at 12 04 57](https://github.com/openSUSE/agama/assets/1691872/2bce1527-8363-4918-866d-54fb31432667) |![Screen Shot 2023-06-12 at 12 04 31](https://github.com/openSUSE/agama/assets/1691872/b79a13ea-afaf-4f4b-9846-5279e408edb6) |

### After

| No auth method defined | At least one auth method defined |
|-|-|
|![Screen Shot 2023-06-12 at 12 04 19](https://github.com/openSUSE/agama/assets/1691872/fe8ea6c2-678e-419d-bd2b-cb2f12846473) |![Screen Shot 2023-06-12 at 12 04 31](https://github.com/openSUSE/agama/assets/1691872/fd4d47fa-dc80-4875-9d6a-b4db86560000) |