### PR TITLE
workaround not complete objects exposed on dbus

### DIFF
--- a/rust/agama-dbus-server/src/questions.rs
+++ b/rust/agama-dbus-server/src/questions.rs
@@ -200,14 +200,16 @@ impl Questions {
         );
         let object_path = ObjectPath::try_from(question.base().object_path()).unwrap();
 
-        let base = question.base();
+        let base = question.base().clone();
+        self.connection
+        .object_server()
+        .at(base.object_path(), question)
+        .await?;
+        // NOTE: order here is important as each interface cause signal, so frontend should wait only for GenericQuestions
+        // which should be the last interface added
         self.connection
             .object_server()
-            .at(base.object_path(), base.clone())
-            .await?;
-        self.connection
-            .object_server()
-            .at(base.object_path(), question)
+            .at(base.object_path(), base)
             .await?;
 
         self.questions.insert(id, QuestionType::Luks);

--- a/rust/agama-dbus-server/src/questions.rs
+++ b/rust/agama-dbus-server/src/questions.rs
@@ -202,9 +202,9 @@ impl Questions {
 
         let base = question.base().clone();
         self.connection
-        .object_server()
-        .at(base.object_path(), question)
-        .await?;
+            .object_server()
+            .at(base.object_path(), question)
+            .await?;
         // NOTE: order here is important as each interface cause signal, so frontend should wait only for GenericQuestions
         // which should be the last interface added
         self.connection

--- a/web/src/client/questions.js
+++ b/web/src/client/questions.js
@@ -133,7 +133,8 @@ class QuestionsClient {
 
     // Note: dbusQuestions contains an empty object when there are no questions.
     // Note: questions without id is not yet fully created with all interfaces.
-    return dbusQuestions.filter(q => Object.keys(q).length !== 0 && 'id' in q).map(buildQuestion);
+    return dbusQuestions.filter(q => Object.keys(q).length !== 0).map(buildQuestion)
+      .filter(q => "id" in q);
   }
 
   /**
@@ -185,7 +186,12 @@ class QuestionsClient {
       const question = buildQuestion({ [path]: ifacesAndProperties });
       // questions without id is not fully created questions
       if ('id' in question) {
-        handler(question);
+        // and here is second tricky part. As we get new interface, but not all interfaces, we do another
+        // dbus call to get all interfaces of question
+        this.getQuestions().then(questions => {
+          const changed_question = questions.find(q => q.id === question.id);
+          handler(changed_question);
+        });
       }
     });
   }

--- a/web/src/client/questions.js
+++ b/web/src/client/questions.js
@@ -132,7 +132,8 @@ class QuestionsClient {
     );
 
     // Note: dbusQuestions contains an empty object when there are no questions.
-    return dbusQuestions.filter(q => Object.keys(q).length !== 0).map(buildQuestion);
+    // Note: questions without id is not yet fully created with all interfaces.
+    return dbusQuestions.filter(q => Object.keys(q).length !== 0 && 'id' in q).map(buildQuestion);
   }
 
   /**
@@ -182,7 +183,10 @@ class QuestionsClient {
   onQuestionAdded(handler) {
     return this.onObjectsChanged("InterfacesAdded", (path, ifacesAndProperties) => {
       const question = buildQuestion({ [path]: ifacesAndProperties });
-      handler(question);
+      // questions without id is not fully created questions
+      if ('id' in question) {
+        handler(question);
+      }
     });
   }
 


### PR DESCRIPTION
## Problem

Zbus implementation signal any new interface appearing and we failed to find way how to attach more interfaces together. This cause strange behavior on UI side when signal arrived. Refresh fixed it.


## Solution

Lets use a workaround that basically attach generic interface as the last one and on UI side object is considered complete only when generic interface appears.

## Testing

- *Tested manually*

