### PR TITLE
Small fixes in autosubmission

### DIFF
--- a/.github/workflows/obs-staging-service.yml
+++ b/.github/workflows/obs-staging-service.yml
@@ -8,6 +8,7 @@ on:
     paths:
       # run only when a service source is changed
       - service/**
+      - Rakefile
 
 jobs:
   update_service:

--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,7 @@ end
 
 Yast::Tasks.configuration do |conf|
   conf.obs_api = "https://api.opensuse.org"
-  conf.obs_project = "systemsmanagement:Agama:Staging"
+  conf.obs_project = ENV["OBS_PROJECT"] || "systemsmanagement:Agama:Staging"
   conf.package_dir = File.join(Rake.original_dir, "package")
   conf.obs_target = "openSUSE_Tumbleweed"
   package_name = package_name_from(Rake.original_dir)


### PR DESCRIPTION
# Small Fixes

- Update the `rubygem-agama` package also when `Rakefile` is changed (it contains the packaging information)
- Use `OBS_PROJECT` env. variable to allow submitting to a different project with the same code (we need that to submit to systemsmanagement:Agama:Devel)
(I forgot to commit this part in the previous PR.)