### PR TITLE
Add support for questions with no default options

### DIFF
--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul  5 11:11:20 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the questions service to handle questions with no default
+  option (gh#openSUSE/agama#649).
+
+-------------------------------------------------------------------
 Thu Jun  1 08:14:14 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add a localization D-Bus service (gh#openSUSE/agama#533).


### PR DESCRIPTION
The Questions service crashes if no default options are given. It was supported in the Ruby-based version, so we need to fix the new service to support it.

According to a comment on the code, we should stop using an array for the default options, forcing a default option anyway. But let's discuss that later.