### PR TITLE
CLI: write network configuration

### DIFF
--- a/rust/agama-dbus-server/src/network/action.rs
+++ b/rust/agama-dbus-server/src/network/action.rs
@@ -1,4 +1,5 @@
-use crate::network::model::{Connection, DeviceType};
+use crate::network::model::Connection;
+use agama_lib::network::types::DeviceType;
 
 /// Networking actions, like adding, updating or removing connections.
 ///

--- a/rust/agama-dbus-server/src/network/action.rs
+++ b/rust/agama-dbus-server/src/network/action.rs
@@ -1,5 +1,4 @@
 use crate::network::model::{Connection, DeviceType};
-use uuid::Uuid;
 
 /// Networking actions, like adding, updating or removing connections.
 ///
@@ -12,7 +11,7 @@ pub enum Action {
     /// Update a connection (replacing the old one).
     UpdateConnection(Connection),
     /// Remove the connection with the given Uuid.
-    RemoveConnection(Uuid),
+    RemoveConnection(String),
     /// Apply the current configuration.
     Apply,
 }

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -184,11 +184,6 @@ impl Connection {
     pub fn id(&self) -> String {
         self.get_connection().id().to_string()
     }
-
-    #[dbus_interface(property, name = "UUID")]
-    pub fn uuid(&self) -> String {
-        self.get_connection().uuid().to_string()
-    }
 }
 
 /// D-Bus interface for IPv4 settings

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -260,15 +260,15 @@ impl Ipv4 {
     }
 
     #[dbus_interface(property)]
-    pub fn method(&self) -> u8 {
+    pub fn method(&self) -> String {
         let connection = self.get_connection();
-        connection.ipv4().method as u8
+        connection.ipv4().method.to_string()
     }
 
     #[dbus_interface(property)]
-    pub fn set_method(&mut self, method: u8) -> zbus::fdo::Result<()> {
+    pub fn set_method(&mut self, method: &str) -> zbus::fdo::Result<()> {
         let mut connection = self.get_connection();
-        connection.ipv4_mut().method = method.try_into()?;
+        connection.ipv4_mut().method = method.parse()?;
         self.update_connection(connection)
     }
 

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -15,7 +15,6 @@ use std::{
     net::{AddrParseError, Ipv4Addr},
     sync::{mpsc::Sender, Arc},
 };
-use uuid::Uuid;
 use zbus::{dbus_interface, zvariant::ObjectPath};
 
 /// D-Bus interface for the network devices collection
@@ -123,11 +122,11 @@ impl Connections {
     /// Removes a network connection.
     ///
     /// * `uuid`: connection UUID..
-    pub async fn remove_connection(&mut self, uuid: &str) -> zbus::fdo::Result<()> {
+    pub async fn remove_connection(&mut self, id: &str) -> zbus::fdo::Result<()> {
         let actions = self.actions.lock();
-        let uuid =
-            Uuid::parse_str(uuid).map_err(|_| NetworkStateError::InvalidUuid(uuid.to_string()))?;
-        actions.send(Action::RemoveConnection(uuid)).unwrap();
+        actions
+            .send(Action::RemoveConnection(id.to_string()))
+            .unwrap();
         Ok(())
     }
 

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -122,10 +122,13 @@ impl Connections {
         Ok(())
     }
 
-    pub async fn get_connection(&self, id: String) -> zbus::fdo::Result<OwnedObjectPath> {
+    /// Returns the D-Bus path of the network connection.
+    ///
+    /// * `id`: connection ID.
+    pub async fn get_connection(&self, id: &str) -> zbus::fdo::Result<OwnedObjectPath> {
         let objects = self.objects.lock();
         match objects.connection_path(&id) {
-            Some(path) => Ok(OwnedObjectPath::try_from(path).unwrap()),
+            Some(path) => Ok(path.into()),
             None => Err(NetworkStateError::UnknownConnection(id.to_string()).into()),
         }
     }

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -444,7 +444,7 @@ impl Wireless {
     /// Possible values: "none", "owe", "ieee8021x", "wpa-psk", "sae", "wpa-eap",
     /// "wpa-eap-suite-b192".
     ///
-    /// See [crate::model::WirelessMode].
+    /// See [crate::model::SecurityProtocol].
     #[dbus_interface(property)]
     pub fn security(&self) -> String {
         let connection = self.get_wireless();

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -70,11 +70,19 @@ impl Device {
 
 #[dbus_interface(name = "org.opensuse.Agama.Network1.Device")]
 impl Device {
+    /// Device name.
+    ///
+    /// Kernel device name, e.g., eth0, enp1s0, etc.
     #[dbus_interface(property)]
     pub fn name(&self) -> &str {
         &self.device.name
     }
 
+    /// Device type.
+    ///
+    /// Possible values: 0 = loopback, 1 = ethernet, 2 = wireless.
+    ///
+    /// See [crate::model::DeviceType].
     #[dbus_interface(property, name = "Type")]
     pub fn device_type(&self) -> u8 {
         self.device.type_ as u8
@@ -180,6 +188,11 @@ impl Connection {
 
 #[dbus_interface(name = "org.opensuse.Agama.Network1.Connection")]
 impl Connection {
+    /// Connection ID.
+    ///
+    /// Unique identifier of the network connection. It may or not be the same that the used by the
+    /// backend. For instance, when using NetworkManager (which is the only supported backend by
+    /// now), it uses the original ID but appending a number in case the ID is duplicated.
     #[dbus_interface(property)]
     pub fn id(&self) -> String {
         self.get_connection().id().to_string()
@@ -226,6 +239,9 @@ impl Ipv4 {
 
 #[dbus_interface(name = "org.opensuse.Agama.Network1.Connection.IPv4")]
 impl Ipv4 {
+    /// List of IP addresses.
+    ///
+    /// When the method is 'auto', these addresses are used as additional addresses.
     #[dbus_interface(property)]
     pub fn addresses(&self) -> Vec<String> {
         let connection = self.get_connection();
@@ -254,6 +270,11 @@ impl Ipv4 {
         self.update_connection(connection)
     }
 
+    /// IP configuration method.
+    ///
+    /// Possible values: "disabled", "auto", "manual" or "link-local".
+    ///
+    /// See [crate::model::IpMethod].
     #[dbus_interface(property)]
     pub fn method(&self) -> String {
         let connection = self.get_connection();
@@ -267,6 +288,7 @@ impl Ipv4 {
         self.update_connection(connection)
     }
 
+    /// Name server addresses.
     #[dbus_interface(property)]
     pub fn nameservers(&self) -> Vec<String> {
         let connection = self.get_connection();
@@ -291,6 +313,10 @@ impl Ipv4 {
         self.update_connection(connection)
     }
 
+    /// Network gateway.
+    ///
+    /// An empty string removes the current value. It is not possible to set a gateway if the
+    /// addresses property is empty.
     #[dbus_interface(property)]
     pub fn gateway(&self) -> String {
         let connection = self.get_connection();
@@ -359,6 +385,7 @@ impl Wireless {
 
 #[dbus_interface(name = "org.opensuse.Agama.Network1.Connection.Wireless")]
 impl Wireless {
+    /// Network SSID.
     #[dbus_interface(property, name = "SSID")]
     pub fn ssid(&self) -> Vec<u8> {
         let connection = self.get_wireless();
@@ -372,6 +399,11 @@ impl Wireless {
         self.update_connection(connection)
     }
 
+    /// Wireless connection mode.
+    ///
+    /// Possible values: "unknown", "adhoc", "infrastructure", "ap" or "mesh".
+    ///
+    /// See [crate::model::WirelessMode].
     #[dbus_interface(property)]
     pub fn mode(&self) -> String {
         let connection = self.get_wireless();
@@ -385,6 +417,7 @@ impl Wireless {
         self.update_connection(connection)
     }
 
+    /// Password to connect to the wireless network.
     #[dbus_interface(property)]
     pub fn password(&self) -> String {
         let connection = self.get_wireless();
@@ -406,6 +439,12 @@ impl Wireless {
         self.update_connection(connection)
     }
 
+    /// Wireless security protocol.
+    ///
+    /// Possible values: "none", "owe", "ieee8021x", "wpa-psk", "sae", "wpa-eap",
+    /// "wpa-eap-suite-b192".
+    ///
+    /// See [crate::model::WirelessMode].
     #[dbus_interface(property)]
     pub fn security(&self) -> String {
         let connection = self.get_wireless();

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -123,7 +123,7 @@ impl Connections {
 
     /// Adds a new network connection.
     ///
-    /// * `name`: connection name.
+    /// * `id`: connection name.
     /// * `ty`: connection type (see [crate::model::DeviceType]).
     pub async fn add_connection(&mut self, id: String, ty: u8) -> zbus::fdo::Result<()> {
         let actions = self.actions.lock();

--- a/rust/agama-dbus-server/src/network/error.rs
+++ b/rust/agama-dbus-server/src/network/error.rs
@@ -6,8 +6,8 @@ use uuid::Uuid;
 /// Errors that are related to the network configuration.
 #[derive(Error, Debug)]
 pub enum NetworkStateError {
-    #[error("Invalid connection name: '{0}'")]
-    UnknownConnection(Uuid),
+    #[error("Unknown connection with ID: '{0}'")]
+    UnknownConnection(String),
     #[error("Invalid connection UUID: '{0}'")]
     InvalidUuid(String),
     #[error("Invalid IP address")]

--- a/rust/agama-dbus-server/src/network/error.rs
+++ b/rust/agama-dbus-server/src/network/error.rs
@@ -18,8 +18,6 @@ pub enum NetworkStateError {
     InvalidWirelessMode(String),
     #[error("Connection '{0}' already exists")]
     ConnectionExists(Uuid),
-    #[error("Invalid device type: '{0}'")]
-    InvalidDeviceType(u8),
     #[error("Invalid security wireless protocol: '{0}'")]
     InvalidSecurityProtocol(String),
     #[error("Adapter error: '{0}'")]

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -241,6 +241,10 @@ impl Connection {
         self.base().id.as_str()
     }
 
+    pub fn set_id(&mut self, id: &str) {
+        self.base_mut().id = id.to_string()
+    }
+
     pub fn uuid(&self) -> Uuid {
         self.base().uuid
     }

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -5,7 +5,7 @@
 use uuid::Uuid;
 
 use crate::network::error::NetworkStateError;
-use agama_lib::network::types::SSID;
+use agama_lib::network::types::{DeviceType, SSID};
 use std::{
     fmt,
     net::{AddrParseError, Ipv4Addr},
@@ -193,26 +193,6 @@ mod tests {
 pub struct Device {
     pub name: String,
     pub type_: DeviceType,
-}
-
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum DeviceType {
-    Loopback = 0,
-    Ethernet = 1,
-    Wireless = 2,
-}
-
-impl TryFrom<u8> for DeviceType {
-    type Error = NetworkStateError;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(DeviceType::Loopback),
-            1 => Ok(DeviceType::Ethernet),
-            2 => Ok(DeviceType::Wireless),
-            _ => Err(NetworkStateError::InvalidDeviceType(value)),
-        }
-    }
 }
 
 /// Represents an available network connection
@@ -519,4 +499,3 @@ impl fmt::Display for IpAddress {
         write!(f, "{}/{}", self.0.to_string(), self.1)
     }
 }
-

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -36,8 +36,8 @@ impl NetworkState {
     /// Get connection by UUID
     ///
     /// * `uuid`: connection UUID
-    pub fn get_connection(&self, uuid: Uuid) -> Option<&Connection> {
-        self.connections.iter().find(|c| c.uuid() == uuid)
+    pub fn get_connection(&self, id: &str) -> Option<&Connection> {
+        self.connections.iter().find(|c| c.id() == id)
     }
 
     /// Get connection by UUID as mutable
@@ -51,7 +51,7 @@ impl NetworkState {
     ///
     /// It uses the `id` to decide whether the connection already exists.
     pub fn add_connection(&mut self, conn: Connection) -> Result<(), NetworkStateError> {
-        if let Some(_) = self.get_connection(conn.uuid()) {
+        if let Some(_) = self.get_connection(conn.id()) {
             return Err(NetworkStateError::ConnectionExists(conn.uuid()));
         }
 
@@ -98,12 +98,13 @@ mod tests {
         let mut state = NetworkState::default();
         let uuid = Uuid::new_v4();
         let base = BaseConnection {
+            id: "eth0".to_string(),
             uuid,
             ..Default::default()
         };
         let conn0 = Connection::Ethernet(EthernetConnection { base });
         state.add_connection(conn0).unwrap();
-        let found = state.get_connection(uuid).unwrap();
+        let found = state.get_connection("eth0").unwrap();
         assert_eq!(found.uuid(), uuid);
     }
 
@@ -124,21 +125,23 @@ mod tests {
     #[test]
     fn test_update_connection() {
         let mut state = NetworkState::default();
-        let uuid = Uuid::new_v4();
         let base0 = BaseConnection {
-            uuid,
+            id: "eth0".to_string(),
+            uuid: Uuid::new_v4(),
             ..Default::default()
         };
         let conn0 = Connection::Ethernet(EthernetConnection { base: base0 });
         state.add_connection(conn0).unwrap();
 
+        let uuid = Uuid::new_v4();
         let base1 = BaseConnection {
+            id: "eth0".to_string(),
             uuid,
             ..Default::default()
         };
         let conn2 = Connection::Ethernet(EthernetConnection { base: base1 });
         state.update_connection(conn2).unwrap();
-        let found = state.get_connection(uuid).unwrap();
+        let found = state.get_connection("eth0").unwrap();
         assert_eq!(found.uuid(), uuid);
     }
 
@@ -168,7 +171,7 @@ mod tests {
         let conn0 = Connection::Ethernet(EthernetConnection { base: base0 });
         state.add_connection(conn0).unwrap();
         state.remove_connection("eth0").unwrap();
-        let found = state.get_connection(uuid).unwrap();
+        let found = state.get_connection("eth0").unwrap();
         assert!(found.is_removed());
     }
 

--- a/rust/agama-dbus-server/src/network/nm/adapter.rs
+++ b/rust/agama-dbus-server/src/network/nm/adapter.rs
@@ -4,6 +4,7 @@ use crate::network::{
     Adapter,
 };
 use agama_lib::error::ServiceError;
+use log;
 
 /// An adapter for NetworkManager
 pub struct NetworkManagerAdapter<'a> {
@@ -48,11 +49,11 @@ impl<'a> Adapter for NetworkManagerAdapter<'a> {
                 }
                 if conn.is_removed() {
                     if let Err(e) = self.client.remove_connection(conn.uuid()).await {
-                        eprintln!("Could not remove the connection {}: {}", conn.uuid(), e);
+                        log::error!("Could not remove the connection {}: {}", conn.uuid(), e);
                     }
                 } else {
                     if let Err(e) = self.client.add_or_update_connection(conn).await {
-                        eprintln!("Could not add/update the connection {}: {}", conn.uuid(), e);
+                        log::error!("Could not add/update the connection {}: {}", conn.uuid(), e);
                     }
                 }
             }

--- a/rust/agama-dbus-server/src/network/nm/client.rs
+++ b/rust/agama-dbus-server/src/network/nm/client.rs
@@ -4,6 +4,7 @@ use super::model::NmDeviceType;
 use super::proxies::{ConnectionProxy, DeviceProxy, NetworkManagerProxy, SettingsProxy};
 use crate::network::model::{Connection, Device};
 use agama_lib::error::ServiceError;
+use log;
 use uuid::Uuid;
 use zbus;
 
@@ -53,9 +54,10 @@ impl<'a> NetworkManagerClient<'a> {
                 });
             } else {
                 // TODO: use a logger
-                eprintln!(
-                    "Unsupported device type {:?} for {}",
-                    &device_type, &device_name
+                log::warn!(
+                    "Ignoring network device '{}' (unsupported type '{}')",
+                    &device_name,
+                    &device_type
                 );
             }
         }

--- a/rust/agama-dbus-server/src/network/nm/client.rs
+++ b/rust/agama-dbus-server/src/network/nm/client.rs
@@ -7,6 +7,7 @@ use agama_lib::error::ServiceError;
 use log;
 use uuid::Uuid;
 use zbus;
+use zbus::zvariant::{ObjectPath, OwnedObjectPath};
 
 /// Simplified NetworkManager D-Bus client.
 ///
@@ -89,14 +90,16 @@ impl<'a> NetworkManagerClient<'a> {
     /// * `conn`: connection to add or update.
     pub async fn add_or_update_connection(&self, conn: &Connection) -> Result<(), ServiceError> {
         let new_conn = connection_to_dbus(conn);
-        if let Ok(proxy) = self.get_connection_proxy(conn.uuid()).await {
+        let path = if let Ok(proxy) = self.get_connection_proxy(conn.uuid()).await {
             let original = proxy.get_settings().await?;
             let merged = merge_dbus_connections(&original, &new_conn);
             proxy.update(merged).await?;
+            OwnedObjectPath::from(proxy.path().to_owned())
         } else {
             let proxy = SettingsProxy::new(&self.connection).await?;
-            proxy.add_connection(new_conn).await?;
-        }
+            proxy.add_connection(new_conn).await?
+        };
+        self.activate_connection(path).await?;
         Ok(())
     }
 
@@ -104,6 +107,18 @@ impl<'a> NetworkManagerClient<'a> {
     pub async fn remove_connection(&self, uuid: Uuid) -> Result<(), ServiceError> {
         let proxy = self.get_connection_proxy(uuid).await?;
         proxy.delete().await?;
+        Ok(())
+    }
+
+    /// Activates a NetworkManager connection.
+    ///
+    /// * `path`: D-Bus patch of the connection.
+    async fn activate_connection(&self, path: OwnedObjectPath) -> Result<(), ServiceError> {
+        let proxy = NetworkManagerProxy::new(&self.connection).await?;
+        let root = ObjectPath::try_from("/").unwrap();
+        proxy
+            .activate_connection(&path.as_ref(), &root, &root)
+            .await?;
         Ok(())
     }
 

--- a/rust/agama-dbus-server/src/network/nm/dbus.rs
+++ b/rust/agama-dbus-server/src/network/nm/dbus.rs
@@ -98,10 +98,12 @@ pub fn merge_dbus_connections<'a>(
 fn cleanup_dbus_connection<'a>(conn: &'a mut NestedHash) {
     if let Some(ipv4) = conn.get_mut("ipv4") {
         ipv4.remove("addresses");
+        ipv4.remove("dns");
     }
 
     if let Some(ipv6) = conn.get_mut("ipv6") {
         ipv6.remove("addresses");
+        ipv6.remove("dns");
     }
 }
 

--- a/rust/agama-dbus-server/src/network/nm/model.rs
+++ b/rust/agama-dbus-server/src/network/nm/model.rs
@@ -68,6 +68,12 @@ impl From<NmDeviceType> for u32 {
     }
 }
 
+impl fmt::Display for NmDeviceType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl Default for NmDeviceType {
     fn default() -> Self {
         NmDeviceType(0)

--- a/rust/agama-dbus-server/src/network/nm/model.rs
+++ b/rust/agama-dbus-server/src/network/nm/model.rs
@@ -7,9 +7,10 @@
 /// Using the newtype pattern around an String is enough. For proper support, we might replace this
 /// struct with an enum.
 use crate::network::{
-    model::{DeviceType, IpMethod, SecurityProtocol, WirelessMode},
+    model::{IpMethod, SecurityProtocol, WirelessMode},
     nm::error::NmError,
 };
+use agama_lib::network::types::DeviceType;
 use std::fmt;
 
 #[derive(Debug, PartialEq)]

--- a/rust/agama-dbus-server/src/network/system.rs
+++ b/rust/agama-dbus-server/src/network/system.rs
@@ -86,9 +86,9 @@ impl NetworkSystem {
             Action::UpdateConnection(conn) => {
                 self.state.update_connection(conn)?;
             }
-            Action::RemoveConnection(uuid) => {
-                self.tree.remove_connection(uuid).await?;
-                self.state.remove_connection(uuid)?;
+            Action::RemoveConnection(id) => {
+                self.tree.remove_connection(&id).await?;
+                self.state.remove_connection(&id)?;
             }
             Action::Apply => {
                 self.to_network_manager().await?;

--- a/rust/agama-dbus-server/src/network/system.rs
+++ b/rust/agama-dbus-server/src/network/system.rs
@@ -59,7 +59,9 @@ impl NetworkSystem {
 
     /// Populates the D-Bus tree with the known devices and connections.
     pub async fn setup(&mut self) -> Result<(), ServiceError> {
-        self.tree.set_connections(&self.state.connections).await?;
+        self.tree
+            .set_connections(&mut self.state.connections)
+            .await?;
         self.tree.set_devices(&self.state.devices).await?;
         Ok(())
     }
@@ -79,8 +81,8 @@ impl NetworkSystem {
     pub async fn dispatch_action(&mut self, action: Action) -> Result<(), Box<dyn Error>> {
         match action {
             Action::AddConnection(name, ty) => {
-                let conn = Connection::new(name, ty);
-                self.tree.add_connection(&conn).await?;
+                let mut conn = Connection::new(name, ty);
+                self.tree.add_connection(&mut conn).await?;
                 self.state.add_connection(conn)?;
             }
             Action::UpdateConnection(conn) => {
@@ -94,7 +96,9 @@ impl NetworkSystem {
                 self.to_network_manager().await?;
                 // TODO: re-creating the tree is kind of brute-force and it sends signals about
                 // adding/removing interfaces. We should add/update/delete objects as needed.
-                self.tree.set_connections(&self.state.connections).await?;
+                self.tree
+                    .set_connections(&mut self.state.connections)
+                    .await?;
             }
         }
 

--- a/rust/agama-lib/share/examples/profile.json
+++ b/rust/agama-lib/share/examples/profile.json
@@ -25,7 +25,7 @@
   "network": {
     "connections": [
       {
-        "name": "Ethernet network device 1",
+        "id": "Ethernet network device 1",
         "method": "manual",
         "addresses": [
           "192.168.122.100/24"

--- a/rust/agama-lib/share/examples/profile.jsonnet
+++ b/rust/agama-lib/share/examples/profile.jsonnet
@@ -32,7 +32,7 @@ local findBiggestDisk(disks) =
   network: {
     connections: [
       {
-        name: 'AgamaNetwork',
+        id: 'AgamaNetwork',
         wireless: {
           password: 'agama.test',
           security: 'wpa-psk',
@@ -40,7 +40,7 @@ local findBiggestDisk(disks) =
         }
       },
       {
-        name: 'Etherned device 1',
+        id: 'Etherned device 1',
         method: 'manual',
         gateway: '192.168.122.1',
         addresses: [

--- a/rust/agama-lib/share/examples/profile.jsonnet
+++ b/rust/agama-lib/share/examples/profile.jsonnet
@@ -49,7 +49,7 @@ local findBiggestDisk(disks) =
         nameservers: [
           '1.2.3.4'
         ]
-      ]
-    }
-  ]
+      }
+    ]
+  }
 }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -19,6 +19,7 @@
     "network": {
       "description": "Network settings",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "connections": {
           "description": "Network connections to be defined",

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -28,7 +28,7 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "name": {
+              "id": {
                 "description": "Connection ID",
                 "type": "string"
               },
@@ -89,7 +89,7 @@
               }
             },
             "required": [
-              "name"
+              "id"
             ]
           }
         }

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -38,6 +38,12 @@ impl<'a> NetworkClient<'a> {
         Ok(connections)
     }
 
+    /// Applies the network configuration.
+    pub async fn apply(&self) -> Result<(), ServiceError> {
+        self.connections_proxy.apply().await?;
+        Ok(())
+    }
+
     /// Returns the NetworkConnection for the given connection path
     ///
     ///  * `path`: the connections path to get the config from

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -52,7 +52,7 @@ impl<'a> NetworkClient<'a> {
             .path(path)?
             .build()
             .await?;
-        let name = connection_proxy.id().await?;
+        let id = connection_proxy.id().await?;
 
         let ipv4_proxy = IPv4Proxy::builder(&self.connection)
             .path(path)?
@@ -68,7 +68,7 @@ impl<'a> NetworkClient<'a> {
         let addresses = ipv4_proxy.addresses().await?;
 
         Ok(NetworkConnection {
-            name,
+            id,
             method: Some(method.to_string()),
             gateway,
             addresses,
@@ -105,7 +105,7 @@ impl<'a> NetworkClient<'a> {
         &self,
         conn: &NetworkConnection,
     ) -> Result<(), ServiceError> {
-        let path = match self.connections_proxy.get_connection(&conn.name).await {
+        let path = match self.connections_proxy.get_connection(&conn.id).await {
             Ok(path) => path,
             Err(_) => self.add_connection(&conn).await?,
         };
@@ -121,9 +121,9 @@ impl<'a> NetworkClient<'a> {
         conn: &NetworkConnection,
     ) -> Result<OwnedObjectPath, ServiceError> {
         self.connections_proxy
-            .add_connection(&conn.name, conn.device_type() as u8)
+            .add_connection(&conn.id, conn.device_type() as u8)
             .await?;
-        Ok(self.connections_proxy.get_connection(&conn.name).await?)
+        Ok(self.connections_proxy.get_connection(&conn.id).await?)
     }
 
     /// Updates a network connection.

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -69,10 +69,6 @@ impl<'a> NetworkClient<'a> {
         };
         let nameservers = ipv4_proxy.nameservers().await?;
         let addresses = ipv4_proxy.addresses().await?;
-        let addresses = addresses
-            .into_iter()
-            .map(|(ip, prefix)| format!("{ip}/{prefix}"))
-            .collect();
 
         Ok(NetworkConnection {
             name,

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -55,7 +55,7 @@ impl<'a> NetworkClient<'a> {
             .build()
             .await?;
 
-        /// TODO: consider using the `IPMethod` struct from `agama-network`.
+        // TODO: consider using the `IPMethod` struct from `agama-network`.
         let method = match ipv4_proxy.method().await? {
             0 => "auto",
             1 => "manual",

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -55,14 +55,7 @@ impl<'a> NetworkClient<'a> {
             .build()
             .await?;
 
-        // TODO: consider using the `IPMethod` struct from `agama-network`.
-        let method = match ipv4_proxy.method().await? {
-            0 => "auto",
-            1 => "manual",
-            2 => "link-local",
-            3 => "disable",
-            _ => "auto",
-        };
+        let method = ipv4_proxy.method().await?;
         let gateway = match ipv4_proxy.gateway().await?.as_str() {
             "" => None,
             value => Some(value.to_string()),

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -76,7 +76,7 @@ impl<'a> NetworkClient<'a> {
 
         Ok(NetworkConnection {
             name,
-            method: method.to_string(),
+            method: Some(method.to_string()),
             gateway,
             addresses,
             nameservers,

--- a/rust/agama-lib/src/network/proxies.rs
+++ b/rust/agama-lib/src/network/proxies.rs
@@ -83,7 +83,7 @@ trait IPv4 {
     /// By now just an array of IPv4 addresses in string format
     #[dbus_proxy(property)]
     fn addresses(&self) -> zbus::Result<Vec<(String, u32)>>;
-    fn set_addresses(&self, value: &[(&str, u32)]) -> zbus::Result<()>;
+    fn set_addresses(&self, value: Vec<String>) -> zbus::Result<()>;
 
     /// Gateway property
     #[dbus_proxy(property)]

--- a/rust/agama-lib/src/network/proxies.rs
+++ b/rust/agama-lib/src/network/proxies.rs
@@ -41,7 +41,7 @@ trait Wireless {
     /// Possible values are 'unknown', 'adhoc', 'infrastructure', 'ap' or 'mesh'
     #[dbus_proxy(property)]
     fn mode(&self) -> zbus::Result<String>;
-    fn set_mode(&self, value: String) -> zbus::Result<()>;
+    fn set_mode(&self, value: &str) -> zbus::Result<()>;
 
     /// Password property
     #[dbus_proxy(property)]
@@ -51,7 +51,7 @@ trait Wireless {
     /// SSID property
     #[dbus_proxy(property, name = "SSID")]
     fn ssid(&self) -> zbus::Result<Vec<u8>>;
-    fn set_ssid(&self, value: Vec<u8>) -> zbus::Result<()>;
+    fn set_ssid(&self, value: &[u8]) -> zbus::Result<()>;
 
     /// Wireless Security property
     ///
@@ -59,7 +59,7 @@ trait Wireless {
     ///     'wpa-eap', 'wpa-eap-suite-b192'
     #[dbus_proxy(property)]
     fn security(&self) -> zbus::Result<String>;
-    fn set_security(&self, value: String) -> zbus::Result<()>;
+    fn set_security(&self, value: &str) -> zbus::Result<()>;
 }
 
 #[dbus_proxy(

--- a/rust/agama-lib/src/network/proxies.rs
+++ b/rust/agama-lib/src/network/proxies.rs
@@ -41,16 +41,19 @@ trait Wireless {
     /// Possible values are 'unknown', 'adhoc', 'infrastructure', 'ap' or 'mesh'
     #[dbus_proxy(property)]
     fn mode(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
     fn set_mode(&self, value: &str) -> zbus::Result<()>;
 
     /// Password property
     #[dbus_proxy(property)]
     fn password(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
     fn set_password(&self, value: &str) -> zbus::Result<()>;
 
     /// SSID property
     #[dbus_proxy(property, name = "SSID")]
     fn ssid(&self) -> zbus::Result<Vec<u8>>;
+    #[dbus_proxy(property, name = "SSID")]
     fn set_ssid(&self, value: &[u8]) -> zbus::Result<()>;
 
     /// Wireless Security property
@@ -59,6 +62,7 @@ trait Wireless {
     ///     'wpa-eap', 'wpa-eap-suite-b192'
     #[dbus_proxy(property)]
     fn security(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
     fn set_security(&self, value: &str) -> zbus::Result<()>;
 }
 

--- a/rust/agama-lib/src/network/proxies.rs
+++ b/rust/agama-lib/src/network/proxies.rs
@@ -75,10 +75,6 @@ trait Connection {
     /// Id property
     #[dbus_proxy(property)]
     fn id(&self) -> zbus::Result<String>;
-
-    /// UUID property
-    #[dbus_proxy(property, name = "UUID")]
-    fn uuid(&self) -> zbus::Result<String>;
 }
 
 #[dbus_proxy(

--- a/rust/agama-lib/src/network/proxies.rs
+++ b/rust/agama-lib/src/network/proxies.rs
@@ -18,6 +18,11 @@ trait Connections {
     /// Apply method
     fn apply(&self) -> zbus::Result<()>;
 
+    /// Gets a connection D-Bus path by its ID
+    ///
+    /// * `id`: connection ID.
+    fn get_connection(&self, id: &str) -> zbus::Result<zbus::zvariant::OwnedObjectPath>;
+
     /// GetConnections method
     fn get_connections(&self) -> zbus::Result<Vec<zbus::zvariant::OwnedObjectPath>>;
 
@@ -82,17 +87,20 @@ trait IPv4 {
     ///
     /// By now just an array of IPv4 addresses in string format
     #[dbus_proxy(property)]
-    fn addresses(&self) -> zbus::Result<Vec<(String, u32)>>;
-    fn set_addresses(&self, value: Vec<String>) -> zbus::Result<()>;
+    fn addresses(&self) -> zbus::Result<Vec<String>>;
+    #[dbus_proxy(property)]
+    fn set_addresses(&self, value: &[&str]) -> zbus::Result<()>;
 
     /// Gateway property
     #[dbus_proxy(property)]
     fn gateway(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
     fn set_gateway(&self, value: &str) -> zbus::Result<()>;
 
     /// Method property
     #[dbus_proxy(property)]
     fn method(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
     fn set_method(&self, value: &str) -> zbus::Result<()>;
 
     /// Nameservers property
@@ -100,5 +108,6 @@ trait IPv4 {
     /// By now just an array of IPv4 addresses in string format
     #[dbus_proxy(property)]
     fn nameservers(&self) -> zbus::Result<Vec<String>>;
+    #[dbus_proxy(property)]
     fn set_nameservers(&self, value: &[&str]) -> zbus::Result<()>;
 }

--- a/rust/agama-lib/src/network/proxies.rs
+++ b/rust/agama-lib/src/network/proxies.rs
@@ -92,8 +92,8 @@ trait IPv4 {
 
     /// Method property
     #[dbus_proxy(property)]
-    fn method(&self) -> zbus::Result<u8>;
-    fn set_method(&self, value: u8) -> zbus::Result<()>;
+    fn method(&self) -> zbus::Result<String>;
+    fn set_method(&self, value: &str) -> zbus::Result<()>;
 
     /// Nameservers property
     ///

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -1,21 +1,36 @@
 //! Representation of the network settings
 
 use crate::settings::{SettingObject, Settings};
-use agama_derive::Settings;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::default::Default;
 
 /// Network settings for installation
-#[derive(Debug, Default, Settings, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkSettings {
     /// Connections to use in the installation
-    #[collection_setting]
     pub connections: Vec<NetworkConnection>,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+impl Settings for NetworkSettings {
+    fn add(&mut self, attr: &str, value: SettingObject) -> Result<(), &'static str> {
+        match attr {
+            "connections" => self.connections.push(value.try_into()?),
+            _ => return Err("unknown attribute"),
+        };
+        Ok(())
+    }
+
+    fn merge(&mut self, other: &Self)
+    where
+        Self: Sized,
+    {
+        self.connections = other.connections.clone();
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct WirelessSettings {
     #[serde(skip_serializing_if = "String::is_empty")]
     pub password: String,
@@ -24,7 +39,7 @@ pub struct WirelessSettings {
     pub mode: String,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct NetworkConnection {
     pub name: String,
     pub method: String,

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -42,7 +42,7 @@ pub struct WirelessSettings {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct NetworkConnection {
-    pub name: String,
+    pub id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -73,15 +73,15 @@ impl TryFrom<SettingObject> for NetworkConnection {
     type Error = &'static str;
 
     fn try_from(value: SettingObject) -> Result<Self, Self::Error> {
-        let Some(name) = value.get("name") else {
-            return Err("The 'name' key is missing");
+        let Some(id) = value.get("id") else {
+            return Err("The 'id' key is missing");
         };
 
         let default_method = SettingValue("disabled".to_string());
         let method = value.get("method").unwrap_or(&default_method);
 
         let conn = NetworkConnection {
-            name: name.clone().try_into()?,
+            id: id.clone().try_into()?,
             method: method.clone().try_into()?,
             ..Default::default()
         };
@@ -112,7 +112,7 @@ mod tests {
     fn test_add_connection_to_setting() {
         let name = SettingValue("Ethernet 1".to_string());
         let method = SettingValue("auto".to_string());
-        let conn = HashMap::from([("name".to_string(), name), ("method".to_string(), method)]);
+        let conn = HashMap::from([("id".to_string(), name), ("method".to_string(), method)]);
         let conn = SettingObject(conn);
 
         let mut settings = NetworkSettings::default();
@@ -124,10 +124,10 @@ mod tests {
     fn test_setting_object_to_network_connection() {
         let name = SettingValue("Ethernet 1".to_string());
         let method = SettingValue("auto".to_string());
-        let settings = HashMap::from([("name".to_string(), name), ("method".to_string(), method)]);
+        let settings = HashMap::from([("id".to_string(), name), ("method".to_string(), method)]);
         let settings = SettingObject(settings);
         let conn: NetworkConnection = settings.try_into().unwrap();
-        assert_eq!(conn.name, "Ethernet 1");
+        assert_eq!(conn.id, "Ethernet 1");
         assert_eq!(conn.method, Some("auto".to_string()));
     }
 }

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -42,12 +42,13 @@ pub struct WirelessSettings {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct NetworkConnection {
     pub name: String,
-    pub method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub addresses: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub nameservers: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wireless: Option<WirelessSettings>,

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -1,5 +1,6 @@
 //! Representation of the network settings
 
+use super::types::DeviceType;
 use crate::settings::{SettingObject, Settings};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -52,6 +53,20 @@ pub struct NetworkConnection {
     pub nameservers: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wireless: Option<WirelessSettings>,
+}
+
+impl NetworkConnection {
+    /// Device type expected for the network connection.
+    ///
+    /// Which device type to use is inferred from the included settings. For instance, if it has
+    /// wireless settings, it should be applied to a wireless device.
+    pub fn device_type(&self) -> DeviceType {
+        if self.wireless.is_some() {
+            DeviceType::Wireless
+        } else {
+            DeviceType::Ethernet
+        }
+    }
 }
 
 impl TryFrom<SettingObject> for NetworkConnection {

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -1,7 +1,7 @@
 //! Representation of the network settings
 
 use super::types::DeviceType;
-use crate::settings::{SettingObject, Settings, SettingValue};
+use crate::settings::{SettingObject, SettingValue, Settings};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::default::Default;
@@ -92,9 +92,9 @@ impl TryFrom<SettingObject> for NetworkConnection {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use crate::settings::{SettingObject, SettingValue};
     use super::*;
+    use crate::settings::{SettingObject, SettingValue};
+    use std::collections::HashMap;
 
     #[test]
     fn test_device_type() {
@@ -112,10 +112,7 @@ mod tests {
     fn test_add_connection_to_setting() {
         let name = SettingValue("Ethernet 1".to_string());
         let method = SettingValue("auto".to_string());
-        let conn = HashMap::from([
-            ("name".to_string(), name),
-            ("method".to_string(), method)
-        ]);
+        let conn = HashMap::from([("name".to_string(), name), ("method".to_string(), method)]);
         let conn = SettingObject(conn);
 
         let mut settings = NetworkSettings::default();
@@ -127,10 +124,7 @@ mod tests {
     fn test_setting_object_to_network_connection() {
         let name = SettingValue("Ethernet 1".to_string());
         let method = SettingValue("auto".to_string());
-        let settings = HashMap::from([
-            ("name".to_string(), name),
-            ("method".to_string(), method)
-        ]);
+        let settings = HashMap::from([("name".to_string(), name), ("method".to_string(), method)]);
         let settings = SettingObject(settings);
         let conn: NetworkConnection = settings.try_into().unwrap();
         assert_eq!(conn.name, "Ethernet 1");

--- a/rust/agama-lib/src/network/store.rs
+++ b/rust/agama-lib/src/network/store.rs
@@ -29,6 +29,7 @@ impl<'a> NetworkStore<'a> {
         for conn in &settings.connections {
             self.network_client.add_or_update_connection(&conn).await?;
         }
+        self.network_client.apply().await?;
 
         Ok(())
     }

--- a/rust/agama-lib/src/network/store.rs
+++ b/rust/agama-lib/src/network/store.rs
@@ -22,7 +22,7 @@ impl<'a> NetworkStore<'a> {
         Ok(NetworkSettings { connections })
     }
 
-    pub async fn store(&self, settings: &NetworkSettings) -> Result<(), Box<dyn Error>> {
+    pub async fn store(&self, _settings: &NetworkSettings) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
 }

--- a/rust/agama-lib/src/network/store.rs
+++ b/rust/agama-lib/src/network/store.rs
@@ -19,10 +19,17 @@ impl<'a> NetworkStore<'a> {
     pub async fn load(&self) -> Result<NetworkSettings, Box<dyn Error>> {
         let connections = self.network_client.connections().await?;
 
-        Ok(NetworkSettings { connections })
+        Ok(NetworkSettings {
+            connections,
+            ..Default::default()
+        })
     }
 
-    pub async fn store(&self, _settings: &NetworkSettings) -> Result<(), Box<dyn Error>> {
+    pub async fn store(&self, settings: &NetworkSettings) -> Result<(), Box<dyn Error>> {
+        for conn in &settings.connections {
+            self.network_client.add_or_update_connection(&conn).await?;
+        }
+
         Ok(())
     }
 }

--- a/rust/agama-lib/src/network/types.rs
+++ b/rust/agama-lib/src/network/types.rs
@@ -31,7 +31,7 @@ pub enum DeviceType {
     Wireless = 2,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 #[error("Invalid device type: {0}")]
 pub struct InvalidDeviceType(u8);
 
@@ -51,5 +51,32 @@ impl TryFrom<u8> for DeviceType {
 impl From<InvalidDeviceType> for zbus::fdo::Error {
     fn from(value: InvalidDeviceType) -> zbus::fdo::Error {
         zbus::fdo::Error::Failed(format!("Network error: {}", value.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_ssid() {
+        let ssid = SSID(vec![97, 103, 97, 109, 97]);
+        assert_eq!(format!("{}", ssid), "agama");
+    }
+
+    #[test]
+    fn test_ssid_to_vec() {
+        let vec = vec![97, 103, 97, 109, 97];
+        let ssid = SSID(vec.clone());
+        assert_eq!(ssid.to_vec(), &vec);
+    }
+
+    #[test]
+    fn test_device_type_from_u8() {
+        let dtype = DeviceType::try_from(0);
+        assert_eq!(dtype, Ok(DeviceType::Loopback));
+
+        let dtype = DeviceType::try_from(128);
+        assert_eq!(dtype, Err(InvalidDeviceType(128)));
     }
 }

--- a/rust/agama-lib/src/network/types.rs
+++ b/rust/agama-lib/src/network/types.rs
@@ -1,6 +1,7 @@
-use std::{fmt, str};
-
 use serde::{Deserialize, Serialize};
+use std::{fmt, str};
+use thiserror::Error;
+use zbus;
 
 #[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
 pub struct SSID(pub Vec<u8>);
@@ -20,5 +21,35 @@ impl fmt::Display for SSID {
 impl From<SSID> for Vec<u8> {
     fn from(value: SSID) -> Self {
         value.0.clone()
+    }
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum DeviceType {
+    Loopback = 0,
+    Ethernet = 1,
+    Wireless = 2,
+}
+
+#[derive(Debug, Error)]
+#[error("Invalid device type: {0}")]
+pub struct InvalidDeviceType(u8);
+
+impl TryFrom<u8> for DeviceType {
+    type Error = InvalidDeviceType;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(DeviceType::Loopback),
+            1 => Ok(DeviceType::Ethernet),
+            2 => Ok(DeviceType::Wireless),
+            _ => Err(InvalidDeviceType(value)),
+        }
+    }
+}
+
+impl From<InvalidDeviceType> for zbus::fdo::Error {
+    fn from(value: InvalidDeviceType) -> zbus::fdo::Error {
+        zbus::fdo::Error::Failed(format!("Network error: {}", value.to_string()))
     }
 }

--- a/rust/agama-lib/src/settings.rs
+++ b/rust/agama-lib/src/settings.rs
@@ -86,12 +86,13 @@ pub trait Settings {
 ///   let value: bool = value.try_into().expect("the conversion failed");
 ///   assert_eq!(value, true);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SettingValue(pub String);
 
 /// Represents a string-based collection and allows converting to other types
 ///
 /// It wraps a hash which uses String as key and SettingValue as value.
+#[derive(Debug)]
 pub struct SettingObject(pub HashMap<String, SettingValue>);
 
 impl SettingObject {

--- a/rust/agama-lib/src/settings.rs
+++ b/rust/agama-lib/src/settings.rs
@@ -94,6 +94,15 @@ pub struct SettingValue(pub String);
 /// It wraps a hash which uses String as key and SettingValue as value.
 pub struct SettingObject(pub HashMap<String, SettingValue>);
 
+impl SettingObject {
+    /// Returns the value for the given key.
+    ///
+    /// * `key`: setting key.
+    pub fn get(&self, key: &str) -> Option<&SettingValue> {
+        self.0.get(key)
+    }
+}
+
 impl From<HashMap<String, String>> for SettingObject {
     fn from(value: HashMap<String, String>) -> SettingObject {
         let mut hash: HashMap<String, SettingValue> = HashMap::new();

--- a/rust/agama-lib/src/storage/settings.rs
+++ b/rust/agama-lib/src/storage/settings.rs
@@ -29,7 +29,7 @@ impl TryFrom<SettingObject> for Device {
     type Error = &'static str;
 
     fn try_from(value: SettingObject) -> Result<Self, Self::Error> {
-        match value.0.get("name") {
+        match value.get("name") {
             Some(name) => Ok(Device {
                 name: name.clone().try_into()?,
             }),


### PR DESCRIPTION
## Problem

#622 added support to display the network configuration through the CLI: `agama config show`. However, writing the configuration was still missing.

Trello card: https://trello.com/c/vVe8CboU/3354-8-agama-set-the-network-configuration-using-a-jsonnet-file

## Solution

This PR implements support to set the network configuration using the CLI. But, as usual, we took the chance to do some refactoring and clean-up.

## Note: naming network connections

Agama's network service API works with connection names (Id) instead of UUIDs. In NetworkManager, you can use any of them. However, we prefer our users to work with Ids, not UUIDs, because they are more human-readable. The problem is that, in NetworkManager, the Id is not unique.

This PR modifies Agama to rename duplicated network connections. For instance, if we have multiple connections with the same name (e.g., `virbr0`), Agama will add a suffix to the duplicates (e.g., `virbr0-1`, `virbr0-2`, etc.).

## Testing

- [x] Added (a few) unit tests
- [x] Tested manually

## Future

We would like to implement a few changes, but we should address them separately.

- Bound a connection to a specific network interface. By now, NetworkManager chooses the device automatically.
- 
- The software service might need to wait until the network is ready.
- Do not update those connections that did not change.