### PR TITLE
Add initial logging capability to agama-dbus-server

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -32,6 +32,8 @@ dependencies = [
  "agama-network",
  "anyhow",
  "async-std",
+ "log",
+ "systemd-journal-logger",
  "zbus",
  "zbus_macros",
 ]
@@ -56,6 +58,7 @@ dependencies = [
  "futures",
  "futures-util",
  "jsonschema",
+ "log",
  "serde",
  "serde_json",
  "tempfile",
@@ -638,6 +641,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -904,6 +908,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1051,24 @@ name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+
+[[package]]
+name = "libsystemd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b9597a67aa1c81a6624603e6bd0bcefb9e0f94c9c54970ec53771082104b4e"
+dependencies = [
+ "hmac",
+ "libc",
+ "log",
+ "nix",
+ "nom",
+ "once_cell",
+ "serde",
+ "sha2",
+ "thiserror",
+ "uuid",
+]
 
 [[package]]
 name = "libz-sys"
@@ -1594,6 +1625,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,6 +1698,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1723,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "systemd-journal-logger"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "356b5cb52ce54916cbfaee19b07d305c7ea8ce5435a088c58743d4a0211f3eff"
+dependencies = [
+ "libsystemd",
+ "log",
 ]
 
 [[package]]
@@ -1879,6 +1937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "anyhow",
  "async-std",
  "log",
+ "simplelog",
  "systemd-journal-logger",
  "zbus",
  "zbus_macros",
@@ -1244,6 +1245,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,6 +1665,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplelog"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
+dependencies = [
+ "log",
+ "termcolor",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1770,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,6 +1804,9 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -2065,6 +2098,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -1,11 +1,11 @@
 use crate::error::CliError;
 use crate::printers::{print, Format};
-use clap::Subcommand;
-use convert_case::{Case, Casing};
 use agama_lib::connection;
 use agama_lib::install_settings::{InstallSettings, Scope};
 use agama_lib::settings::{SettingObject, SettingValue, Settings};
 use agama_lib::Store as SettingsStore;
+use clap::Subcommand;
+use convert_case::{Case, Casing};
 use std::str::FromStr;
 use std::{collections::HashMap, error::Error, io};
 

--- a/rust/agama-cli/src/main.rs
+++ b/rust/agama-cli/src/main.rs
@@ -8,15 +8,15 @@ mod profile;
 mod progress;
 
 use crate::error::CliError;
-use async_std::task::{self, block_on};
-use commands::Commands;
-use config::run as run_config_cmd;
 use agama_lib::error::ServiceError;
 use agama_lib::manager::ManagerClient;
 use agama_lib::progress::build_progress_monitor;
+use async_std::task::{self, block_on};
+use commands::Commands;
+use config::run as run_config_cmd;
 use printers::Format;
-use progress::InstallerProgress;
 use profile::run as run_profile_cmd;
+use progress::InstallerProgress;
 use std::error::Error;
 use std::time::Duration;
 
@@ -58,7 +58,10 @@ async fn show_progress() -> Result<(), ServiceError> {
     let conn = agama_lib::connection().await?;
     let mut monitor = build_progress_monitor(conn).await.unwrap();
     let presenter = InstallerProgress::new();
-    monitor.run(presenter).await.expect("failed to monitor the progress");
+    monitor
+        .run(presenter)
+        .await
+        .expect("failed to monitor the progress");
     Ok(())
 }
 

--- a/rust/agama-cli/src/profile.rs
+++ b/rust/agama-cli/src/profile.rs
@@ -1,7 +1,7 @@
-use clap::Subcommand;
 use agama_lib::error::ProfileError;
 use agama_lib::profile::{download, ProfileEvaluator, ProfileValidator, ValidationResult};
-use std::{path::Path};
+use clap::Subcommand;
+use std::path::Path;
 
 #[derive(Subcommand, Debug)]
 pub enum ProfileCommands {

--- a/rust/agama-dbus-server/Cargo.toml
+++ b/rust/agama-dbus-server/Cargo.toml
@@ -10,6 +10,8 @@ anyhow = "1.0"
 agama-locale-data = { path="../agama-locale-data" }
 agama-network = { path="../agama-network" }
 agama-lib = { path="../agama-lib" }
+log = "0.4"
+systemd-journal-logger = "1.0"
 zbus = "3.7.0"
 zbus_macros = "3.7.0"
 async-std = { version = "1.12.0", features = ["attributes"]}

--- a/rust/agama-dbus-server/Cargo.toml
+++ b/rust/agama-dbus-server/Cargo.toml
@@ -11,6 +11,7 @@ agama-locale-data = { path="../agama-locale-data" }
 agama-network = { path="../agama-network" }
 agama-lib = { path="../agama-lib" }
 log = "0.4"
+simplelog = "0.12.1"
 systemd-journal-logger = "1.0"
 zbus = "3.7.0"
 zbus_macros = "3.7.0"

--- a/rust/agama-dbus-server/src/main.rs
+++ b/rust/agama-dbus-server/src/main.rs
@@ -4,15 +4,22 @@ pub mod questions;
 
 use agama_network::NetworkService;
 use std::future::pending;
+use systemd_journal_logger::JournalLog;
+use log::LevelFilter;
 
 const ADDRESS: &str = "unix:path=/run/agama/bus";
 
 #[async_std::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    JournalLog::default().install().unwrap();
+    log::set_max_level(LevelFilter::Info);
     // When adding more services here, the order might be important.
     crate::questions::start_service(ADDRESS).await?;
+    log::info!("Started questions interface");
     let _conn = crate::locale::start_service(ADDRESS).await?;
+    log::info!("Started locale interface");
     NetworkService::start(ADDRESS).await?;
+    log::info!("Started network interface");
 
     // Do other things or go to wait forever
     pending::<()>().await;

--- a/rust/agama-dbus-server/src/main.rs
+++ b/rust/agama-dbus-server/src/main.rs
@@ -4,15 +4,25 @@ pub mod questions;
 
 use agama_network::NetworkService;
 use std::future::pending;
-use systemd_journal_logger::JournalLog;
 use log::LevelFilter;
 
 const ADDRESS: &str = "unix:path=/run/agama/bus";
 
 #[async_std::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    JournalLog::default().install().unwrap();
-    log::set_max_level(LevelFilter::Info);
+    // be smart with logging and log directly to journal if connected to it
+    if systemd_journal_logger::connected_to_journal(){
+        // unwrap here is intentional as we are sure no other logger is active yet
+        systemd_journal_logger::JournalLog::default().install().unwrap();
+        log::set_max_level(LevelFilter::Info); // log only info for journal logger
+    } else {
+        simplelog::TermLogger::init(
+            LevelFilter::Info,  // lets use info, trace provides too much output from libraries
+            simplelog::Config::default(),
+            simplelog::TerminalMode::Stderr, // only stderr output for easier filtering
+            simplelog::ColorChoice::Auto
+        ).unwrap(); // unwrap here as we are sure no other logger active
+    }
     // When adding more services here, the order might be important.
     crate::questions::start_service(ADDRESS).await?;
     log::info!("Started questions interface");

--- a/rust/agama-dbus-server/src/main.rs
+++ b/rust/agama-dbus-server/src/main.rs
@@ -3,25 +3,28 @@ pub mod locale;
 pub mod questions;
 
 use agama_network::NetworkService;
-use std::future::pending;
 use log::LevelFilter;
+use std::future::pending;
 
 const ADDRESS: &str = "unix:path=/run/agama/bus";
 
 #[async_std::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // be smart with logging and log directly to journal if connected to it
-    if systemd_journal_logger::connected_to_journal(){
+    if systemd_journal_logger::connected_to_journal() {
         // unwrap here is intentional as we are sure no other logger is active yet
-        systemd_journal_logger::JournalLog::default().install().unwrap();
+        systemd_journal_logger::JournalLog::default()
+            .install()
+            .unwrap();
         log::set_max_level(LevelFilter::Info); // log only info for journal logger
     } else {
         simplelog::TermLogger::init(
-            LevelFilter::Info,  // lets use info, trace provides too much output from libraries
+            LevelFilter::Info, // lets use info, trace provides too much output from libraries
             simplelog::Config::default(),
             simplelog::TerminalMode::Stderr, // only stderr output for easier filtering
-            simplelog::ColorChoice::Auto
-        ).unwrap(); // unwrap here as we are sure no other logger active
+            simplelog::ColorChoice::Auto,
+        )
+        .unwrap(); // unwrap here as we are sure no other logger active
     }
     // When adding more services here, the order might be important.
     crate::questions::start_service(ADDRESS).await?;

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -6,15 +6,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zbus = "3.7.0"
-serde = { version = "1.0.152", features = ["derive"] }
 agama-derive = { path="../agama-derive" }
+anyhow = "1.0"
 async-std = "1.12.0"
 curl = { version = "0.4.44", features = ["protocol-ftp"] }
+futures = "0.3.27"
+futures-util = "0.3.27"
 jsonschema = { version = "0.16.1", default-features = false }
+log = "0.4"
+serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.94"
 tempfile = "3.4.0"
 thiserror = "1.0.39"
-anyhow = "1.0"
-futures = "0.3.27"
-futures-util = "0.3.27"
+zbus = "3.7.0"

--- a/rust/agama-lib/src/profile.rs
+++ b/rust/agama-lib/src/profile.rs
@@ -1,6 +1,7 @@
 use crate::error::ProfileError;
 use curl::easy::Easy;
 use jsonschema::JSONSchema;
+use log::info;
 use serde_json;
 use std::{
     fs, io,
@@ -10,7 +11,7 @@ use std::{
 };
 use tempfile::tempdir;
 
-/// Downloads a file a writes it to the stdout()
+/// Downloads a file and writes it to the stdout()
 ///
 /// TODO: move this code to a struct
 /// TODO: add support for YaST-specific URLs
@@ -65,6 +66,7 @@ impl ProfileValidator {
         } else {
             Path::new("/usr/share/agama-cli/profile.schema.json")
         };
+        info!("Validation with path {}", path.to_str().unwrap());
         Self::new(path)
     }
 

--- a/rust/agama-lib/src/store/software.rs
+++ b/rust/agama-lib/src/store/software.rs
@@ -31,9 +31,11 @@ impl<'a> SoftwareStore<'a> {
             if ids.contains(&product) {
                 self.software_client.select_product(product).await?;
             } else {
-                return Err(Box::new(WrongParameter::UnknownProduct(product.clone(), ids)));
+                return Err(Box::new(WrongParameter::UnknownProduct(
+                    product.clone(),
+                    ids,
+                )));
             }
-            
         }
         Ok(())
     }

--- a/rust/agama-lib/src/store/users.rs
+++ b/rust/agama-lib/src/store/users.rs
@@ -1,6 +1,6 @@
+use crate::error::WrongParameter;
 use crate::install_settings::{FirstUserSettings, RootUserSettings, UserSettings};
 use crate::users::{FirstUser, UsersClient};
-use crate::error::WrongParameter;
 use std::error::Error;
 use zbus::Connection;
 
@@ -57,7 +57,7 @@ impl<'a> UsersStore<'a> {
         };
         let (success, issues) = self.users_client.set_first_user(&first_user).await?;
         if !success {
-            return Err(Box::new(WrongParameter::WrongUser(issues)));  
+            return Err(Box::new(WrongParameter::WrongUser(issues)));
         }
         Ok(())
     }

--- a/rust/agama-lib/src/users.rs
+++ b/rust/agama-lib/src/users.rs
@@ -78,10 +78,7 @@ impl<'a> UsersClient<'a> {
         value: &str,
         encrypted: bool,
     ) -> Result<u32, ServiceError> {
-        Ok(self
-            .users_proxy
-            .set_root_password(value, encrypted)
-            .await?)
+        Ok(self.users_proxy.set_root_password(value, encrypted).await?)
     }
 
     /// Whether the root password is set or not

--- a/rust/agama-locale-data/src/deprecated_timezones.rs
+++ b/rust/agama-locale-data/src/deprecated_timezones.rs
@@ -1,19 +1,19 @@
 /// List of timezones which are deprecated and langtables missing translations for it
-/// 
+///
 /// Filtering it out also helps with returning smaller list of real timezones.
 /// Sadly many libraries facing issues with deprecated timezones, see e.g.
-/// 
-pub(crate) const DEPRECATED_TIMEZONES : &[&str]= &[
-    "Africa/Asmera", // replaced by Africa/Asmara
-    "Africa/Timbuktu", // replaced by Africa/Bamako
+///
+pub(crate) const DEPRECATED_TIMEZONES: &[&str] = &[
+    "Africa/Asmera",                    // replaced by Africa/Asmara
+    "Africa/Timbuktu",                  // replaced by Africa/Bamako
     "America/Argentina/ComodRivadavia", // replaced by America/Argentina/Catamarca
-    "America/Atka", // replaced by America/Adak
-    "America/Ciudad_Juarez", // failed to find replacement
-    "America/Coral_Harbour", // replaced by America/Atikokan
-    "America/Ensenada", // replaced by America/Tijuana
+    "America/Atka",                     // replaced by America/Adak
+    "America/Ciudad_Juarez",            // failed to find replacement
+    "America/Coral_Harbour",            // replaced by America/Atikokan
+    "America/Ensenada",                 // replaced by America/Tijuana
     "America/Fort_Nelson",
     "America/Fort_Wayne", // replaced by America/Indiana/Indianapolis
-    "America/Knox_IN", // replaced by America/Indiana/Knox
+    "America/Knox_IN",    // replaced by America/Indiana/Knox
     "America/Nuuk",
     "America/Porto_Acre", // replaced by America/Rio_Branco
     "America/Punta_Arenas",

--- a/rust/agama-locale-data/src/language.rs
+++ b/rust/agama-locale-data/src/language.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use crate::ranked::{RankedTerritories, RankedLocales};
+use crate::ranked::{RankedLocales, RankedTerritories};
 
 #[derive(Debug, Deserialize)]
 pub struct Language {
@@ -8,12 +8,12 @@ pub struct Language {
     pub id: String,
     pub territories: RankedTerritories,
     pub locales: RankedLocales,
-    pub names: crate::localization::Localization
+    pub names: crate::localization::Localization,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct Languages {
-    pub language: Vec<Language>
+    pub language: Vec<Language>,
 }
 
 impl Languages {

--- a/rust/agama-locale-data/src/localization.rs
+++ b/rust/agama-locale-data/src/localization.rs
@@ -2,13 +2,12 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct Localization {
-    pub name: Vec<LocalizationEntry>
+    pub name: Vec<LocalizationEntry>,
 }
 
 impl Localization {
     pub fn name_for(&self, language: &str) -> Option<String> {
-        let entry = self.name.iter()
-            .find(|n| n.language == language)?;
+        let entry = self.name.iter().find(|n| n.language == language)?;
         Some(entry.value.clone())
     }
 }
@@ -18,5 +17,5 @@ pub struct LocalizationEntry {
     #[serde(rename(deserialize = "languageId"))]
     pub language: String,
     #[serde(rename(deserialize = "trName"))]
-    pub value: String
+    pub value: String,
 }

--- a/rust/agama-locale-data/src/ranked.rs
+++ b/rust/agama-locale-data/src/ranked.rs
@@ -6,13 +6,13 @@ pub struct RankedLanguage {
     #[serde(rename(deserialize = "languageId"))]
     pub id: String,
     /// Bigger rank means it is more important
-    pub rank: u16
+    pub rank: u16,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct RankedLanguages {
     #[serde(default)]
-    pub language: Vec<RankedLanguage>
+    pub language: Vec<RankedLanguage>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -20,24 +20,24 @@ pub struct RankedTerritory {
     #[serde(rename(deserialize = "territoryId"))]
     pub id: String,
     /// Bigger rank means it is more important
-    pub rank: u16
+    pub rank: u16,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct RankedTerritories {
     #[serde(default)]
-    pub territory: Vec<RankedTerritory>
+    pub territory: Vec<RankedTerritory>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct RankedLocale {
     #[serde(rename(deserialize = "localeId"))]
     pub id: String,
-    pub rank: u16
+    pub rank: u16,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct RankedLocales {
     #[serde(default)]
-    pub locale: Vec<RankedLocale>
+    pub locale: Vec<RankedLocale>,
 }

--- a/rust/agama-locale-data/src/territory.rs
+++ b/rust/agama-locale-data/src/territory.rs
@@ -5,12 +5,12 @@ pub struct Territory {
     #[serde(rename(deserialize = "territoryId"))]
     pub id: String,
     pub languages: crate::ranked::RankedLanguages,
-    pub names: crate::localization::Localization
+    pub names: crate::localization::Localization,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct Territories {
-    pub territory: Vec<Territory>
+    pub territory: Vec<Territory>,
 }
 
 impl Territories {

--- a/rust/agama-locale-data/src/xkeyboard.rs
+++ b/rust/agama-locale-data/src/xkeyboard.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use crate::ranked::{RankedTerritories, RankedLanguages};
+use crate::ranked::{RankedLanguages, RankedTerritories};
 
 #[derive(Debug, Deserialize)]
 pub struct XKeyboard {
@@ -12,10 +12,10 @@ pub struct XKeyboard {
     pub ascii: bool,
     pub comment: Option<String>,
     pub languages: RankedLanguages,
-    pub territories: RankedTerritories
+    pub territories: RankedTerritories,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct XKeyboards {
-    pub keyboard: Vec<XKeyboard>
+    pub keyboard: Vec<XKeyboard>,
 }

--- a/rust/agama-network/src/dbus/tree.rs
+++ b/rust/agama-network/src/dbus/tree.rs
@@ -36,10 +36,7 @@ impl Tree {
     /// adding/removing interfaces. We should add/update/delete objects as needed.
     ///
     /// * `connections`: list of connections.
-    pub async fn set_connections(
-        &self,
-        connections: &Vec<Connection>,
-    ) -> Result<(), ServiceError> {
+    pub async fn set_connections(&self, connections: &Vec<Connection>) -> Result<(), ServiceError> {
         self.remove_connections().await?;
         self.add_connections(connections).await?;
         Ok(())

--- a/rust/agama-network/src/system.rs
+++ b/rust/agama-network/src/system.rs
@@ -58,9 +58,7 @@ impl NetworkSystem {
 
     /// Populates the D-Bus tree with the known devices and connections.
     pub async fn setup(&mut self) -> Result<(), ServiceError> {
-        self.tree
-            .set_connections(&self.state.connections)
-            .await?;
+        self.tree.set_connections(&self.state.connections).await?;
         self.tree.set_devices(&self.state.devices).await?;
         Ok(())
     }
@@ -95,9 +93,7 @@ impl NetworkSystem {
                 self.to_network_manager().await?;
                 // TODO: re-creating the tree is kind of brute-force and it sends signals about
                 // adding/removing interfaces. We should add/update/delete objects as needed.
-                self.tree
-                    .set_connections(&self.state.connections)
-                    .await?;
+                self.tree.set_connections(&self.state.connections).await?;
             }
         }
 


### PR DESCRIPTION
## Problem

Currently agama-dbus-service does not provide any logging. So troubleshooting is hard.

trello: https://trello.com/c/qjrhMrmi/3378-2-agama-enable-a-logging-mechanism-in-agama-dbus-server


## Solution

Add initial logging capability with systemd logger to be consistent with ruby counterpart that also logs to journal.


## Testing

- *Tested manually*


