### PR TITLE
Code coverage for the Rust code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,9 +171,12 @@ jobs:
 
     strategy:
       fail-fast: false
+      matrix:
+        distro: [ "tumbleweed" ]
 
     container:
-      image: registry.opensuse.org/opensuse/tumbleweed:latest
+      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
+      options: --security-opt seccomp=unconfined
 
     steps:
 
@@ -188,16 +191,33 @@ jobs:
       run: zypper --non-interactive install rustup
 
     - name: Install required packages
-      run: zypper --non-interactive install  python-langtable-data openssl-3 libopenssl-3-devel
+      run: zypper --non-interactive install  python-langtable-data openssl-3 libopenssl-3-devel jq
 
     - name: Install Rust toolchains
       run: rustup toolchain install stable
 
+    - name: Install cargo-binstall
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-binstall
+
+    - name: Install Tarpaulin (for code coverage)
+      run: cargo-binstall --no-confirm cargo-tarpaulin
+
     - name: Run the tests
-      run: cargo test --verbose
+      run: cargo tarpaulin --out xml
 
     - name: Lint formatting
       run: cargo fmt --all -- --check
+
+    - name: Coveralls GitHub Action
+      uses: coverallsapp/github-action@v2
+      with:
+        base-path: ./rust
+        format: cobertura
+        flag-name: rust-backend
+        parallel: true
+        debug: true
 
   integration-tests:
     timeout-minutes: 60
@@ -285,7 +305,7 @@ jobs:
   finish:
     runs-on: ubuntu-latest
 
-    needs: [frontend_build, ruby_tests]
+    needs: [frontend_build, ruby_tests, rust_ci]
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
         base-path: ./service
         flag-name: backend
         parallel: true
-        debug: true
 
   ruby_linter:
     runs-on: ubuntu-latest
@@ -217,7 +216,6 @@ jobs:
         format: cobertura
         flag-name: rust-backend
         parallel: true
-        debug: true
 
   integration-tests:
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,9 @@ jobs:
       run: npm test -- --coverage
 
     - name: Coveralls GitHub Action
-      uses: coverallsapp/github-action@v1
+      uses: coverallsapp/github-action@v2
       with:
         base-path: ./web
-        path-to-lcov: ./web/coverage/lcov.info
         flag-name: frontend
         parallel: true
 
@@ -93,12 +92,12 @@ jobs:
       run: bundle exec rspec
 
     - name: Coveralls GitHub Action
-      uses: coverallsapp/github-action@v1
+      uses: coverallsapp/github-action@v2
       with:
         base-path: ./service
-        path-to-lcov: ./service/coverage/lcov.info
         flag-name: backend
         parallel: true
+        debug: true
 
   ruby_linter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

We do not have any report about the test coverage for the Rust code.

## Solution

This PR enables code coverage reporting for the Rust code using [Tarpaulin](https://github.com/xd009642/tarpaulin).

* All jobs are using `coverallsapp/github-action@v2` now.
* Use [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) to install Tarpaulin, saving the build time. An alternative approach might be to package Tarpaulin ourselves.
* `rust_ci` uses the yast-ruby container because the Coveralls GitHub Action was not working with the Tumbleweed image (IDK the reason).
* `rust_ci` uses the *cobertura* format instead of *lcov* because the file names in the latter are absolute (which looks wrong). See the [list of supported formats](https://github.com/coverallsapp/coverage-reporter#supported-coverage-report-formats) if you are interested.
* Code coverage is ~15% 😞 

## Screenshots

![Screenshot from 2023-06-30 11-42-29](https://github.com/openSUSE/agama/assets/15836/d1c7a5c5-a246-4fcc-9cf0-94cf1b949dbf)
