### PR TITLE
[web] Adjust volume size options wording and order

### DIFF
--- a/web/src/components/storage/VolumeForm.jsx
+++ b/web/src/components/storage/VolumeForm.jsx
@@ -130,7 +130,7 @@ const SizeManual = ({ errors, formData, onChange }) => {
           <NumericTextInput
             id="size"
             name="size"
-            aria-label="Desired size"
+            aria-label="Exact size"
             value={formData.size}
             onChange={(size) => onChange({ size })}
             validated={errors.size && 'error'}

--- a/web/src/components/storage/VolumeForm.jsx
+++ b/web/src/components/storage/VolumeForm.jsx
@@ -240,7 +240,7 @@ const SizeOptions = ({ errors, formData, volume, onChange }) => {
   const { sizeMethod } = formData;
   const sizeWidgetProps = { errors, formData, volume, onChange };
 
-  const sizeOptions = [SIZE_METHODS.MANUAL, SIZE_METHODS.RANGE];
+  const sizeOptions = [SIZE_METHODS.RANGE, SIZE_METHODS.MANUAL];
 
   if (volume.adaptiveSizes) sizeOptions.unshift(SIZE_METHODS.AUTO);
 
@@ -267,8 +267,8 @@ const SizeOptions = ({ errors, formData, volume, onChange }) => {
 
       <div aria-live="polite" className="highlighted-live-region">
         <If condition={sizeMethod === SIZE_METHODS.AUTO} then={<SizeAuto { ...sizeWidgetProps } />} />
-        <If condition={sizeMethod === SIZE_METHODS.MANUAL} then={<SizeManual { ...sizeWidgetProps } />} />
         <If condition={sizeMethod === SIZE_METHODS.RANGE} then={<SizeRange {...sizeWidgetProps } />} />
+        <If condition={sizeMethod === SIZE_METHODS.MANUAL} then={<SizeManual { ...sizeWidgetProps } />} />
       </div>
     </div>
   );

--- a/web/src/components/storage/VolumeForm.test.jsx
+++ b/web/src/components/storage/VolumeForm.test.jsx
@@ -100,7 +100,7 @@ it("renders controls for setting the desired size", () => {
   plainRender(<VolumeForm {...props} />);
 
   screen.getByRole("radio", { name: "Auto" });
-  screen.getByRole("radio", { name: "Manual" });
+  screen.getByRole("radio", { name: "Fixed" });
   screen.getByRole("radio", { name: "Range" });
 });
 
@@ -164,14 +164,14 @@ it("calls the onSubmit callback with resulting volume when the form is submitted
 });
 
 describe("size validations", () => {
-  describe("when 'Manual' size is selected", () => {
+  describe("when 'Fixed' size is selected", () => {
     beforeEach(() => { props.volume = volumes.home });
 
     it("renders an error when size is not given", async () => {
       const { user } = plainRender(<VolumeFormWrapper volume={volumes.home} onSubmit={onSubmitFn} />);
 
       const submitForm = screen.getByRole("button", { name: "Submit VolumeForm" });
-      const manualSize = screen.getByRole("radio", { name: "Manual" });
+      const manualSize = screen.getByRole("radio", { name: "Fixed" });
       await user.click(manualSize);
 
       const sizeInput = screen.getByRole("textbox", { name: "Desired size" });

--- a/web/src/components/storage/VolumeForm.test.jsx
+++ b/web/src/components/storage/VolumeForm.test.jsx
@@ -174,7 +174,7 @@ describe("size validations", () => {
       const manualSize = screen.getByRole("radio", { name: "Fixed" });
       await user.click(manualSize);
 
-      const sizeInput = screen.getByRole("textbox", { name: "Desired size" });
+      const sizeInput = screen.getByRole("textbox", { name: "Exact size" });
       await user.clear(sizeInput);
       await user.click(submitForm);
       screen.getByText("A size value is required");

--- a/web/src/components/storage/utils.js
+++ b/web/src/components/storage/utils.js
@@ -34,7 +34,7 @@ import xbytes from "xbytes";
 
 const SIZE_METHODS = Object.freeze({
   AUTO: "auto",
-  MANUAL: "manual",
+  MANUAL: "fixed",
   RANGE: "range"
 });
 


### PR DESCRIPTION
## Problem

During the review meeting we had yesterday morning, we got feedback about the recently added options for adjusting a volume size

* To use "Fixed" instead of "Manual" for the option to tell the installer the exact desired size.
* To rearrange the options for ordering them from fully-automatic to fixed, keeping the semi-auto option (aka "Range") in the middle.

## Solution

To apply these suggestions.


## Testing

- Unit tests adapted
- Tested manually

## Screenshots

| Before | After |
|-|-|
|![Screen Shot 2023-06-13 at 07 48 00](https://github.com/openSUSE/agama/assets/1691872/face89cb-c0f0-4927-96f8-b40eb52864c3) | ![Screen Shot 2023-06-13 at 07 47 30](https://github.com/openSUSE/agama/assets/1691872/6405a1ff-35b2-485e-8443-2f9e79648757) |


