### PR TITLE
Adjust to ruby-dbus-0.23.0.beta2

### DIFF
--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    agama (2.1.devel317)
+    agama (2.1.devel397)
       cfa (~> 1.0.2)
       cfa_grub2 (~> 2.0.0)
       cheetah (~> 1.0.0)
@@ -49,7 +49,7 @@ GEM
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
     ruby-augeas (0.5.0)
-    ruby-dbus (0.23.0.beta1)
+    ruby-dbus (0.23.0.beta2)
       rexml
     simplecov (0.21.2)
       docile (~> 1.1)

--- a/service/agama.gemspec
+++ b/service/agama.gemspec
@@ -58,5 +58,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fast_gettext", "~> 2.2.0"
   spec.add_dependency "nokogiri", "~> 1.13.1"
   spec.add_dependency "rexml", "~> 3.2.5"
-  spec.add_dependency "ruby-dbus", ">= 0.23.0.beta1", "< 1.0"
+  spec.add_dependency "ruby-dbus", ">= 0.23.0.beta2", "< 1.0"
 end

--- a/service/lib/agama/dbus/bus.rb
+++ b/service/lib/agama/dbus/bus.rb
@@ -42,13 +42,6 @@ module Agama
           @current = nil
         end
       end
-
-      # @param address [String] a connectable address
-      # @see https://dbus.freedesktop.org/doc/dbus-specification.html#addresses
-      def initialize(address)
-        super(address)
-        send_hello
-      end
     end
   end
 end


### PR DESCRIPTION

## Problem

`agama config show` would fail

DBus::BusConnection#initialize now calls send_hello already and the bus will Error when it sees a second one

## Solution

remove `send_hello` from the constructor of our derived class

## Testing

- Tested manually with `agama config show`
