### PR TITLE
zFCP UI

### DIFF
--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -27,7 +27,7 @@
     # yast2 with ArchFilter
     Requires:       yast2 >= 4.5.20
     %ifarch s390 s390x
-    Requires:       yast2-s390 >= 4.6.3
+    Requires:       yast2-s390 >= 4.6.4
     %endif
   :filelist: "%{_datadir}/dbus-1/agama.conf\n
     %dir %{_datadir}/dbus-1/agama-services\n

--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,15 +1,20 @@
 -------------------------------------------------------------------
+Mon Jul  3 10:18:32 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Add page for managing zFCP devices (gh#openSUSE/agama#634).
+
+-------------------------------------------------------------------
 Wed Jun 21 09:05:21 UTC 2023 - Balsa Asanovic <balsaasanovic95@gmail.com>
 
 - Moved the logic for adding and removing HTML element's
   attributes from sidebar component to custom hook
-  (gh#openSUSE/agama#565) .
+  (gh#openSUSE/agama#565).
 
 -------------------------------------------------------------------
 Tue Jun 13 15:40:01 UTC 2023 - David Diaz <dgonzalez@suse.com>
 
 - UI: stop using fixed sizes for modal dialogs
-  (gh#openSUSE/agama#620) .
+  (gh#openSUSE/agama#620).
 
 -------------------------------------------------------------------
 Tue Jun 13 06:59:12 UTC 2023 - David Diaz <dgonzalez@suse.com>

--- a/web/src/components/storage/ProposalPageOptions.jsx
+++ b/web/src/components/storage/ProposalPageOptions.jsx
@@ -25,7 +25,7 @@ import { useInstallerClient } from "~/context/installer";
 import { If, PageOptions } from "~/components/core";
 
 /**
- * Internal component for build the link to Storage/DASD page
+ * Internal component for building the link to Storage/DASD page
  * @component
  */
 const DASDLink = () => {
@@ -43,7 +43,25 @@ const DASDLink = () => {
 };
 
 /**
- * Internal component for build the link to Storage/iSCSI page
+ * Internal component for building the link to Storage/zFCP page
+ * @component
+ */
+const ZFCPLink = () => {
+  const href = useHref("/storage/zfcp");
+
+  return (
+    <PageOptions.Item
+      key="zfcp-link"
+      href={href}
+      description="Activate disks"
+    >
+      zFCP
+    </PageOptions.Item>
+  );
+};
+
+/**
+ * Internal component for building the link to Storage/iSCSI page
  * @component
  */
 const ISCSILink = () => {
@@ -66,17 +84,20 @@ const ISCSILink = () => {
  */
 export default function ProposalPageOptions () {
   const [showDasdLink, setShowDasdLink] = useState(false);
+  const [showZFCPLink, setShowZFCPLink] = useState(false);
   const { storage: client } = useInstallerClient();
 
   useEffect(() => {
     client.dasd.isSupported().then(setShowDasdLink);
-  }, [client.dasd]);
+    client.zfcp.isSupported().then(setShowZFCPLink);
+  }, [client.dasd, client.zfcp]);
 
   return (
     <PageOptions>
       <PageOptions.Group key="devices-options">
         <If condition={showDasdLink} then={<DASDLink />} />
         <ISCSILink />
+        <If condition={showZFCPLink} then={<ZFCPLink />} />
       </PageOptions.Group>
     </PageOptions>
   );

--- a/web/src/components/storage/ProposalPageOptions.test.jsx
+++ b/web/src/components/storage/ProposalPageOptions.test.jsx
@@ -34,12 +34,19 @@ const dasd = {
   isSupported: isDASDSupportedFn
 };
 
+const isZFCPSupportedFn = jest.fn();
+
+const zfcp = {
+  isSupported: isZFCPSupportedFn
+};
+
 beforeEach(() => {
   isDASDSupportedFn.mockResolvedValue(false);
+  isZFCPSupportedFn.mockResolvedValue(false);
 
   createClient.mockImplementation(() => {
     return {
-      storage: { dasd }
+      storage: { dasd, zfcp }
     };
   });
 });
@@ -61,6 +68,22 @@ it("contains an entry for configuring DASD when is supported", async () => {
 
 it("does not contain an entry for configuring DASD when is NOT supported", async () => {
   isDASDSupportedFn.mockResolvedValue(false);
+  const { user } = installerRender(<ProposalPageOptions />);
+  const toggler = screen.getByRole("button");
+  await user.click(toggler);
+  expect(screen.queryByRole("menuitem", { name: /DASD/ })).toBeNull();
+});
+
+it("contains an entry for configuring zFCP when is supported", async () => {
+  isZFCPSupportedFn.mockResolvedValue(true);
+  const { user } = installerRender(<ProposalPageOptions />);
+  const toggler = screen.getByRole("button");
+  await user.click(toggler);
+  screen.getByRole("menuitem", { name: /zFCP/ });
+});
+
+it("does not contain an entry for configuring zFCP when is NOT supported", async () => {
+  isZFCPSupportedFn.mockResolvedValue(false);
   const { user } = installerRender(<ProposalPageOptions />);
   const toggler = screen.getByRole("button");
   await user.click(toggler);

--- a/web/src/components/storage/ZFCPDiskForm.jsx
+++ b/web/src/components/storage/ZFCPDiskForm.jsx
@@ -41,6 +41,7 @@ import { noop } from "~/utils";
  *
  * @callback onSubmitFn
  * @param {FormData}
+ * @returns {number} 0 on success
  *
  * @typedef {object} FormData
  * @property {string} channel

--- a/web/src/components/storage/ZFCPDiskForm.jsx
+++ b/web/src/components/storage/ZFCPDiskForm.jsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// cspell:ignore wwpns
+
+import React, { useEffect, useState } from "react";
+import {
+  Alert,
+  Form, FormGroup, FormSelect, FormSelectOption
+} from "@patternfly/react-core";
+import { If } from "~/components/core";
+import { noop } from "~/utils";
+
+/**
+ * Form for activating a zFCP disk.
+ * @component
+ *
+ * @param {object} props
+ * @param {string} props.id - Form Id
+ * @param {import(~/components/storage/ZFCPPage).LUN[]} [props.luns]
+ * @param {onSubmitFn} [props.onSubmit] - Callback to be called when the form is submitted.
+ * @param {onValidateFn} [props.onValidate] - Callback to be called when the form is validated.
+ *
+ * @callback onSubmitFn
+ * @param {FormData}
+ *
+ * @typedef {object} FormData
+ * @property {string} channel
+ * @property {string} wwpn
+ * @property {string} lun
+ *
+ * @callback onValidateFn
+ * @param {boolean} valid - Whether the form data is valid.
+ */
+export default function ZFCPDiskForm({ id, luns = [], onSubmit = noop, onValidate = noop }) {
+  const [formData, setFormData] = useState({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFailed, setIsFailed] = useState(false);
+
+  useEffect(() => {
+    const valid = formData.channel !== undefined;
+    onValidate(valid);
+  }, [onValidate, formData]);
+
+  const getChannels = () => {
+    const channels = [...new Set(luns.map(l => l.channel))];
+    return channels.sort();
+  };
+
+  const getWWPNs = (channel) => {
+    const selection = luns.filter(l => l.channel === channel);
+    const wwpns = [...new Set(selection.map(l => l.wwpn))];
+    return wwpns.sort();
+  };
+
+  const getLUNs = (channel, wwpn) => {
+    const selection = luns.filter(l => l.channel === channel && l.wwpn === wwpn);
+    return selection.map(l => l.lun).sort();
+  };
+
+  const select = (channel, wwpn, lun) => {
+    if (!channel) channel = getChannels()[0];
+    if (!wwpn) wwpn = getWWPNs(channel)[0];
+    if (!lun) lun = getLUNs(channel, wwpn)[0];
+
+    if (channel) setFormData({ channel, wwpn, lun });
+  };
+
+  const selectChannel = (channel) => select(channel);
+
+  const selectWWPN = (wwpn) => select(formData.channel, wwpn);
+
+  const selectLUN = (lun) => select(formData.channel, formData.wwpn, lun);
+
+  const submit = async (event) => {
+    event.preventDefault();
+
+    setIsLoading(true);
+    const result = await onSubmit(formData);
+    setIsLoading(false);
+
+    setIsFailed(result !== 0);
+  };
+
+  if (!formData.channel && getChannels().length > 0) select();
+
+  return (
+    <>
+      <If
+        condition={isFailed}
+        then={
+          <Alert variant="warning" isInline title="Something went wrong">
+            <p>The zFCP disk was not activated.</p>
+          </Alert>
+        }
+      />
+      <Form id={id} name="ZFCPDisk" onSubmit={submit}>
+        <FormGroup fieldId="channelId" label="Channel ID">
+          <FormSelect
+            id="channelId"
+            value={formData.channel}
+            onChange={selectChannel}
+            isDisabled={isLoading}
+          >
+            {getChannels().map((channel, i) => <FormSelectOption key={i} value={channel} label={channel} />)}
+          </FormSelect>
+        </FormGroup>
+        <FormGroup fieldId="wwpn" label="WWPN">
+          <FormSelect
+            id="wwpn"
+            value={formData.wwpn}
+            onChange={selectWWPN}
+            isDisabled={isLoading}
+          >
+            {getWWPNs(formData.channel).map((wwpn, i) => <FormSelectOption key={i} value={wwpn} label={wwpn} />)}
+          </FormSelect>
+        </FormGroup>
+        <FormGroup fieldId="lun" label="LUN">
+          <FormSelect
+            id="lun"
+            value={formData.lun}
+            onChange={selectLUN}
+            isDisabled={isLoading}
+          >
+            {getLUNs(formData.channel, formData.wwpn).map((lun, i) => <FormSelectOption key={i} value={lun} label={lun} />)}
+          </FormSelect>
+        </FormGroup>
+      </Form>
+    </>
+  );
+}

--- a/web/src/components/storage/ZFCPDiskForm.jsx
+++ b/web/src/components/storage/ZFCPDiskForm.jsx
@@ -37,7 +37,7 @@ import { noop } from "~/utils";
  * @param {string} props.id - Form Id
  * @param {import(~/components/storage/ZFCPPage).LUN[]} [props.luns]
  * @param {onSubmitFn} [props.onSubmit] - Callback to be called when the form is submitted.
- * @param {onValidateFn} [props.onValidate] - Callback to be called when the form is validated.
+ * @param {onLoadingFn} [props.onValidate] - Callback to be called when the form starts/stops loading.
  *
  * @callback onSubmitFn
  * @param {FormData}
@@ -48,18 +48,17 @@ import { noop } from "~/utils";
  * @property {string} wwpn
  * @property {string} lun
  *
- * @callback onValidateFn
- * @param {boolean} valid - Whether the form data is valid.
+ * @callback onLoadingFn
+ * @param {boolean} isLoading - Whether the form is loading.
  */
-export default function ZFCPDiskForm({ id, luns = [], onSubmit = noop, onValidate = noop }) {
+export default function ZFCPDiskForm({ id, luns = [], onSubmit = noop, onLoading = noop }) {
   const [formData, setFormData] = useState({});
   const [isLoading, setIsLoading] = useState(false);
   const [isFailed, setIsFailed] = useState(false);
 
   useEffect(() => {
-    const valid = formData.channel !== undefined;
-    onValidate(valid);
-  }, [onValidate, formData]);
+    onLoading(isLoading);
+  }, [onLoading, isLoading]);
 
   const getChannels = () => {
     const channels = [...new Set(luns.map(l => l.channel))];

--- a/web/src/components/storage/ZFCPDiskForm.test.jsx
+++ b/web/src/components/storage/ZFCPDiskForm.test.jsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen, within } from "@testing-library/react";
+import userEvent from '@testing-library/user-event';
+import { plainRender } from "~/test-utils";
+import { ZFCPDiskForm } from "~/components/storage";
+
+// The form does not provide a submit button by itself.
+const FormWrapper = (props) => {
+  return (
+    <>
+      <ZFCPDiskForm {...props} />
+      <input type="submit" form={props.id} value="Accept" />
+    </>
+  );
+};
+
+const luns = [
+  { channel: "0.0.fa00", wwpn: "0x500507630703d3b3", lun: "0x0000000000000001" },
+  { channel: "0.0.fa00", wwpn: "0x500507630703d3b3", lun: "0x0000000000000002" },
+  { channel: "0.0.fa00", wwpn: "0x500507630704d3b3", lun: "0x0000000000000010" },
+  { channel: "0.0.fa00", wwpn: "0x500507630704d3b3", lun: "0x0000000000000020" },
+  { channel: "0.0.fb00", wwpn: "0x500507630705d3b3", lun: "0x0000000000000100" },
+  { channel: "0.0.fb00", wwpn: "0x500507630705d3b3", lun: "0x0000000000000200" }
+];
+
+let props = {};
+
+beforeEach(() => {
+  props = {
+    id: "ZFCPDiskForm",
+    luns,
+    onSubmit: jest.fn().mockResolvedValue(0),
+    onValidate: jest.fn()
+  };
+});
+
+it("renders a form for selecting channel, WWPN and LUN", async () => {
+  plainRender(<ZFCPDiskForm {...props} />);
+
+  const form = await screen.findByRole("form");
+  const channelSelector = within(form).getByRole("combobox", { name: "Channel ID" });
+  expect(within(channelSelector).getAllByRole("option").length).toBe(2);
+  within(channelSelector).getByRole("option", { name: "0.0.fa00" });
+  within(channelSelector).getByRole("option", { name: "0.0.fb00" });
+
+  within(form).getByRole("combobox", { name: "WWPN" });
+  within(form).getByRole("combobox", { name: "LUN" });
+});
+
+it("offers the WWPNs of the selected channel", async () => {
+  plainRender(<ZFCPDiskForm {...props} />);
+
+  const form = await screen.findByRole("form");
+  const channelSelector = within(form).getByRole("combobox", { name: "Channel ID" });
+  const channelOption = within(channelSelector).getByRole("option", { name: "0.0.fb00" });
+
+  await userEvent.selectOptions(channelSelector, channelOption);
+
+  const wwpnSelector = within(form).getByRole("combobox", { name: "WWPN" });
+  expect(within(wwpnSelector).getAllByRole("option").length).toBe(1);
+  within(wwpnSelector).getByRole("option", { name: "0x500507630705d3b3" });
+});
+
+it("offers the LUNs of the selected channel and WWPN", async () => {
+  plainRender(<ZFCPDiskForm {...props} />);
+
+  const form = await screen.findByRole("form");
+  const channelSelector = within(form).getByRole("combobox", { name: "Channel ID" });
+  const channelOption = within(channelSelector).getByRole("option", { name: "0.0.fa00" });
+
+  await userEvent.selectOptions(channelSelector, channelOption);
+
+  const wwpnSelector = within(form).getByRole("combobox", { name: "WWPN" });
+  expect(within(wwpnSelector).getAllByRole("option").length).toBe(2);
+  const wwpnOption = within(wwpnSelector).getByRole("option", { name: "0x500507630704d3b3" });
+
+  await userEvent.selectOptions(wwpnSelector, wwpnOption);
+
+  const lunSelector = within(form).getByRole("combobox", { name: "LUN" });
+  expect(within(lunSelector).getAllByRole("option").length).toBe(2);
+  within(lunSelector).getByRole("option", { name: "0x0000000000000010" });
+  within(lunSelector).getByRole("option", { name: "0x0000000000000020" });
+});
+
+describe("when the form is submitted", () => {
+  it("calls to the given onSubmit prop", async () => {
+    const { user } = plainRender(<FormWrapper {...props} />);
+
+    const accept = screen.getByRole("button", { name: "Accept" });
+    await user.click(accept);
+
+    expect(props.onSubmit).toHaveBeenCalledWith({
+      channel: "0.0.fa00", wwpn: "0x500507630703d3b3", lun: "0x0000000000000001"
+    });
+
+    expect(screen.queryByText(/was not activated/)).toBeNull();
+  });
+
+  it("shows an error if the action fails", async () => {
+    props.onSubmit = jest.fn().mockResolvedValue(1);
+
+    const { user } = plainRender(<FormWrapper {...props} />);
+
+    const accept = screen.getByRole("button", { name: "Accept" });
+    await user.click(accept);
+
+    screen.getByText(/was not activated/);
+  });
+});

--- a/web/src/components/storage/ZFCPDiskForm.test.jsx
+++ b/web/src/components/storage/ZFCPDiskForm.test.jsx
@@ -51,7 +51,7 @@ beforeEach(() => {
     id: "ZFCPDiskForm",
     luns,
     onSubmit: jest.fn().mockResolvedValue(0),
-    onValidate: jest.fn()
+    onLoading: jest.fn()
   };
 });
 

--- a/web/src/components/storage/ZFCPPage.jsx
+++ b/web/src/components/storage/ZFCPPage.jsx
@@ -1,0 +1,726 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// cspell:ignore wwpns npiv
+
+import React, { useCallback, useEffect, useReducer, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button, Skeleton, Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { MainActions } from "~/components/layout";
+import { If, Page, Popup, RowActions, Section, SectionSkeleton } from "~/components/core";
+import { ZFCPDiskForm } from "~/components/storage";
+import { noop, useCancellablePromise } from "~/utils";
+import { useInstallerClient } from "~/context/installer";
+
+/**
+ * @typedef {import(~/clients/storage).ZFCPManager} ZFCPManager
+ * @typedef {import(~/clients/storage).ZFCPController} Controller
+ * @typedef {import(~/clients/storage).ZFCPDisk} Disk
+ *
+ * @typedef {object} LUN
+ * @property {string} channel
+ * @property {string} wwpn
+ * @property {string} lun
+ */
+
+/**
+ * Internal class for managing zFCP data in a format that is useful for components.
+ */
+class Manager {
+  /**
+   * @param {Controller[]} controllers
+   * @param {Disk[]} disks
+   * @param {LUN[]} luns
+   */
+  constructor(controllers = [], disks = [], luns = []) {
+    this.controllers = controllers;
+    this.disks = disks;
+    this.luns = luns;
+  }
+
+  /**
+   * Gets the activated controllers.
+   *
+   * @returns {Controller[]}
+   */
+  getActiveControllers() {
+    return this.controllers.filter(c => c.active);
+  }
+
+  /**
+   * Gets the controller for the given channel.
+   *
+   * @param {string} channel
+   * @returns {Controller|undefined}
+   */
+  getController(channel) {
+    const index = this.findController(channel);
+    if (index === -1) return undefined;
+
+    return this.controllers[index];
+  }
+
+  /**
+   * Updates the info about the given controller.
+   *
+   * @param {Controller} controller
+   * @returns {void}
+   */
+  updateController(controller) {
+    const index = this.findController(controller.channel);
+    if (index === -1) return;
+
+    this.controllers[index] = controller;
+  }
+
+  /**
+   * Gets the disk for the given channel, WWPN and LUN.
+   *
+   * @param {string} channel
+   * @param {wwpn} wwpn
+   * @param {lun} lun
+   * @returns {Disk|undefined}
+   */
+  getDisk(channel, wwpn, lun) {
+    const index = this.findDisk(channel, wwpn, lun);
+    if (index === -1) return undefined;
+
+    return this.disks[index];
+  }
+
+  /**
+   * Adds the given disk to the list of disks.
+   *
+   * @param {Disk} disk
+   * @returns {void}
+   */
+  addDisk(disk) {
+    if (this.getDisk(disk.channel, disk.wwpn, disk.lun)) return;
+
+    this.disks.push(disk);
+  }
+
+  /**
+   * Updates the info about the given disk.
+   * @param {Disk} disk
+   * @returns {void}
+   */
+  updateDisk(disk) {
+    const index = this.findDisk(disk.channel, disk.wwpn, disk.lun);
+    if (index === -1) return;
+
+    this.disks[index] = disk;
+  }
+
+  /**
+   * Removes the given disk from the list of disks.
+   * @param {Disk} disk
+   * @returns {void}
+   */
+  removeDisk(disk) {
+    const index = this.findDisk(disk.channel, disk.wwpn, disk.lun);
+    if (index === -1) return;
+
+    this.disks.splice(index, 1);
+  }
+
+  /**
+   * Gets the list of inactive LUNs.
+   *
+   * @returns {LUN[]}
+   */
+  getInactiveLUNs() {
+    const luns = this.getActiveControllers().map(controller => {
+      return this.luns.filter(l => l.channel === controller.channel &&
+        !this.isLUNActive(l.channel, l.wwpn, l.lun));
+    });
+
+    return luns.flat();
+  }
+
+  /**
+   * Whether the LUN is active.
+   *
+   * @param {string} channel
+   * @param {string} wwpn
+   * @param {string} lun
+   * @returns {boolean}
+   */
+  isLUNActive(channel, wwpn, lun) {
+    const disk = this.getDisk(channel, wwpn, lun);
+    return disk !== undefined;
+  }
+
+  /**
+   * @private
+   * Index of the controller for the given channel.
+   *
+   * @param {string} channel
+   * @returns {number}
+   */
+  findController(channel) {
+    return this.controllers.findIndex(c => c.channel === channel);
+  }
+
+  /**
+   * @private
+   * Index of the disk with the given channel, WWPN and LUN.
+   *
+   * @param {string} channel
+   * @param {string} wwpn
+   * @param {string} lun
+   * @returns {number}
+   */
+  findDisk(channel, wwpn, lun) {
+    return this.disks.findIndex(d => d.channel === channel && d.wwpn === wwpn && d.lun === lun);
+  }
+}
+
+/**
+ * Generic table for zFCP devices.
+ *
+ * It shows a row as loading meanwhile performing an action.
+ *
+ * @component
+ *
+ * @param {object} props
+ * @param {Controller[]|Disk[]} [props.devices] - Devices to show in the table.
+ * @param {Column[]} [props.columns] - Columns to show.
+ * @param {ColumnValueFn} [props.columnValue] - Function to get the value of a column for a given device.
+ * @param {DeviceActionsFn} [props.actions] - Function to get the actions for a given device.
+ *
+ * @callback ColumnValueFn
+ * @param {Controller} controller
+ * @param {Column} Column
+ * @returns {string}
+ *
+ * @typedef {object} Column
+ * @property {string} id
+ * @property {string} label
+ *
+ * @callback DeviceActionsFn
+ * @param {Controller|Disk} device
+ * @returns {DeviceAction[]}
+ *
+ * @typedef {DeviceAction}
+ * @property {string} label
+ * @property {function} call
+ */
+const DevicesTable = ({ devices = [], columns = [], columnValue = noop, actions = noop }) => {
+  const [loadingRow, setLoadingRow] = useState();
+
+  const sortedDevices = () => {
+    return devices.sort((d1, d2) => {
+      const v1 = columnValue(d1, columns[0]);
+      const v2 = columnValue(d2, columns[0]);
+      if (v1 < v2) return -1;
+      if (v1 > v2) return 1;
+      return 0;
+    });
+  };
+
+  const Actions = ({ device }) => {
+    const deviceActions = actions(device);
+    if (deviceActions.length === 0) return null;
+
+    const items = deviceActions.map((action) => (
+      {
+        title: action.label,
+        onClick: async () => {
+          setLoadingRow(device.id);
+          await action.run();
+          setLoadingRow(undefined);
+        }
+      }
+    ));
+
+    return <RowActions actions={items} />;
+  };
+
+  return (
+    <TableComposable variant="compact">
+      <Thead>
+        <Tr>
+          { columns.map((column) => <Th key={column.id}>{column.label}</Th>) }
+        </Tr>
+      </Thead>
+      <Tbody>
+        { sortedDevices().map((device) => (
+          <Tr key={device.id}>
+            <If
+              condition={loadingRow === device.id}
+              then={<Td colSpan={columns.length + 1}><Skeleton /></Td>}
+              else={
+                <>
+                  { columns.map(column => <Td key={column.id} dataLabel={column.label}>{columnValue(device, column)}</Td>) }
+                  <Td isActionCell key="device-actions">
+                    <Actions device={device} />
+                  </Td>
+                </>
+              }
+            />
+          </Tr>
+        ))}
+      </Tbody>
+    </TableComposable>
+  );
+};
+
+/**
+ * Table of zFCP controllers.
+ * @component
+ *
+ * @param {object} props
+ * @param {ZFCPManager} props.client
+ * @param {Manager} props.manager
+ */
+const ControllersTable = ({ client, manager }) => {
+  const { cancellablePromise } = useCancellablePromise();
+
+  const columns = [
+    { id: "channel", label: "Channel ID" },
+    { id: "status", label: "Status" },
+    { id: "lunScan", label: "Auto LUNs Scan" }
+  ];
+
+  const columnValue = (controller, column) => {
+    let value;
+
+    switch (column.id) {
+      case 'channel':
+        value = controller.channel;
+        break;
+      case 'status':
+        value = controller.active ? "Activated" : "Deactivated";
+        break;
+      case 'lunScan':
+        if (controller.active)
+          value = controller.lunScan ? "Yes" : "No";
+        else
+          value = "-";
+        break;
+    }
+
+    return value;
+  };
+
+  const actions = (controller) => {
+    if (controller.active) return [];
+
+    return [
+      {
+        label: "Activate",
+        run: async () => await cancellablePromise(client.activateController(controller))
+      }
+    ];
+  };
+
+  return (
+    <DevicesTable
+      devices={manager.controllers}
+      columns={columns}
+      columnValue={columnValue}
+      actions={actions}
+    />
+  );
+};
+
+/**
+ * Table of zFCP disks.
+ * @component
+ *
+ * @param {object} props
+ * @param {ZFCPManager} props.client
+ * @param {Manager} props.manager
+ */
+const DisksTable = ({ client, manager }) => {
+  const { cancellablePromise } = useCancellablePromise();
+
+  const columns = [
+    { id: "name", label: "Name" },
+    { id: "channel", label: "Channel ID" },
+    { id: "wwpn", label: "WWPN" },
+    { id: "lun", label: "LUN" }
+  ];
+
+  const columnValue = (disk, column) => disk[column.id];
+
+  const actions = (disk) => {
+    const controller = manager.getController(disk.channel);
+    if (!controller || controller.lunScan) return [];
+
+    return [
+      {
+        label: "Deactivate",
+        run: async () => await cancellablePromise(
+          client.deactivateDisk(controller, disk.wwpn, disk.lun)
+        )
+      }
+    ];
+  };
+
+  return (
+    <DevicesTable
+      devices={manager.disks}
+      columns={columns}
+      columnValue={columnValue}
+      actions={actions}
+    />
+  );
+};
+
+/**
+ * Section for zFCP controllers.
+ * @component
+ *
+ * @param {object} props
+ * @param {ZFCPManager} props.client
+ * @param {Manager} props.manager
+ * @param {function} props.load - Allows loading the zFCP data.
+ * @param {boolean} props.isLoading
+ */
+const ControllersSection = ({ client, manager, load = noop, isLoading = false }) => {
+  const [allowLUNScan, setAllowLUNScan] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const autoScan = await client.getAllowLUNScan();
+      setAllowLUNScan(autoScan);
+    };
+
+    load();
+  }, [client, setAllowLUNScan]);
+
+  const EmptyState = () => {
+    return (
+      <div className="stack">
+        <div className="bold">No zFCP controllers found</div>
+        <div>Please, try to read the zFCP devices again.</div>
+        <Button variant="primary" onClick={load}>Read zFCP devices</Button>
+      </div>
+    );
+  };
+
+  const Content = () => {
+    const AllowLUNScan = () => {
+      return (
+        <p>
+          The system is configured to perform automatic LUN scan. If a controller is running in
+          NPIV mode, then all its LUNs are automatically activated.
+        </p>
+      );
+    };
+
+    return (
+      <If
+        condition={manager.controllers.length === 0}
+        then={<EmptyState />}
+        else={
+          <>
+            <If condition={allowLUNScan} then={<AllowLUNScan />} />
+            <ControllersTable client={client} manager={manager} />
+          </>
+        }
+      />
+    );
+  };
+
+  return (
+    <Section title="Controllers">
+      <If
+        condition={isLoading}
+        then={<SectionSkeleton />}
+        else={
+          <If
+            condition={manager.controllers.length === 0}
+            then={<EmptyState />}
+            else={<Content />}
+          />
+        }
+      />
+    </Section>
+  );
+};
+
+/**
+ * Popup to show the zFCP disk form.
+ * @component
+ *
+ * @param {object} props
+ * @param {ZFCPManager} props.client
+ * @param {Manager} props.manager
+ * @param {function} props.onClose - Callback to be called when closing the popup.
+ */
+const DiskPopup = ({ client, manager, onClose = noop }) => {
+  const [isAcceptDisabled, setIsAcceptDisabled] = useState(false);
+  const { cancellablePromise } = useCancellablePromise();
+
+  const onSubmit = async (formData) => {
+    setIsAcceptDisabled(true);
+    const controller = manager.getController(formData.channel);
+    const result = await cancellablePromise(client.activateDisk(controller, formData.wwpn, formData.lun));
+    setIsAcceptDisabled(false);
+
+    if (result === 0) onClose();
+  };
+
+  const onValidate = (valid) => setIsAcceptDisabled(!valid);
+
+  const formId = "ZFCPDiskForm";
+
+  return (
+    <Popup isOpen title="Activate a zFCP disk">
+      <ZFCPDiskForm
+        id={formId}
+        luns={manager.getInactiveLUNs()}
+        onSubmit={onSubmit}
+        onValidate={onValidate}
+      />
+      <Popup.Actions>
+        <Popup.Confirm
+          form={formId}
+          type="submit"
+          isDisabled={isAcceptDisabled}
+        >
+          Accept
+        </Popup.Confirm>
+        <Popup.Cancel onClick={onClose} />
+      </Popup.Actions>
+    </Popup>
+  );
+};
+
+/**
+ * Section for zFCP disks.
+ * @component
+ *
+ * @param {object} props
+ * @param {ZFCPManager} props.client
+ * @param {Manager} props.manager
+ * @param {boolean} props.isLoading
+ */
+const DisksSection = ({ client, manager, isLoading = false }) => {
+  const [isActivateOpen, setIsActivateOpen] = useState(false);
+
+  const openActivate = () => setIsActivateOpen(true);
+  const closeActivate = () => setIsActivateOpen(false);
+
+  const EmptyState = () => {
+    const NoActiveControllers = () => {
+      return (
+        <div>Please, try to activate a zFCP controller.</div>
+      );
+    };
+
+    const NoActiveDisks = () => {
+      return (
+        <>
+          <div>Please, try to activate a zFCP disk.</div>
+          <Button variant="primary" onClick={openActivate}>Activate zFCP disk</Button>
+        </>
+      );
+    };
+
+    return (
+      <div className="stack">
+        <div className="bold">No zFCP disks found</div>
+        <If
+          condition={manager.getActiveControllers().length === 0}
+          then={<NoActiveControllers />}
+          else={<NoActiveDisks />}
+        />
+      </div>
+    );
+  };
+
+  const Content = () => {
+    const isDisabled = manager.getInactiveLUNs().length === 0;
+
+    return (
+      <>
+        <Toolbar className="no-stack-gutter">
+          <ToolbarContent alignment="alignRight">
+            <ToolbarItem alignment={{ default: "alignRight" }}>
+              <Button onClick={openActivate} isDisabled={isDisabled}>Activate new disk</Button>
+            </ToolbarItem>
+          </ToolbarContent>
+        </Toolbar>
+
+        <DisksTable client={client} manager={manager} />
+      </>
+    );
+  };
+
+  return (
+    <Section title="Disks">
+      <If
+        condition={isLoading}
+        then={<SectionSkeleton />}
+        else={
+          <If
+            condition={manager.disks.length === 0}
+            then={<EmptyState />}
+            else={<Content />}
+          />
+        }
+      />
+      <If
+        condition={isActivateOpen}
+        then={
+          <DiskPopup
+            client={client}
+            manager={manager}
+            onClose={closeActivate}
+          />
+        }
+      />
+    </Section>
+  );
+};
+
+const reducer = (state, action) => {
+  const { type, payload } = action;
+
+  switch (type) {
+    case "START_LOADING": {
+      return { ...state, isLoading: true };
+    }
+
+    case "STOP_LOADING": {
+      return { ...state, isLoading: false };
+    }
+
+    case "SET_MANAGER": {
+      const { manager } = payload;
+      return { ...state, manager };
+    }
+
+    case "UPDATE_CONTROLLER": {
+      state.manager.updateController(payload.controller);
+      return { ...state };
+    }
+
+    case "ADD_DISK": {
+      const { disk } = payload;
+      state.manager.addDisk(disk);
+      return { ...state };
+    }
+
+    case "UPDATE_DISK": {
+      const { disk } = payload;
+      state.manager.updateDisk(disk);
+      return { ...state };
+    }
+
+    case "REMOVE_DISK": {
+      const { disk } = payload;
+      state.manager.removeDisk(disk);
+      return { ...state };
+    }
+
+    default: {
+      return state;
+    }
+  }
+};
+
+const initialState = {
+  manager: new Manager(),
+  isLoading: true
+};
+
+/**
+ * Page for managing zFCP devices.
+ * @component
+ */
+export default function ZFCPPage() {
+  const { storage: client } = useInstallerClient();
+  const navigate = useNavigate();
+  const { cancellablePromise } = useCancellablePromise();
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const load = useCallback(async () => {
+    dispatch({ type: "START_LOADING" });
+    await cancellablePromise(client.zfcp.probe());
+    const controllers = await cancellablePromise(client.zfcp.getControllers());
+    const disks = await cancellablePromise(client.zfcp.getDisks());
+    const luns = [];
+    for (const controller of controllers) {
+      const wwpns = await cancellablePromise(client.zfcp.getWWPNs(controller));
+      for (const wwpn of wwpns) {
+        const all = await cancellablePromise(client.zfcp.getLUNs(controller, wwpn));
+        for (const lun of all) {
+          luns.push({ channel: controller.channel, wwpn, lun });
+        }
+      }
+    }
+    const manager = new Manager(controllers, disks, luns);
+    dispatch({ type: "SET_MANAGER", payload: { manager } });
+    dispatch({ type: "STOP_LOADING" });
+  }, [client.zfcp, cancellablePromise]);
+
+  useEffect(() => {
+    load().catch(console.error);
+  }, [load]);
+
+  useEffect(() => {
+    const subscriptions = [];
+
+    const subscribe = async () => {
+      const action = (type, payload) => dispatch({ type, payload });
+
+      subscriptions.push(
+        await client.zfcp.onControllerChanged(c => action("UPDATE_CONTROLLER", { controller: c })),
+        await client.zfcp.onDiskAdded(d => action("ADD_DISK", { disk: d })),
+        await client.zfcp.onDiskChanged(d => action("UPDATE_DISK", { disk: d })),
+        await client.zfcp.onDiskRemoved(d => action("REMOVE_DISK", { disk: d }))
+      );
+    };
+
+    const unsubscribe = () => {
+      subscriptions.forEach(fn => fn());
+    };
+
+    subscribe();
+    return unsubscribe;
+  }, [client.zfcp, cancellablePromise]);
+
+  return (
+    <Page title="Storage zFCP" icon="hard_drive">
+      <MainActions>
+        <Button isLarge variant="secondary" onClick={() => navigate("/storage")}>Back</Button>
+      </MainActions>
+
+      <ControllersSection
+        client={client.zfcp}
+        manager={state.manager}
+        load={load}
+        isLoading={state.isLoading}
+      />
+      <DisksSection
+        client={client.zfcp}
+        manager={state.manager}
+        isLoading={state.isLoading}
+      />
+    </Page>
+  );
+}

--- a/web/src/components/storage/ZFCPPage.jsx
+++ b/web/src/components/storage/ZFCPPage.jsx
@@ -120,18 +120,6 @@ class Manager {
   }
 
   /**
-   * Updates the info about the given disk.
-   * @param {Disk} disk
-   * @returns {void}
-   */
-  updateDisk(disk) {
-    const index = this.findDisk(disk.channel, disk.wwpn, disk.lun);
-    if (index === -1) return;
-
-    this.disks[index] = disk;
-  }
-
-  /**
    * Removes the given disk from the list of disks.
    * @param {Disk} disk
    * @returns {void}
@@ -638,12 +626,6 @@ const reducer = (state, action) => {
       return { ...state };
     }
 
-    case "UPDATE_DISK": {
-      const { disk } = payload;
-      state.manager.updateDisk(disk);
-      return { ...state };
-    }
-
     case "REMOVE_DISK": {
       const { disk } = payload;
       state.manager.removeDisk(disk);
@@ -724,7 +706,6 @@ export default function ZFCPPage() {
           }
         }),
         await client.zfcp.onDiskAdded(d => action("ADD_DISK", { disk: d })),
-        await client.zfcp.onDiskChanged(d => action("UPDATE_DISK", { disk: d })),
         await client.zfcp.onDiskRemoved(d => action("REMOVE_DISK", { disk: d }))
       );
     };

--- a/web/src/components/storage/ZFCPPage.jsx
+++ b/web/src/components/storage/ZFCPPage.jsx
@@ -484,7 +484,9 @@ const DiskPopup = ({ client, manager, onClose = noop }) => {
     if (result === 0) onClose();
   };
 
-  const onValidate = (valid) => setIsAcceptDisabled(!valid);
+  const onLoading = (isLoading) => {
+    setIsAcceptDisabled(isLoading);
+  };
 
   const formId = "ZFCPDiskForm";
 
@@ -494,7 +496,7 @@ const DiskPopup = ({ client, manager, onClose = noop }) => {
         id={formId}
         luns={manager.getInactiveLUNs()}
         onSubmit={onSubmit}
-        onValidate={onValidate}
+        onLoading={onLoading}
       />
       <Popup.Actions>
         <Popup.Confirm

--- a/web/src/components/storage/ZFCPPage.test.jsx
+++ b/web/src/components/storage/ZFCPPage.test.jsx
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen, waitFor, within } from "@testing-library/react";
+import { installerRender, mockComponent } from "~/test-utils";
+import { createClient } from "~/client";
+import { ZFCPPage } from "~/components/storage";
+
+jest.mock("~/client");
+
+jest.mock("@patternfly/react-core", () => {
+  const original = jest.requireActual("@patternfly/react-core");
+
+  return {
+    ...original,
+    Skeleton: mockComponent("PFSkeleton")
+  };
+});
+
+const controllers = [
+  { id: "1", channel: "0.0.fa00", active: false, lunScan: false },
+  { id: "2", channel: "0.0.fb00", active: true, lunScan: false }
+];
+
+const disks = [
+  { id: "1", name: "/dev/sda", channel: "0.0.fb00", wwpn: "0x500507630703d3b3", lun: "0x0000000000000001" },
+  { id: "2", name: "/dev/sdb", channel: "0.0.fb00", wwpn: "0x500507630703d3b3", lun: "0x0000000000000002" }
+];
+
+const defaultClient = {
+  probe: jest.fn().mockResolvedValue(),
+  getControllers: jest.fn().mockResolvedValue(controllers),
+  getDisks: jest.fn().mockResolvedValue(disks),
+  getWWPNs: jest.fn().mockResolvedValue([]),
+  getLUNs: jest.fn().mockResolvedValue([]),
+  onControllerChanged: jest.fn().mockResolvedValue(jest.fn()),
+  onDiskAdded: jest.fn().mockResolvedValue(jest.fn()),
+  onDiskChanged: jest.fn().mockResolvedValue(jest.fn()),
+  onDiskRemoved: jest.fn().mockResolvedValue(jest.fn()),
+  activateController: jest.fn().mockResolvedValue(0),
+  getAllowLUNScan: jest.fn().mockResolvedValue(false),
+  activateDisk: jest.fn().mockResolvedValue(0),
+  deactivateDisk: jest.fn().mockResolvedValue(0)
+};
+
+let client;
+
+beforeEach(() => {
+  client = { ...defaultClient };
+  createClient.mockImplementation(() => ({ storage: { zfcp: client } }));
+});
+
+it("loads the zFCP devices", async () => {
+  installerRender(<ZFCPPage />);
+
+  screen.getAllByText(/PFSkeleton/);
+  expect(screen.queryAllByRole("grid").length).toBe(0);
+  await waitFor(() => expect(client.probe).toHaveBeenCalled());
+  expect(screen.getAllByRole("grid").length).toBe(2);
+});
+
+it("renders two sections: Controllers and Disks", async () => {
+  installerRender(<ZFCPPage />);
+
+  await screen.findByRole("heading", { name: "Controllers" });
+  await screen.findByRole("heading", { name: "Disks" });
+});
+
+describe("if allow-lun-scan is activated", () => {
+  beforeEach(() => {
+    client.getAllowLUNScan = jest.fn().mockResolvedValue(true);
+  });
+
+  it("renders an explanation about allow-lun-scan", async () => {
+    installerRender(<ZFCPPage />);
+
+    await screen.findByText(/is configured to perform automatic LUN scan/);
+  });
+});
+
+describe("if allow-lun-scan is not activated", () => {
+  beforeEach(() => {
+    client.getAllowLUNScan = jest.fn().mockResolvedValue(false);
+  });
+
+  it("does not render an explanation about allow-lun-scan", async () => {
+    installerRender(<ZFCPPage />);
+
+    await waitFor(() => expect(screen.queryByText(/is configured to perform automatic LUN scan/)).toBeNull());
+  });
+});
+
+describe("if there are controllers", () => {
+  it("renders the information for each controller", async () => {
+    installerRender(<ZFCPPage />);
+
+    await screen.findByRole("row", { name: "0.0.fa00 Deactivated -" });
+    await screen.findByRole("row", { name: "0.0.fb00 Activated No" });
+  });
+
+  it("allows activating the controller", async () => {
+    const { user } = installerRender(<ZFCPPage />);
+
+    const row = await screen.findByRole("row", { name: /^0.0.fa00/ });
+    const actions = within(row).getByRole("button", { name: "Actions" });
+    await user.click(actions);
+    const activate = within(row).getByRole("menuitem", { name: "Activate" });
+    await user.click(activate);
+
+    await waitFor(() => expect(client.activateController).toHaveBeenCalledWith(controllers[0]));
+  });
+
+  it("does not allow activating an already activated controller", async () => {
+    installerRender(<ZFCPPage />);
+
+    const row = await screen.findByRole("row", { name: /^0.0.fb00/ });
+    await waitFor(() => expect(within(row).queryByRole("button", { name: "Actions" })).toBeNull());
+  });
+});
+
+describe("if there are not controllers", () => {
+  beforeEach(() => {
+    client.getControllers = jest.fn().mockResolvedValue([]);
+  });
+
+  it("does not render controllers information", async () => {
+    installerRender(<ZFCPPage />);
+
+    await waitFor(() => expect(screen.queryAllByRole("row", { name: /^0\.0\.f/ }).length).toBe(0));
+  });
+
+  it("renders a button for reading zFCP devices", async () => {
+    installerRender(<ZFCPPage />);
+
+    await screen.findByText(/No zFCP controllers found/);
+    await screen.findByRole("button", { name: /Read zFCP devices/ });
+  });
+
+  it("loads the zFCP devices if the button is clicked", async () => {
+    const { user } = installerRender(<ZFCPPage />);
+
+    const button = await screen.findByRole("button", { name: /Read zFCP devices/ });
+
+    client.getControllers = jest.fn().mockResolvedValue(controllers);
+
+    await user.click(button);
+    await waitFor(() => expect(client.probe).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getAllByRole("row", { name: /^0\.0\.f/ }).length).toBe(2));
+    await waitFor(() => expect(screen.getAllByRole("row", { name: /^\/dev\// }).length).toBe(2));
+  });
+});
+
+describe("if there are disks", () => {
+  beforeEach(() => {
+    client.getWWPNs = jest.fn().mockResolvedValue(["0x500507630703d3b3"]);
+    client.getLUNs = jest.fn().mockResolvedValue(
+      ["0x0000000000000001", "0x0000000000000002", "0x0000000000000003"]
+    );
+  });
+
+  it("renders the information for each disk", async () => {
+    installerRender(<ZFCPPage />);
+
+    await screen.findByRole("row", { name: "/dev/sda 0.0.fb00 0x500507630703d3b3 0x0000000000000001" });
+    await screen.findByRole("row", { name: "/dev/sdb 0.0.fb00 0x500507630703d3b3 0x0000000000000002" });
+  });
+
+  it("renders a button for activating a disk", async () => {
+    installerRender(<ZFCPPage />);
+
+    const button = await screen.findByRole("button", { name: "Activate new disk" });
+    expect(button).toBeEnabled();
+  });
+
+  describe("if there are not inactive LUNs", () => {
+    beforeEach(() => {
+      client.getWWPNs = jest.fn().mockResolvedValue(["0x500507630703d3b3"]);
+      client.getLUNs = jest.fn().mockResolvedValue(["0x0000000000000001", "0x0000000000000002"]);
+    });
+
+    it("disables the button for activating a disk", async () => {
+      installerRender(<ZFCPPage />);
+
+      const button = await screen.findByRole("button", { name: "Activate new disk" });
+      expect(button).toBeDisabled();
+    });
+  });
+
+  describe("if the controller is not using auto LUN scan", () => {
+    beforeEach(() => {
+      client.getControllers = jest.fn().mockResolvedValue([
+        { id: "1", channel: "0.0.fb00", active: true, lunScan: false }
+      ]);
+    });
+
+    it("allows deactivating a disk", async () => {
+      const { user } = installerRender(<ZFCPPage />);
+
+      const row = await screen.findByRole("row", { name: /^\/dev\/sda/ });
+      const actions = within(row).getByRole("button", { name: "Actions" });
+      await user.click(actions);
+      const deactivate = within(row).getByRole("menuitem", { name: "Deactivate" });
+      await user.click(deactivate);
+
+      const [controller] = await client.getControllers();
+      const [disk] = await client.getDisks();
+
+      await waitFor(() => expect(client.deactivateDisk).toHaveBeenCalledWith(controller, disk.wwpn, disk.lun));
+    });
+  });
+
+  describe("if the controller is using auto LUN scan", () => {
+    beforeEach(() => {
+      client.getControllers = jest.fn().mockResolvedValue([
+        { id: "1", channel: "0.0.fb00", active: true, lunScan: true }
+      ]);
+    });
+
+    it("does not allow deactivating a disk", async () => {
+      installerRender(<ZFCPPage />);
+
+      const row = await screen.findByRole("row", { name: /^\/dev\/sda/ });
+      waitFor(() => expect(within(row).queryByRole("button", { name: "Actions" })).toBeNull());
+    });
+  });
+});
+
+describe("if there are not disks", () => {
+  beforeEach(() => {
+    client.getDisks = jest.fn().mockResolvedValue([]);
+  });
+
+  it("does not render disks information", async () => {
+    installerRender(<ZFCPPage />);
+
+    await waitFor(() => expect(screen.queryAllByRole("row", { name: /^\/dev\// }).length).toBe(0));
+  });
+
+  it("renders a button for activating a disk", async () => {
+    installerRender(<ZFCPPage />);
+
+    await screen.findByText("No zFCP disks found");
+    await screen.findByText(/try to activate a zFCP disk/);
+    screen.findByRole("button", { name: "Activate zFCP disk" });
+  });
+
+  describe("and there is no active controller", () => {
+    beforeEach(() => {
+      client.getControllers = jest.fn().mockResolvedValue([controllers[0]]);
+    });
+
+    it("does not render a button for activating a disk", async () => {
+      installerRender(<ZFCPPage />);
+
+      await screen.findByText("No zFCP disks found");
+      await screen.findByText(/try to activate a zFCP controller/);
+      await waitFor(() => expect(screen.queryByRole("button", { name: "Activate zFCP disk" })).toBeNull());
+    });
+  });
+});
+
+describe("if the button for adding a disk is used", () => {
+  beforeEach(() => {
+    client.getWWPNs = jest.fn().mockResolvedValue(["0x500507630703d3b3"]);
+    client.getLUNs = jest.fn().mockResolvedValue(
+      ["0x0000000000000001", "0x0000000000000002", "0x0000000000000003"]
+    );
+  });
+
+  it("opens a popup with the form for a new disk", async () => {
+    const { user } = installerRender(<ZFCPPage />);
+
+    const button = await screen.findByRole("button", { name: "Activate new disk" });
+    await user.click(button);
+
+    const popup = await screen.findByRole("dialog");
+    within(popup).getByText("Activate a zFCP disk");
+
+    const form = screen.getByRole("form");
+    within(form).getByRole("combobox", { name: "Channel ID" });
+    within(form).getByRole("combobox", { name: "WWPN" });
+    within(form).getByRole("combobox", { name: "LUN" });
+  });
+
+  it("only allows to select an active controller with inactive LUNs", async () => {
+    const { user } = installerRender(<ZFCPPage />);
+
+    const button = await screen.findByRole("button", { name: "Activate new disk" });
+    await user.click(button);
+    const popup = await screen.findByRole("dialog");
+    within(popup).getByText("Activate a zFCP disk");
+    const form = screen.getByRole("form");
+
+    const channelSelector = within(form).getByRole("combobox", { name: "Channel ID" });
+    expect(within(channelSelector).getAllByRole("option").length).toBe(1);
+    within(channelSelector).getByRole("option", { name: "0.0.fb00" });
+  });
+
+  it("submits the form if accept is clicked", async () => {
+    const { user } = installerRender(<ZFCPPage />);
+
+    const button = await screen.findByRole("button", { name: "Activate new disk" });
+    await user.click(button);
+    const popup = await screen.findByRole("dialog");
+
+    const accept = await within(popup).findByRole("button", { name: "Accept" });
+    await user.click(accept);
+
+    expect(client.activateDisk).toHaveBeenCalledWith(
+      controllers[1], "0x500507630703d3b3", "0x0000000000000003"
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes the popup if cancel is clicked", async () => {
+    const { user } = installerRender(<ZFCPPage />);
+
+    const button = await screen.findByRole("button", { name: "Activate new disk" });
+    await user.click(button);
+    const popup = await screen.findByRole("dialog");
+
+    const cancel = await within(popup).findByRole("button", { name: "Cancel" });
+    await user.click(cancel);
+
+    expect(client.activateDisk).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/storage/ZFCPPage.test.jsx
+++ b/web/src/components/storage/ZFCPPage.test.jsx
@@ -70,11 +70,16 @@ beforeEach(() => {
 });
 
 it("loads the zFCP devices", async () => {
+  client.getWWPNs = jest.fn().mockResolvedValue(["0x500507630703d3b3", "0x500507630704d3b3"]);
   installerRender(<ZFCPPage />);
 
   screen.getAllByText(/PFSkeleton/);
   expect(screen.queryAllByRole("grid").length).toBe(0);
   await waitFor(() => expect(client.probe).toHaveBeenCalled());
+  await waitFor(() => expect(client.getLUNs).toHaveBeenCalledWith(controllers[1], "0x500507630703d3b3"));
+  await waitFor(() => expect(client.getLUNs).toHaveBeenCalledWith(controllers[1], "0x500507630704d3b3"));
+  await waitFor(() => expect(client.getLUNs).not.toHaveBeenCalledWith(controllers[0], "0x500507630703d3b3"));
+  await waitFor(() => expect(client.getLUNs).not.toHaveBeenCalledWith(controllers[0], "0x500507630704d3b3"));
   expect(screen.getAllByRole("grid").length).toBe(2);
 });
 

--- a/web/src/components/storage/index.js
+++ b/web/src/components/storage/index.js
@@ -27,6 +27,8 @@ export { default as ProposalVolumes } from "./ProposalVolumes";
 export { default as DASDPage } from "./DASDPage";
 export { default as DASDTable } from "./DASDTable";
 export { default as DASDFormatProgress } from "./DASDFormatProgress";
+export { default as ZFCPPage } from "./ZFCPPage";
+export { default as ZFCPDiskForm } from "./ZFCPDiskForm";
 export { default as ISCSIPage } from "./ISCSIPage";
 export { default as DeviceSelector } from "./DeviceSelector";
 export { default as VolumeForm } from "./VolumeForm";

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -41,7 +41,7 @@ import Main from "~/Main";
 import DevServerWrapper from "~/DevServerWrapper";
 import { Overview } from "~/components/overview";
 import { ProductSelectionPage } from "~/components/software";
-import { ProposalPage as StoragePage, DASDPage, ISCSIPage } from "~/components/storage";
+import { ProposalPage as StoragePage, ISCSIPage, DASDPage, ZFCPPage } from "~/components/storage";
 import { UsersPage } from "~/components/users";
 import { L10nPage } from "~/components/l10n";
 import { NetworkPage } from "~/components/network";
@@ -85,6 +85,7 @@ root.render(
                   <Route path="/storage" element={<StoragePage />} />
                   <Route path="/storage/iscsi" element={<ISCSIPage />} />
                   <Route path="/storage/dasd" element={<DASDPage />} />
+                  <Route path="/storage/zfcp" element={<ZFCPPage />} />
                   <Route path="/network" element={<NetworkPage />} />
                   <Route path="/users" element={<UsersPage />} />
                   <Route path="/issues" element={<IssuesPage />} />


### PR DESCRIPTION
## Problem

Agama already provides a D-Bus API for managing zFCP devices, see https://github.com/openSUSE/agama/pull/594 and https://github.com/openSUSE/agama/pull/626. But there is no UI yet for configuring zFCP.

## Solution

Add a new page for managing zFCP.

Requires https://github.com/yast/yast-s390/pull/107.

Note: The target of this PR is  the *zfcp* feature branch. 

## Testing

* Added unit test
* Tested manually

## Screenshots

<details>
<summary>Show/Hide</summary>

![localhost_8080_ (5)](https://github.com/openSUSE/agama/assets/1112304/a4221896-958b-4554-b367-f1c68c768046)

![localhost_8080_ (6)](https://github.com/openSUSE/agama/assets/1112304/a336e9f2-61b2-4d11-a8a4-9369c114c2d0)

![localhost_8080_ (10)](https://github.com/openSUSE/agama/assets/1112304/3bf8924f-13d1-43f0-bec1-bd240ebcb46c)

![localhost_8080_ (9)](https://github.com/openSUSE/agama/assets/1112304/ce545e75-f971-4292-9104-f6d96deb8278)

![localhost_8080_ (8)](https://github.com/openSUSE/agama/assets/1112304/ad3bc4fe-d835-4191-9f81-302181b82cbc)

![localhost_8080_ (11)](https://github.com/openSUSE/agama/assets/1112304/a9fe5f72-8a8b-46d7-8c48-ba68c373195e)

</details>
