### PR TITLE
Fixed submitting rubygem-agama

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -94,6 +94,8 @@ Rake::Task["package"].clear
 # Disables the osc:build
 if ENV["SKIP_OSC_BUILD"] == "1"
   Rake::Task["osc:build"].clear
+  # ensure the package sources are still built
+  task :"osc:build" => :package
 end
 
 # TODO: redefine :tarball instead of :package


### PR DESCRIPTION
## Problem

- To make submission faster I  skipped (deleted) the `osc:build` step. Unfortunately that step as a dependency builds the source files, that resulted in missing files in OBS.

## Solution

- Define empty build step with packaging dependency
