### PR TITLE
Draft for FCoE D-Bus interface

### DIFF
--- a/service/lib/agama/dbus/storage/fcoe_interface.rb
+++ b/service/lib/agama/dbus/storage/fcoe_interface.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dbus"
+require "agama/dbus/base_object"
+require "forwardable"
+
+module Agama
+  module DBus
+    module Storage
+      # Class representing [...]
+      class FcoeInterface < BaseObject
+        # @return [Agama::Storage::Fcoe::Manager]
+        attr_reader :fcoe_manager
+
+        # @return [Agama::Storage::Fcoe::Interface]
+        attr_reader :interface
+
+        # Constructor
+        #
+        # @param fcoe_manager [Agama::Storage::Fcoe::Manager]
+        # @param interface [Agama::Storage::Fcoe::Interface]
+        # @param path [DBus::ObjectPath] Path in which the object is exported
+        # @param logger [Logger, nil]
+        def initialize(fcoe_manager, interface, path, logger: nil)
+          super(path, logger: logger)
+
+          @fcoe_manager = fcoe_manager
+          @interface = interface
+        end
+
+        def_delegators :interface, :parent_device, :vlan_id, :model, :driver,
+          :dcb_capable, :fcoe_vlan_possible, :fcoe_vlan
+
+        def fcoe_vlan_device
+          fcoe_vlan ? fcoe_vlan.device : ""
+        end
+
+        def fcoe_service
+          !!(fcoe_vlan&.fcoe_service)
+        end
+
+        def dcb_service
+          !!(fcoe_vlan&.dcb_service)
+        end
+
+        def auto_vlan
+          !!(fcoe_vlan&.auto_vlan)
+        end
+
+        # Sets a new value for the dcb_service attribute
+        #
+        # @param value [String]
+        def dcb_service=(value)
+          # YaST somehow validates dcb_required in the form. A warning pop-up is displayed as soon
+          # as the selector is set to "yes" if the card is not DCB capable. That happens before
+          # clicking on "next", but the user can ignore it and store the "wrong" value.
+          #
+          # For the time being, let's do something similar - control the case at UI level and allow
+          # any value at D-Bus level. We may reconsider that in the future and do something like:
+          # raise ::DBus::Error, "Invalid dcb_required" unless valid_dcb_required?(value)
+
+          fcoe_manager.update_fcoe_vlan(interface, :dcb_service, value)
+        end
+
+        # Sets a new value for the fcoe_service attribute
+        #
+        # @param value [String]
+        def fcoe_service=(value)
+          fcoe_manager.update_fcoe_vlan(interface, :fcoe_service, value)
+        end
+
+        # Sets a new value for the auto_vlan attribute
+        #
+        # @param value [String]
+        def auto_vlan=(value)
+          fcoe_manager.update_fcoe_vlan(interface, :auto_vlan, value)
+        end
+
+        # Sets the associated interface
+        #
+        # @note A properties changed signal is always emitted.
+        #
+        # @param value [Agama::Storage::Fcoe::Interface]
+        def interface=(value)
+          @interface = value
+
+          properties = interfaces_and_properties[FCOE_IFACE_INTERFACE]
+          dbus_properties_changed(FCOE_IFACE_INTERFACE, properties, [])
+        end
+
+        # @return [Integer] 0 on success, 1 if creating an FCoE VLAN is not supported on that
+        #   interface, 2 if creating the VLAN makes no sense in the current context (eg. there is
+        #   already a FCoE VLAN for another VLAN of this interface), 3 if any of the steps of
+        #   the operation failed
+        def create_fcoe_vlan
+          result = fcoe_manager.create_fcoe_vlan(interface)
+          return unless result.zero?
+
+          self.interface = interface
+        end
+
+        FCOE_IFACE_INTERFACE = "org.opensuse.Agama.Storage1.FCOE.Interface"
+        private_constant :FCOE_IFACE_INTERFACE
+
+        dbus_interface FCOE_IFACE_INTERFACE do
+          dbus_reader(:parent_device, "s") # eth1
+          dbus_reader(:vlan_id, "s") # "500", "0" if no VLAN is used
+          dbus_reader(:model, "s") 
+          dbus_reader(:driver, "s") 
+          dbus_reader(:dcb_capable, "b") 
+          # FCoE VLAN
+          dbus_reader(:fcoe_vlan_possible, "b")
+          dbus_reader(:fcoe_vlan_device, "s") # "eth1.500-fcoe" or ""
+          # Configuration of the FCoE VLAN
+          dbus_accessor(:fcoe_service, "b")
+          dbus_accessor(:dcb_service, "b")
+          dbus_accessor(:auto_vlan, "b")
+          # Management of the FCoE VLAN
+          dbus_method(:CreateFcoeVlan, "out result:u") { create_fcoe_vlan }
+          dbus_method(:RemoveFcoeVlan, "out result:u") { remove_fcoe_vlan }
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/dbus/storage/fcoe_interfaces_tree.rb
+++ b/service/lib/agama/dbus/storage/fcoe_interfaces_tree.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/dbus/with_path_generator"
+require "agama/dbus/storage/fcoe_interface"
+
+module Agama
+  module DBus
+    module Storage
+      # Class representing the FCoE interfaces tree exported on D-Bus
+      class FcoeInterfacesTree
+        include WithPathGenerator
+
+        ROOT_PATH = "/org/opensuse/Agama/Storage1/fcoe_interfaces"
+        path_generator ROOT_PATH
+
+        # Constructor
+        #
+        # @param service [::DBus::Service]
+        # @param fcoe_manager Agama::Storage::Fcoe::Manager]
+        # @param logger [Logger, nil]
+        def initialize(service, fcoe_manager, logger: nil)
+          @service = service
+          @fcoe_manager = fcoe_manager
+          @logger = logger
+        end
+
+        # Updates the D-Bus tree according to the given FCoE interface objects
+        #
+        # The current D-Bus nodes are all unexported.
+        #
+        # @param ifaces [Array<Agama::Storage::Fcoe::Interface>]
+        def update(ifaces)
+          unexport_interfaces
+          ifaces.each { |i| export_object(i) }
+        end
+
+      private
+
+        # @return [::DBus::Service]
+        attr_reader :service
+
+        # @return [Agama::Storage::Fcoe::Manager]
+        attr_reader :fcoe_manager
+
+        # @return [Logger]
+        attr_reader :logger
+
+        # Unexports the currently exported D-Bus objects
+        def unexport_interfaces
+          dbus_objects.each { |o| service.unexport(o) }
+        end
+
+        # Exports a D-Bus node for the given FCoE Interface
+        #
+        # @param iscsi_node [Agama::Storage::Fcoe::Interface]
+        def add_object(iface)
+          dbus_object = DBus::Storage::FcoeInterface.new(
+            fcoe_manager, iface, next_path, logger: logger
+          )
+          service.export(dbus_object)
+        end
+
+        # All exported D-Bus objects
+        #
+        # @return [Array<Agama::DBus::Storage::FcoeInterface>]
+        def dbus_objects
+          root = service.get_node(ROOT_PATH, create: false)
+          return [] unless root
+
+          root.descendant_objects
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/fcoe.rb
+++ b/service/lib/agama/storage/fcoe.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Agama
+  module Storage
+    # Module for FCoE
+    module Fcoe
+    end
+  end
+end
+
+require "agama/storage/fcoe/manager"
+require "agama/storage/fcoe/interface"
+require "agama/storage/fcoe/fcoe_vlan"

--- a/service/lib/agama/storage/fcoe/fcoe_vlan.rb
+++ b/service/lib/agama/storage/fcoe/fcoe_vlan.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Agama
+  module Storage
+    module Fcoe
+      # Blah
+      class FcoeVlan
+        # Device name of the VLAN interface (eg. "eth1.500-fcoe")
+        #
+        # @return [String] empty string if there is no network interface for the VLAN
+        attr_accessor :device
+
+        # Whether FCoE service is enabled at the ethernet port
+        #
+        # This corresponds to the setting FCOE_ENABLE at /etc/fcoe/cfg-xxx
+        #
+        # @return [Boolean]
+        attr_accessor :fcoe_service
+        alias_method :fcoe_service?, :fcoe_service
+
+        # Whether DCB service is required at the ethernet port
+        #
+        # This corresponds to the setting DCB_REQUIRED at /etc/fcoe/cfg-xxx
+        #
+        # @return [Boolean]
+        attr_accessor :dcb_service
+        alias_method :dcb_service?, :dcb_service
+
+        # Whether VLAN discovery should be handled by fcoemon
+        #
+        # This corresponds to the setting AUTO_VLAN at /etc/fcoe/cfg-xxx
+        #
+        # @return [Boolean]
+        attr_accessor :auto_vlan
+        alias_method :auto_vlan?, :auto_vlan
+
+        # Whether there is an active network interface for the FCoE VLAN
+        #
+        # @return [Boolean]
+        def up?
+          device != ""
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/fcoe/interface.rb
+++ b/service/lib/agama/storage/fcoe/interface.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Agama
+  module Storage
+    module Fcoe
+      # Blah
+      class Interface
+        # @return [Integer]
+        attr_accessor :yast_index
+
+        # Device name of the network card (eg. "eth0")
+        #
+        # @return [String]
+        attr_accessor :parent_device
+
+        # VLAN identifier
+        #
+        # @return [String] "0" if the interface is not a VLAN
+        attr_accessor :vlan_id
+
+        # Model of the network card
+        #
+        # @return [String]
+        attr_accessor :model
+
+        # Driver used by the interface
+        #
+        # @return [String]
+        attr_accessor :driver
+
+        # Whether the interface has DCB (Data Center Bridging) capabilities
+        #
+        # @return [Boolean]
+        attr_accessor :dcb_capable
+        alias_method :dcb_capable?, :dcb_capable
+
+        # Whether is possible to create an FCoE VLAN for the interface
+        #
+        # @return [Boolean]
+        attr_accessor :fcoe_vlan_supported
+        alias_method :fcoe_vlan_supported?, :fcoe_vlan_supported
+
+        # Information about the possible FCoE VLAN for the interface
+        #
+        # @return [FcoeVlan, nil] nil if #fcoe_vlan_supported? is false
+        attr_accessor :fcoe_vlan
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/fcoe/manager.rb
+++ b/service/lib/agama/storage/fcoe/manager.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2fcoe_client/inst_client"
+require "y2fcoe_client/actions"
+
+Yast.import "FcoeClient"
+
+module Agama
+  module Storage
+    module Fcoe
+      # Manager for FCoE
+      class Manager
+        # Constructor
+        #
+        # @param logger [Logger, nil]
+        def initialize(logger: nil)
+          @logger = logger || ::Logger.new($stdout)
+          @inst_client = Y2FcoeClient::InstClient.new
+          @interfaces = []
+
+          @on_probe_callbacks = []
+          @on_interfaces_change_callbacks = []
+        end
+
+        # Probes FCoE
+        #
+        # Callbacks are called at the end, see {#on_probe}.
+        def probe
+          logger.info "Probing FCoE"
+          inst_client.read(silent: true)
+
+          @interfaces = Yast::FcoeClient.GetNetworkCards.map.with_index do |card, idx|
+            iface_from(card, idx)
+          end
+          @on_probe_callbacks.each(&:call)
+        end
+
+        def create_fcoe_vlan(iface)
+          return 1 unless iface.fcoe_vlan_possible?
+
+          action = Y2FcoeClient::Actions::Create.new(iface.yast_index)
+          issues = action.validate
+          return 2 if issues.error?
+
+          issues = action.execute
+          return 3 if issues.any?
+
+          iface.fcoe_vlan = fcoe_vlan_from(Yast::FcoeClient.GetNetworkCards[iface.yast_index])
+          write
+          0
+        end
+
+        def remove_fcoe_vlan(iface)
+          return 1 unless iface.fcoe_vlan&.up?
+
+          action = Y2FcoeClient::Actions::Remove.new(iface.yast_index)
+          issues = action.execute
+          return 2 if issues.any?
+
+          iface.fcoe_vlan = fcoe_vlan_from(Yast::FcoeClient.GetNetworkCards[iface.yast_index])
+          write
+          0
+        end
+
+        def update_fcoe_vlan(iface, attr, value)
+          iface.fcoe_vlan.public_send(":#{attr}=", value)
+
+          values = Yast::FcoeClient.GetNetworkCards[iface.yast_index]
+          key = FCOE_VLAN_CONFIG_MAPPING[attr].to_s
+          values[key] = value ? "yes" : "no"
+          Yast::FcoeClient.SetNetworkCardsValue(iface.yast_index, values)
+          Yast::FcoeClient.SetModified(true)
+          write
+        end
+
+        private
+
+        def write
+          # FIXME: this always adds fcoe-utils and yast2-fcoe-client to the resolvables
+          inst_client.write
+          @on_interfaces_change_callbacks.each(&:call)
+        end
+
+        # Attributes used to configure the FCoE VLAN
+        FCOE_VLAN_CONFIG_MAPPING = {
+          fcoe_service: :fcoe_enable,
+          dcb_service:  :dcb_required,
+          auto_vlan:    :auto_vlan
+        }
+
+        def iface_from(card, index)
+          Interface.new.tap do |iface|
+            # Needed for mapping with Yast::FcoeClient
+            iface.yast_index    = index
+
+            # General information of the interface
+            iface.parent_device = str_value(card,  :dev_name)
+            iface.vlan_id       = str_value(card,  :vlan_interface)
+            iface.fcf_mac       = str_value(card,  :mac_addr)
+            iface.model         = str_value(card,  :device)
+            iface.driver        = str_value(card,  :driver)
+            iface.dcb_capable   = bool_value(card, :dcb_capable)
+
+            if card["fcoe_vlan"] == Yast::FcoeClient.NOT_AVAILABLE
+              iface.fcoe_vlan_supported = false
+            else
+              iface.fcoe_vlan_supported = true
+              iface.fcoe_vlan = fcoe_vlan_from(card)
+            end
+          end
+        end
+
+        def fcoe_vlan_from(card)
+          FcoeVlan.new.tap do |vlan|
+            vlan.device =
+              if card["fcoe_vlan"] == Yast::FcoeClient.NOT_CONFIGURED
+                ""
+              else
+                card["fcoe_vlan"]
+              end
+
+            FCOE_VLAN_CONFIG_MAPPING.each_pair do |attr, field|
+              iface.public_send(":#{attr}=", bool_value(card, field))
+            end
+          end
+        end
+
+        def str_value(card, field)
+          card[field.to_s] || ""
+        end
+
+        def bool_value(card, field)
+          card[field.to_s] == "yes"
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -27,7 +27,8 @@ require "agama/storage/proposal"
 require "agama/storage/proposal_settings"
 require "agama/storage/callbacks"
 require "agama/storage/iscsi/manager"
-require "agama/storage/finisher"
+require "agama/storage/fcoe"
+require "agama/storage/fiscsiinisher"
 require "agama/issue"
 require "agama/with_issues"
 require "agama/with_progress"
@@ -142,6 +143,13 @@ module Agama
       # @return [Storage::ISCSI::Manager]
       def iscsi
         @iscsi ||= ISCSI::Manager.new(logger: logger)
+      end
+
+      # FCoE manager
+      #
+      # @return [Storage::Fcoe::Manager]
+      def fcoe
+        @fcoe ||= Fcoe::Manager.new(logger: logger)
       end
 
       # Returns the client to ask the software service


### PR DESCRIPTION
This pull request is the skeleton for a D-Bus interface that would allow the same FCoE operations currently supported by the YaST installer. In a nutshell, this offers a list of the network interfaces of the system, allowing to create an FCoE VLAN interface for any of them. It also makes it possible to modify the configuration of such a FCoE VLAN and to delete it.

The line of work was abandoned because it was kind of agreed that all those explicit operations should not be needed anymore in any system that is currently in production. All FCoE systems currently in existence work out-of-the-box without intervention from the installer.

This needs the following patches to yast2-fcoe-client: https://github.com/yast/yast-fcoe-client/pull/70

The current implementation for modifying the properties of an FCoE VLAN (`fcoe_service`, `dcb_service` and `auto_vlan`) is quite inefficient. Modifying them should not immediately introduce any change in the system or any restart of the services. Instead, we should add an explicit D-Bus call to write the changes for a given interface (so first the properties are set and then the changes are "applied" by calling that method). But doing so would implies more changes in yast2-fcoe-client to offer that per-interface `write` (something that is perfectly doable).