### PR TITLE
Bring back the rb_build_versions definition

### DIFF
--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -1,6 +1,7 @@
 ---
 :sourceurl: "%{mod_full_name}.gem"
 :preamble: |-
+  %global rb_build_versions %{rb_default_ruby}
   BuildRequires:  dbus-1-common
   Requires:       dbus-1-common
 :post_install: |-
@@ -11,6 +12,8 @@
   install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/etc/agama.yaml %{buildroot}%{_sysconfdir}/agama.yaml
 :main:
   :preamble: |-
+    # Override build.rpm, see also https://github.com/openSUSE/obs-build/blob/master/configs/
+    %global rb_build_versions %{rb_default_ruby}
     BuildRequires:  dbus-1-common
     Requires:       dbus-1-common
     Requires:       snapper


### PR DESCRIPTION
By mistake, we removed the `rb_build_versions` macro. We should bring it back.