### PR TITLE
Extend zFCP D-Bus API

### DIFF
--- a/doc/dbus/bus/org.opensuse.Agama.Storage1.ZFCP.Controller.bus.xml
+++ b/doc/dbus/bus/org.opensuse.Agama.Storage1.ZFCP.Controller.bus.xml
@@ -49,6 +49,7 @@
       <arg name="result" direction="out" type="u"/>
     </method>
     <property type="b" name="Active" access="read"/>
+    <property type="b" name="LUNScan" access="read"/>
     <property type="s" name="Channel" access="read"/>
   </interface>
 </node>

--- a/doc/dbus/bus/org.opensuse.Agama.Storage1.bus.xml
+++ b/doc/dbus/bus/org.opensuse.Agama.Storage1.bus.xml
@@ -1,6 +1,8 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node name="/org/opensuse/Agama/Storage1">
+  <node name="zfcp_controllers" />
+  <node name="zfcp_disks" />
   <interface name="org.freedesktop.DBus.Properties">
     <method name="Get">
       <arg name="interface_name" direction="in" type="s"/>
@@ -109,5 +111,6 @@
   <interface name="org.opensuse.Agama.Storage1.ZFCP.Manager">
     <method name="Probe">
     </method>
+    <property type="b" name="AllowLUNScan" access="read"/>
   </interface>
 </node>

--- a/doc/dbus/org.opensuse.Agama.Storage1.ZFCP.Controller.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Storage1.ZFCP.Controller.doc.xml
@@ -80,6 +80,10 @@
     -->
     <property type="b" name="Active" access="read"/>
     <!--
+      Whether the controller is performing auto LUN scan.
+    -->
+    <property type="b" name="LUNScan" access="read"/>
+    <!--
       zFCP channel id (e.g., 0.0.fa00).
     -->
     <property type="s" name="Channel" access="read"/>

--- a/doc/dbus/org.opensuse.Agama.Storage1.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Storage1.doc.xml
@@ -26,5 +26,9 @@
     -->
     <method name="Probe">
     </method>
+    <!--
+      Whether the option allow_lun_scan is active.
+    -->
+    <property type="b" name="AllowLUNScan" access="read"/>
   </interface>
 </node>

--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    agama (2.1)
+    agama (2.1.devel317)
       cfa (~> 1.0.2)
       cfa_grub2 (~> 2.0.0)
       cheetah (~> 1.0.0)
@@ -26,13 +26,13 @@ GEM
     docile (1.4.0)
     eventmachine (1.2.7)
     fast_gettext (2.2.0)
-    mini_portile2 (2.8.1)
+    mini_portile2 (2.8.2)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     packaging_rake_tasks (1.5.1)
       rake
-    racc (1.6.2)
+    racc (1.7.1)
     rake (13.0.6)
     rexml (3.2.5)
     rspec (3.11.0)

--- a/service/lib/agama/dbus/storage/interfaces/zfcp_manager.rb
+++ b/service/lib/agama/dbus/storage/interfaces/zfcp_manager.rb
@@ -31,6 +31,13 @@ module Agama
         #
         # @note This mixin is expected to be included by {Agama::DBus::Storage::Manager}.
         module ZFCPManager
+          # Whether the option for allowing automatic LUN scan is active
+          #
+          # @return [Boolean]
+          def allow_lun_scan
+            zfcp_backend.allow_lun_scan?
+          end
+
           # Registers callbacks to update the collection of zFCP controllers, the disks and
           # deprecate the system
           def register_zfcp_callbacks
@@ -71,6 +78,9 @@ module Agama
           def self.included(base)
             base.class_eval do
               dbus_interface ZFCP_MANAGER_INTERFACE do
+                # @see #allow_lun_scan
+                dbus_reader(:allow_lun_scan, "b", dbus_name: "AllowLUNScan")
+
                 # Probes the zFCP controllers and disks
                 dbus_method(:Probe) do
                   busy_while { zfcp_backend.probe }

--- a/service/lib/agama/dbus/storage/zfcp_controller.rb
+++ b/service/lib/agama/dbus/storage/zfcp_controller.rb
@@ -55,6 +55,13 @@ module Agama
           controller.active?
         end
 
+        # Whether the controller is automatically scanning LUNs
+        #
+        # @return [Boolean]
+        def lun_scan
+          controller.lun_scan?
+        end
+
         # zFCP channel id
         #
         # @return [String]
@@ -131,6 +138,9 @@ module Agama
         dbus_interface ZFCP_CONTROLLER_INTERFACE do
           # @see #active
           dbus_reader(:active, "b")
+
+          # @see #lun_scan
+          dbus_reader(:lun_scan, "b", dbus_name: "LUNScan")
 
           # @see #channel
           dbus_reader(:channel, "s")

--- a/service/lib/agama/storage/zfcp/controller.rb
+++ b/service/lib/agama/storage/zfcp/controller.rb
@@ -33,8 +33,15 @@ module Agama
         # @return [String]
         attr_reader :channel
 
+        # @see #active?
+        #
         # @return [Boolean]
         attr_writer :active
+
+        # @see #lun_scan?
+        #
+        # @return [Boolean]
+        attr_writer :lun_scan
 
         eql_attr :channel, :active?
 
@@ -50,6 +57,13 @@ module Agama
         # @return [Boolean]
         def active?
           !!@active
+        end
+
+        # Whether the controller is automatically scanning LUNs
+        #
+        # @return [Booelan]
+        def lun_scan?
+          !!@lun_scan
         end
       end
     end

--- a/service/lib/agama/storage/zfcp/manager.rb
+++ b/service/lib/agama/storage/zfcp/manager.rb
@@ -78,6 +78,17 @@ module Agama
           yast_zfcp.disks.map { |d| disk_from(d) }
         end
 
+        # Whether the option for allowing automatic LUN scan (allow_lun_scan) is active
+        #
+        # Having allow_lun_scan active has some implications:
+        #   * All LUNs are automatically activated when the controller is activated.
+        #   * LUNs cannot be deactivated.
+        #
+        # @return [Boolean]
+        def allow_lun_scan?
+          yast_zfcp.allow_lun_scan?
+        end
+
         # Activates the controller with the given channel id
         #
         # @note: If "allow_lun_scan" is active, then all LUNs are automatically activated.
@@ -161,6 +172,7 @@ module Agama
         def controller_from(record)
           Controller.new(record["sysfs_bus_id"]).tap do |controller|
             controller.active = yast_zfcp.activated_controller?(controller.channel)
+            controller.lun_scan = yast_zfcp.lun_scan_controller?(controller.channel)
           end
         end
 

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -27,7 +27,7 @@
     # yast2 with ArchFilter
     Requires:       yast2 >= 4.5.20
     %ifarch s390 s390x
-    Requires:       yast2-s390 >= 4.6.2
+    Requires:       yast2-s390 >= 4.6.3
     %endif
   :filelist: "%{_datadir}/dbus-1/agama.conf\n
     %dir %{_datadir}/dbus-1/agama-services\n

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 14 15:11:56 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Extend zFCP D-Bus API to provide allow_lun_scan info
+  (gh#openSUSE/agama/626).
+
+-------------------------------------------------------------------
 Wed Jun  7 11:13:49 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Add D-Bus API for managing zFCP devices (gh#openSUSE/agama#594).

--- a/service/test/agama/dbus/storage/zfcp_controller_test.rb
+++ b/service/test/agama/dbus/storage/zfcp_controller_test.rb
@@ -61,6 +61,28 @@ describe Agama::DBus::Storage::ZFCPController do
     end
   end
 
+  describe "#lun_scan" do
+    before do
+      controller1.lun_scan = lun_scan
+    end
+
+    context "if the controller is automatically scanning LUNs" do
+      let(:lun_scan) { true }
+
+      it "returns true" do
+        expect(subject.lun_scan).to eq(true)
+      end
+    end
+
+    context "if the controller is not automatically scanning LUNs" do
+      let(:lun_scan) { false }
+
+      it "returns false" do
+        expect(subject.lun_scan).to eq(false)
+      end
+    end
+  end
+
   describe "#channel" do
     it "returns the channel id of the controller" do
       expect(subject.channel).to eq("0.0.fa00")

--- a/service/test/agama/storage/zfcp/manager_test.rb
+++ b/service/test/agama/storage/zfcp/manager_test.rb
@@ -108,7 +108,10 @@ describe Agama::Storage::ZFCP::Manager do
 
     before do
       allow(yast_zfcp).to receive(:activated_controller?).with("0.0.fa00").and_return(true)
+      allow(yast_zfcp).to receive(:lun_scan_controller?).with("0.0.fa00").and_return(true)
+
       allow(yast_zfcp).to receive(:activated_controller?).with("0.0.fc00").and_return(false)
+      allow(yast_zfcp).to receive(:lun_scan_controller?).with("0.0.fc00").and_return(false)
     end
 
     it "returns the zFCP controllers" do
@@ -118,9 +121,11 @@ describe Agama::Storage::ZFCP::Manager do
 
       controller = controllers.find { |c| c.channel == "0.0.fa00" }
       expect(controller.active?).to eq(true)
+      expect(controller.lun_scan?).to eq(true)
 
       controller = controllers.find { |c| c.channel == "0.0.fc00" }
       expect(controller.active?).to eq(false)
+      expect(controller.lun_scan?).to eq(false)
     end
   end
 
@@ -146,6 +151,28 @@ describe Agama::Storage::ZFCP::Manager do
           lun:     "0x0000000000000004"
         )
       )
+    end
+  end
+
+  describe "#allow_lun_scan?" do
+    before do
+      allow(yast_zfcp).to receive(:allow_lun_scan?).and_return(active)
+    end
+
+    context "if allow_lun_scan is active" do
+      let(:active) { true }
+
+      it "returns true" do
+        expect(subject.allow_lun_scan?).to eq(true)
+      end
+    end
+
+    context "if allow_lun_scan is not active" do
+      let(:active) { false }
+
+      it "returns false" do
+        expect(subject.allow_lun_scan?).to eq(false)
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

Agama already provides a D-Bus API for managing zFCP devices. But the current API offers nothing to check whether a controller is automatically scanning LUNs. That info is important for clients, because the actions over a LUN depend on that config.

For example, if a controller is not doing auto LUN scan, then LUNs have to be manually activated one by one. But, if auto LUN scan is active, then all LUNs are activated as side effect of activating a controller. Moreover, automatically activated LUNs cannot be manually deactivated.

## Solution

Extend D-Bus API. Now, *Agama.Storage1.ZFCP.Manager* interface has the *AllowLUNScan* attribute, which indicates whether *allow_lun_scan* is active in the system. And *Agama.Storage1.ZFCP.Controller* interface has the *LUNScan* attribrute, which indicates whether the controller is automatically scanning LUNs. Note that the controller must be running in NPIV mode.

Requires https://github.com/yast/yast-s390/pull/106.

Note: *allow_lun_scan* is active by default in the zfcp module since SLE 12. A kernel parameter can be used to disable it (i.e., *zfcp.allow_lun_scan=0*). If it is used, then it should be persisted in the target system, see https://github.com/yast/yast-bootloader/pull/687. 

Note: some CI tasks are failing because a coveralls error, but all checks actually pass. 

## Testing

* Added new unit tests
* Tested manually
