### PR TITLE
CLI: wait before trying to start the installation

### DIFF
--- a/rust/agama-cli/src/error.rs
+++ b/rust/agama-cli/src/error.rs
@@ -6,4 +6,6 @@ pub enum CliError {
     InvalidKeyName(String),
     #[error("Cannot perform the installation as the settings are not valid")]
     ValidationError,
+    #[error("Could not start the installation")]
+    InstallationError,
 }

--- a/rust/agama-cli/src/main.rs
+++ b/rust/agama-cli/src/main.rs
@@ -46,10 +46,13 @@ async fn probe() -> Result<(), Box<dyn Error>> {
 ///
 /// * `manager`: the manager client.
 async fn install(manager: &ManagerClient<'_>, max_attempts: u8) -> Result<(), Box<dyn Error>> {
+    if manager.is_busy().await {
+        println!("Agama's manager is busy. Waiting until it is ready...");
+    }
+
     if !manager.can_install().await? {
         return Err(Box::new(CliError::ValidationError));
     }
-
     // Display the progress (if needed) and makes sure that the manager is ready
     manager.wait().await?;
 
@@ -72,6 +75,7 @@ async fn install(manager: &ManagerClient<'_>, max_attempts: u8) -> Result<(), Bo
         attempts += 1;
         sleep(Duration::from_secs(1));
     }
+    println!("The installation process has started.");
     Ok(())
 }
 

--- a/rust/agama-cli/src/main.rs
+++ b/rust/agama-cli/src/main.rs
@@ -47,13 +47,10 @@ async fn probe() -> Result<(), Box<dyn Error>> {
 /// * `manager`: the manager client.
 async fn install(manager: &ManagerClient<'_>, max_attempts: u8) -> Result<(), Box<dyn Error>> {
     if !manager.can_install().await? {
-        // TODO: add some hints what is wrong or add dedicated command for it?
-        eprintln!("There are issues with configuration. Cannot install.");
         return Err(Box::new(CliError::ValidationError));
     }
 
     // Display the progress (if needed) and makes sure that the manager is ready
-    show_progress().await?;
     manager.wait().await?;
 
     // Try to start the installation up to max_attempts times.
@@ -121,7 +118,6 @@ async fn run_command(cli: Cli) -> Result<(), Box<dyn Error>> {
         Commands::Profile(subcommand) => Ok(run_profile_cmd(subcommand)?),
         Commands::Install => {
             let manager = build_manager().await?;
-            block_on(wait_for_services(&manager))?;
             block_on(install(&manager, 3))
         }
         _ => unimplemented!(),

--- a/rust/agama-lib/src/manager.rs
+++ b/rust/agama-lib/src/manager.rs
@@ -43,9 +43,19 @@ impl<'a> ManagerClient<'a> {
         Progress::from_proxy(&self.progress_proxy).await
     }
 
+    /// Returns whether the service is busy or not
+    ///
+    /// TODO: move this code to a trait with functions related to the service status.
+    pub async fn is_busy(&self) -> bool {
+        if let Ok(status) = self.status_proxy.current().await {
+            return status != 0;
+        }
+        true
+    }
+
     /// Waits until the manager is idle.
     pub async fn wait(&self) -> Result<(), ServiceError> {
-        if self.status_proxy.current().await? == 0 {
+        if !self.is_busy().await {
             return Ok(());
         }
 

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul  6 09:13:47 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Improve the waiting logic and implement a retry mechanism for the
+  "agama install" command (bsc#1213047).
+
+-------------------------------------------------------------------
 Wed Jul  5 11:11:20 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the questions service to handle questions with no default


### PR DESCRIPTION
## Problem

The `agama install` command might find the Manager service busy even if the progress reporting has finished. It may start the installation process right before the service status has been updated (although it is effectively not busy).

* [bsc#1210941](https://bugzilla.suse.com/show_bug.cgi?id=1210941)

## Solution

Let's try to make the `agama install` command more robust:

* Wait until the Manager reports to be idle.
* Retry (up to three times) if there is a problem.
* Stop reporting the progress while waiting. This command is expected to be used in the auto-installation scripts. We can add a *monitor* command for such a purpose.

## Notes

* Error and progress reporting in the UI are far from ideal. But let's address that later.
* We could add switches to influence the number of retries and the time between them.