### PR TITLE
OBS Integration Update

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,47 +1,78 @@
 # Packaging
 
-Agama packages are available in the [YaST:Head:Agama project in
-OBS](https://build.opensuse.org/project/show/YaST:Head:Agama). This document summarizes the
-process we follow to build those packages.
+This document summarizes the process we follow to build the Agama packages.
+
+The Agama packages are available in two OBS projects:
+
+- [systemsmanagement:Agama:Staging](
+  https://build.opensuse.org/project/show/systemsmanagement:Agama:Staging) -
+  contains the latest packages built from the `master` branch in Git. This
+  project contains unstable development version of Agama. It is intended for
+  development or testing new unfinished features.
+
+  These packages are automatically updated whenever the master branch is changed.
+
+- [systemsmanagement:Agama:Devel](
+  https://build.opensuse.org/project/show/systemsmanagement:Agama:Devel) -
+  contains the latest released version of the Agama project. These packages
+  should be more stable than in the Staging project. It is intended for testing.
+
+  These packages are updated automatically when a new version is released. See
+  more detail in the [bumping the version](#bumping-the-version) section below.
+
+You can find more details the automatic OBS synchronization in the
+[obs_integration.md](doc/obs_integration.md) file.
 
 The process to build each package is slightly different depending on the technology we are using.
 While the Ruby-based one (`rubygem-agama`) is built as any other YaST package, the web UI
 (`cockpit-agama`) and the CLI (`agama-cli`) rely on [OBS source
 services](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.source_service.html).
 
-## Versioning policy
+## Versioning Policy
 
 We have decided to follow a single number schema: 1, 2, 3, etc. However, if we need to release a
 hot-fix, we might use a dotted version (e.g., 2.1). Moreover, all the components share the same
 version number. Releasing a new version implies that all of them get the new number, no matter if
 they contain changes or not.
 
-## Bumping the version
+## Bumping the Version
 
 In order to release a new version, we need to:
 
-1. Update the version number in the `service/VERSION` file with the new number. These file is read
-  when building the `rubygem-agama` package.
-2. `(cd service; bundle install)` # Updates Gemfile.lock which is part of the repository
-3. Add entries in the changes files.
+1. `(cd service; bundle install)` # Updates Gemfile.lock which is part of the repository
+2. Add entries in the changes files.
     `osc vc service/package`
     `osc vc rust/package`
     `osc vc web/package`
-4. Open a pull request to get these changes into the repository.
-5. Once the pull request is merged, tag the repository with the proper version number. The processes
-   to build `cockpit-agama` and `agama-cli` use this information to infer the version. You can set
-   the tag with something like:
+3. Open a pull request to get these changes into the repository.
+4. Once the pull request is merged, tag the repository with the proper version number. The processes
+   to build the packages use this information to infer the version. You can set
+   the tag with the `rake tag` command.
 
-      git tag --sign v$(cat service/VERSION) --message "Version $(cat service/VERSION)"
-      git push --tags
+   ```shell
+   # automatic version, use the current <major version> + 1
+   rake tag
+   # manual version, useful for releasing a hot fix with a minor version
+   rake tag[42.1]
+   ```
 
+   You need to push the tag to the server manually, see the `rake tag` output.
 
-## Building the packages
+After creating the tag on the server the GitHub Actions will publish the
+packages in the [systemsmanagement:Agama:Devel](
+https://build.opensuse.org/project/show/systemsmanagement:Agama:Devel)
+project and create submit requests to openSUSE Factory.
+
+## Building the Packages
+
+The packages are updated automatically using the GitHub actions. Here are details
+for manual update.
 
 ### Service
 
 You can check the current package in
-[YaST:Head:Agama/rubygem-agama](https://build.opensuse.org/package/show/YaST:Head:Agama/rubygem-agama).
+[systemsmanagement:Agama:Staging/rubygem-agama](
+https://build.opensuse.org/package/show/systemsmanagement:Agama:Staging/rubygem-agama).
 
 Use `rake` to update the package in OBS as you would do with any other YaST package:
 
@@ -52,16 +83,17 @@ If you just want to build the package locally, run:
 
       rake osc:build
 
-### The Cockpit module
+### The Cockpit Module
 
-The current package is
-[YaST:Head:Agama/cockpit-agama](https://build.opensuse.org/package/show/YaST:Head:Agama/cockpit-agama).
+The current package is [systemsmanagement:Agama:Staging/cockpit-agama](
+https://build.opensuse.org/package/show/systemsmanagement:Agama:Staging/cockpit-agama).
+
 It relies on [OBS Source
 Services](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.source_service.html) to
 fetch the sources (including the dependencies), set the version and build the package. You can
 figure out most details by checking the [_service](web/package/_service) file.
 
-To update the package in the build service, you just need to type:
+To manually update the package in the build service, you just need to type:
 
       sudo zypper install obs-service-node_modules
       osc service manualrun
@@ -71,16 +103,17 @@ If you want to build the package locally, just checkout (or branch) the package 
 
 The version number is inferred from the repository tags (see [Releasing a new
 version](#releasing-a-new-version)): it uses the latest tag and the offset of the latest commit
-respect such a tag. (e.g., `0.1~2`).
+respect such a tag. (e.g. `2.1+42`).
 
 You can read more about the overall approach of this package in the following article: [Git work
 flows in the upcoming 2.7 release](https://openbuildservice.org/2016/04/08/new_git_in_27/).
 
-### Command-line interface
+### Command-line Interface
 
-The current package is
-[YaST:Head:Agama](https://build.opensuse.org/package/show/YaST:Head:Agama/agama-cli). To update the
-package in the build service, run the following commands:
+The current package is [systemsmanagement:Agama:Staging/agama-cli](
+https://build.opensuse.org/package/show/systemsmanagement:Agama:Staging/agama-cli).
+
+To manually update the package in the build service, run the following commands:
 
       sudo zypper install obs-service-cargo_vendor obs-service-cargo_audit   # from Factory or devel:languages:rust
       osc service manualrun
@@ -91,10 +124,10 @@ If you want to build the package locally, just checkout (or branch) the package 
 
 The version number is inferred from the repository tags (see [Releasing a new
 version](#releasing-a-new-version)): it uses the latest tag and the offset of the latest commit
-respect such a tag. (e.g., `0.1~2`).
+respect such a tag. (e.g. `2.1+42`).
 
 ### The Live ISO
 
-The ISO is built and developed in
-[YaST:Head:Agama/agama-live](https://build.opensuse.org/package/show/YaST:Head:Agama/agama-live).
+The ISO is built and developed in [systemsmanagement:Agama:Staging/agama-live](
+https://build.opensuse.org/package/show/systemsmanagement:Agama:Staging/agama-live).
 See [IMAGE.md](./IMAGE.md) for more details.

--- a/Rakefile
+++ b/Rakefile
@@ -72,6 +72,22 @@ Yast::Tasks.configuration do |conf|
   conf.package_name = package_name if package_name
 end
 
+desc "Create a new version tag, the new version is <current major> + 1 or pass the version as a parameter"
+task :tag, [:version] do |t, args|
+  args.with_defaults = { :version => nil }
+
+  if args[:version]
+    new_version = args[:version]
+  else
+    new_version = `git describe --tags --match "v[0-9]*"`.match(/^v(\d+)/)[1].to_i + 1
+  end
+
+  system("git tag -s -m 'Version #{new_version}' v#{new_version}") || exit(1)
+
+  puts "Created version tag: v#{new_version}"
+  puts "To push the tag to the server run: git push origin v#{new_version}"
+end
+
 # Removes the "package" task to redefine it later.
 Rake::Task["package"].clear
 

--- a/doc/obs_integration.md
+++ b/doc/obs_integration.md
@@ -24,18 +24,9 @@ more details below.
 
 ## Releasing a New Version
 
-For releasing a new version just create a new version tag in form `v[0-9]+\..*`
-and push it to the server:
-
-```shell
-# consider using `git tag -s` option to create a GPG signed tag
-git tag -a -m "Version 2.3.4" v2.3.4
-git push origin v2.3.4
-```
-
-The GitHub Actions will publish the packages in the [systemsmanagement:Agama:Devel](
-https://build.opensuse.org/project/show/systemsmanagement:Agama:Devel)
-project and create submit requests to openSUSE Factory.
+For releasing a new version just create a new version tag. The process is then
+fully automated. See more details in the [Packaging documentation](
+../PACKAGING.md#bumping-the-version).
 
 ## OBS Synchronization
 

--- a/rust/package/_service
+++ b/rust/package/_service
@@ -1,0 +1,28 @@
+<services>
+  <service name="obs_scm" mode="manual">
+    <param name="url">https://github.com/openSUSE/agama.git</param>
+    <param name="versionformat">@PARENT_TAG@+@TAG_OFFSET@</param>
+    <param name="versionrewrite-pattern">v(.*)</param>    
+    <param name="scm">git</param>
+    <param name="revision">master</param>
+    <param name="subdir">rust</param>
+    <param name="without-version">enable</param>
+    <param name="extract">package/agama-cli.changes</param>
+    <param name="extract">package/agama-cli.spec</param>
+  </service>
+  <service name="cargo_vendor" mode="manual">
+    <param name="srcdir">agama/rust</param>
+     <param name="compression">zst</param>
+     <param name="update">true</param>
+  </service>
+  <service name="cargo_audit" mode="manual">
+    <param name="srcdir">agama/rust</param>
+  </service>
+  <service mode="buildtime" name="tar">
+    <param name="obsinfo">agama.obsinfo</param>
+    <param name="filename">agama</param>
+  </service>
+  <service mode="buildtime" name="set_version">
+    <param name="basename">agama</param>
+  </service>
+</services>

--- a/service/agama.gemspec
+++ b/service/agama.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   if File.exist?(File.join(__dir__, "../.git"))
     # the version is <version_tag>.devel<number_of_commits_since_the_tag>
     # or just <version_tag> if there are no additional commits
-    spec.version = `git describe --tags`.chomp.sub(/^v/, "").sub(/-([0-9]+)-g\h+\Z/, ".devel\\1")
+    spec.version = `git describe --tags --match "v[0-9]*"`.chomp.sub(/^v/, "").sub(/-([0-9]+)-g\h+\Z/, ".devel\\1")
   else
     # running in yupdate script, use a fake version
     spec.version = "99.yupdate"

--- a/web/package/_service
+++ b/web/package/_service
@@ -1,6 +1,7 @@
 <services>
   <service name="obs_scm" mode="manual">
-    <param name="versionformat">@PARENT_TAG@~@TAG_OFFSET@</param>
+    <param name="versionformat">@PARENT_TAG@+@TAG_OFFSET@</param>
+    <param name="versionrewrite-pattern">v(.*)</param>
     <param name="url">http://github.com/openSUSE/agama.git</param>
     <param name="scm">git</param>
     <param name="revision">master</param>


### PR DESCRIPTION
## Small Fixes and Updates

- Updated packaging documentation
- Added `rake tag` task for creating a new git version tag. The new tag needs to be pushed manually to the server to avoid creating a wrong tag accidentally (it triggers OBS submission to Factory so we need to be careful about it)
- Updated `web/package/_service` from OBS, added missing `rust/package/_service` file
- Added `--match "v[0-9]*"` option to `git describe` to avoid accidentally using a non-version tag 
