### PR TITLE
Add zFCP to storage client 

### DIFF
--- a/web/cspell.json
+++ b/web/cspell.json
@@ -23,6 +23,7 @@
         "autoconnect",
         "btrfs",
         "ccmp",
+        "chzdev",
         "dasd",
         "dasds",
         "dbus",
@@ -60,7 +61,9 @@
         "testsuite",
         "textinput",
         "tkip",
-        "udev"
+        "udev",
+        "wwpn",
+        "zfcp"
       ]
     }
   ],


### PR DESCRIPTION
## Problem

The storage service already provides a D-Bus API for managing zFCP devices, see https://github.com/openSUSE/agama/pull/594 and https://github.com/openSUSE/agama/pull/626. But the cockpit storage client is not adapted yet. 

## Solution

Adapt the storage client in order to provide the required API for implementing a zFCP UI.

Note: This PR is created through the *zfcp* feature branch.  

## Testing

* Added new unit tests
* Tested manually
