### PR TITLE
zFCP improvements

### DIFF
--- a/service/lib/agama/storage/zfcp/manager.rb
+++ b/service/lib/agama/storage/zfcp/manager.rb
@@ -21,6 +21,7 @@
 
 require "yast"
 require "y2s390/zfcp"
+require "y2storage/storage_manager"
 require "agama/storage/zfcp/controller"
 require "agama/storage/zfcp/disk"
 
@@ -54,14 +55,20 @@ module Agama
 
         # Probes zFCP
         #
-        # Callbacks are called at the end, see {#on_probe}.
+        # Callbacks {#on_probe} are called after probing, and callbacks {#on_disks_change} are
+        # called if there is any change in the disks.
         def probe
           logger.info "Probing zFCP"
 
+          previous_disks = disks
           yast_zfcp.probe_controllers
           yast_zfcp.probe_disks
 
           @on_probe_callbacks&.each { |c| c.call(controllers, disks) }
+
+          return unless disks_changed?(previous_disks)
+
+          @on_disks_change_callbacks&.each { |c| c.call(disks) }
         end
 
         # zFCP controllers
@@ -102,10 +109,10 @@ module Agama
             # activating a controller for first time because some SCSI initialization. Probing the
             # disks should be done after all disks are activated.
             #
-            # FIXME: waiting 2 seconds should be enough, but there is no guarantee that the disks
-            # are actually exported.
+            # FIXME: waiting 2 seconds should be enough, but there is no guarantee that all the
+            # disks are actually activated.
             sleep(2)
-            update_disks
+            probe
           end
           output["exit"]
         end
@@ -119,7 +126,7 @@ module Agama
         # @return [Integer] Exit code of the chzdev command (0 on success)
         def activate_disk(channel, wwpn, lun)
           output = yast_zfcp.activate_disk(channel, wwpn, lun)
-          update_disks if output["exit"] == 0
+          probe if output["exit"] == 0
           output["exit"]
         end
 
@@ -134,7 +141,7 @@ module Agama
         # @return [Integer] Exit code of the chzdev command (0 on success)
         def deactivate_disk(channel, wwpn, lun)
           output = yast_zfcp.deactivate_disk(channel, wwpn, lun)
-          update_disks if output["exit"] == 0
+          probe if output["exit"] == 0
           output["exit"]
         end
 
@@ -163,15 +170,28 @@ module Agama
         # @return [Logger]
         attr_reader :logger
 
-        # Probes and runs the on_disk_change callbacsk if disks have changed
-        def update_disks
-          disk_records = yast_zfcp.disks.sort_by { |d| d["dev_name"] }
-          probe
-          new_disk_records = yast_zfcp.disks.sort_by { |d| d["dev_name"] }
+        # Whether threre is any change in the disks
+        #
+        # Checks whether any of the removed disks is still probed or whether any of the current
+        # disks is not probed yet.
+        #
+        # @param previous_disks [Array<Disk>] Previously activated disks (before zFCP (re)probing)
+        # @return [Booelan]
+        def disks_changed?(previous_disks)
+          removed_disks = previous_disks - disks
 
-          return if disk_records == new_disk_records
+          return true if removed_disks.any? { |d| exist_disk?(d) }
+          return true if disks.any? { |d| !exist_disk?(d) }
 
-          @on_disks_change_callbacks&.each { |c| c.call(disks) }
+          false
+        end
+
+        # Whether the given disk is probed
+        #
+        # @param disk [Disk]
+        # @return [Booelan]
+        def exist_disk?(disk)
+          !Y2Storage::StorageManager.instance.probed.find_by_name(disk.name).nil?
         end
 
         # Creates a zFCP controller from YaST data

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul  5 14:02:23 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Delay zFCP probing after activating a controller and ensure the
+  system is marked as deprecated if needed after probing zFCP
+  (gh#openSUSE/agama#650).
+
+-------------------------------------------------------------------
 Wed Jun 14 15:11:56 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Extend zFCP D-Bus API to provide allow_lun_scan info

--- a/service/test/agama/storage/zfcp/manager_test.rb
+++ b/service/test/agama/storage/zfcp/manager_test.rb
@@ -179,6 +179,7 @@ describe Agama::Storage::ZFCP::Manager do
   describe "#activate_controller" do
     before do
       allow(yast_zfcp).to receive(:activate_controller).and_return(output)
+      allow(subject).to receive(:sleep)
 
       subject.on_disks_change(&callback)
     end

--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul  5 13:59:58 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Add info about deactivated zFCP auto_lun_scan and sort members in
+  device selector (gh#openSUSE/agama#650).
+
+-------------------------------------------------------------------
 Mon Jul  3 10:18:32 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Add page for managing zFCP devices (gh#openSUSE/agama#634).

--- a/web/src/components/storage/DeviceSelector.jsx
+++ b/web/src/components/storage/DeviceSelector.jsx
@@ -122,7 +122,7 @@ const ItemContent = ({ device }) => {
 
       const members = device.members.map(m => m.split("/").at(-1));
 
-      return <div>Members: {members.join(", ")}</div>;
+      return <div>Members: {members.sort().join(", ")}</div>;
     };
 
     const RAIDInfo = () => {
@@ -130,7 +130,7 @@ const ItemContent = ({ device }) => {
 
       const devices = device.devices.map(m => m.split("/").at(-1));
 
-      return <div>Devices: {devices.join(", ")}</div>;
+      return <div>Devices: {devices.sort().join(", ")}</div>;
     };
 
     const MultipathInfo = () => {
@@ -138,7 +138,7 @@ const ItemContent = ({ device }) => {
 
       const wires = device.wires.map(m => m.split("/").at(-1));
 
-      return <div>Wires: {wires.join(", ")}</div>;
+      return <div>Wires: {wires.sort().join(", ")}</div>;
     };
 
     return (

--- a/web/src/components/storage/ZFCPPage.jsx
+++ b/web/src/components/storage/ZFCPPage.jsx
@@ -422,26 +422,31 @@ const ControllersSection = ({ client, manager, load = noop, isLoading = false })
   };
 
   const Content = () => {
-    const AllowLUNScan = () => {
+    const LUNScanInfo = () => {
       return (
-        <p>
-          The system is configured to perform automatic LUN scan. If a controller is running in
-          NPIV mode, then all its LUNs are automatically activated.
-        </p>
+        <If
+          condition={allowLUNScan}
+          then={
+            <p>
+              Automatic LUN scan is <b>enabled</b>. Activating a controller which is running in NPIV
+              mode will automatically configures all its LUNs.
+            </p>
+          }
+          else={
+            <p>
+              Automatic LUN scan is <b>disabled</b>. LUNs have to be manually configured after
+              activating a controller.
+            </p>
+          }
+        />
       );
     };
 
     return (
-      <If
-        condition={manager.controllers.length === 0}
-        then={<EmptyState />}
-        else={
-          <>
-            <If condition={allowLUNScan} then={<AllowLUNScan />} />
-            <ControllersTable client={client} manager={manager} />
-          </>
-        }
-      />
+      <>
+        <LUNScanInfo />
+        <ControllersTable client={client} manager={manager} />
+      </>
     );
   };
 

--- a/web/src/components/storage/ZFCPPage.test.jsx
+++ b/web/src/components/storage/ZFCPPage.test.jsx
@@ -98,7 +98,7 @@ describe("if allow-lun-scan is activated", () => {
   it("renders an explanation about allow-lun-scan", async () => {
     installerRender(<ZFCPPage />);
 
-    await screen.findByText(/is configured to perform automatic LUN scan/);
+    await screen.findByText(/automatically configures all its LUNs/);
   });
 });
 
@@ -107,10 +107,10 @@ describe("if allow-lun-scan is not activated", () => {
     client.getAllowLUNScan = jest.fn().mockResolvedValue(false);
   });
 
-  it("does not render an explanation about allow-lun-scan", async () => {
+  it("renders an explanation about not using allow-lun-scan", async () => {
     installerRender(<ZFCPPage />);
 
-    await waitFor(() => expect(screen.queryByText(/is configured to perform automatic LUN scan/)).toBeNull());
+    await screen.findByText(/LUNs have to be manually configured/);
   });
 });
 


### PR DESCRIPTION
## Problem

Two things to fix/improve:

* Automatically activated zFCP disks are not probed after activating a controller.
* There is no info about allow_lun_scan when the option is disabled.

## Solution

* Delay zFCP probing in order to give some time to disk activation.
* The system is marked as deprecated after probing, if needed.
* allow_lun_scan status is always informed.
* The allow_lun_scan explanation is improved.

Bonus: members of a device are sorted in the disk selector. 

## Testing

* Adapted unit tests
* Tested manually

## Screenshots

<details>
<summary>Show/hide</summary>

![localhost_8080_ (13)](https://github.com/openSUSE/agama/assets/1112304/71c3c4b0-6073-4fa0-9f57-a095c55bbfad)

![localhost_8080_ (14)](https://github.com/openSUSE/agama/assets/1112304/0a8bdb4a-3e0f-4665-8002-ee774f63b796)

</details>
