### PR TITLE
CLI: Better progress reporting

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "agama-lib",
  "async-std",
  "clap",
+ "console",
  "convert_case",
  "indicatif",
  "serde",

--- a/rust/agama-cli/Cargo.toml
+++ b/rust/agama-cli/Cargo.toml
@@ -15,6 +15,7 @@ indicatif= "0.17.3"
 async-std = { version ="1.12.0", features = ["attributes"] }
 thiserror = "1.0.39"
 convert_case = "0.6.0"
+console = "0.15.7"
 
 [[bin]]
 name = "agama"

--- a/rust/agama-cli/src/main.rs
+++ b/rust/agama-cli/src/main.rs
@@ -10,7 +10,7 @@ mod progress;
 use crate::error::CliError;
 use agama_lib::error::ServiceError;
 use agama_lib::manager::ManagerClient;
-use agama_lib::progress::build_progress_monitor;
+use agama_lib::progress::ProgressMonitor;
 use async_std::task::{self, block_on};
 use commands::Commands;
 use config::run as run_config_cmd;
@@ -83,7 +83,7 @@ async fn show_progress() -> Result<(), ServiceError> {
     // wait 1 second to give other task chance to start, so progress can display something
     task::sleep(Duration::from_secs(1)).await;
     let conn = agama_lib::connection().await?;
-    let mut monitor = build_progress_monitor(conn).await.unwrap();
+    let mut monitor = ProgressMonitor::new(conn).await.unwrap();
     let presenter = InstallerProgress::new();
     monitor
         .run(presenter)

--- a/rust/agama-lib/src/progress.rs
+++ b/rust/agama-lib/src/progress.rs
@@ -2,41 +2,48 @@
 //! interface.
 //!
 //! The library does not prescribe any way to present that information to the user. As shown in the
-//! example below, you need to implement the [ProgressPresenter] for your own presenter.
+//! example below, you can build your own presenter and implement the [ProgressPresenter] trait.
 //!
 //! ```no_run
-//! # use agama_lib::progress::{Progress, ProgressMonitorBuilder, ProgressPresenter};
+//! # use agama_lib::progress::{Progress, ProgressMonitor, ProgressPresenter};
 //! # use async_std::task::block_on;
 //! # use zbus;
 //!
 //! // Custom presenter
 //! struct SimplePresenter {};
 //!
+//! impl SimplePresenter {
+//!   fn report_progress(&self, progress: &Progress) {
+//!       println!("{}/{} {}", &progress.current_step, &progress.max_steps, &progress.title);
+//!   }
+//! }
+//!
 //! impl ProgressPresenter for SimplePresenter {
-//!     fn start(&mut self, progress: &[Progress]) {
-//!         println!("Starting...");
+//!     fn start(&mut self, progress: &Progress) {
+//!        println!("Starting...");
+//!        self.report_progress(progress);
 //!     }
 //!
-//!     fn update(&mut self, progress: &[Progress]) {
-//!         for info in progress.iter() {
-//!             println!("{} ({}/{})", info.current_title, info.current_step, info.max_steps);
-//!         }
+//!     fn update(&mut self, progress: &Progress) {
+//!        self.report_progress(progress);
+//!     }
+//!
+//!     fn finish(&mut self) {
+//!         println!("Done");
 //!     }
 //! }
 //!
 //! let connection = block_on(zbus::Connection::system()).unwrap();
-//! let builder = ProgressMonitorBuilder::new(connection)
-//!     .add_proxy("org.opensuse.Agama1", "/org/opensuse/Agama1/Manager");
-//! let mut monitor = block_on(builder.build()).unwrap();
+//! let mut monitor = block_on(ProgressMonitor::new(connection)).unwrap();
 //! monitor.run(SimplePresenter {});
 //! ```
 
+use crate::error::ServiceError;
 use crate::proxies::ProgressProxy;
-use futures::stream::StreamExt;
-use futures::stream::{select_all, SelectAll};
-use futures_util::future::try_join3;
+use futures::stream::{SelectAll, StreamExt};
+use futures_util::{future::try_join3, Stream};
 use std::error::Error;
-use zbus::{Connection, PropertyStream};
+use zbus::Connection;
 
 /// Represents the progress for an Agama service.
 #[derive(Default, Debug)]
@@ -49,8 +56,6 @@ pub struct Progress {
     pub current_title: String,
     /// Whether the progress reporting is finished
     pub finished: bool,
-    /// D-Bus path that reports the progress
-    pub object_path: String,
 }
 
 impl Progress {
@@ -63,134 +68,114 @@ impl Progress {
             current_title,
             max_steps,
             finished,
-            object_path: proxy.path().to_string(),
         })
     }
 }
 
-pub struct ProgressMonitorBuilder {
-    proxies: Vec<(String, String)>,
-    connection: Connection,
-}
-
-/// Builds a [ProgressMonitor] for a set of services. See [build_progress_monitor] for a usage
-/// example.
-impl<'a> ProgressMonitorBuilder {
-    pub fn new(connection: Connection) -> Self {
-        Self {
-            proxies: vec![],
-            connection,
-        }
-    }
-
-    pub fn add_proxy(mut self, destination: &str, path: &str) -> Self {
-        self.proxies.push((destination.to_owned(), path.to_owned()));
-        self
-    }
-
-    pub async fn build(self) -> Result<ProgressMonitor<'a>, Box<dyn Error>> {
-        let mut monitor = ProgressMonitor::default();
-
-        for (destination, path) in self.proxies {
-            let proxy = ProgressProxy::builder(&self.connection)
-                .path(path)?
-                .destination(destination)?
-                .build()
-                .await?;
-            monitor.add_proxy(proxy);
-        }
-        Ok(monitor)
-    }
-}
-
 /// Monitorizes and reports the progress of Agama's current operation.
-#[derive(Default)]
+///
+/// It implements a main/details reporter by listening to the manager and software services,
+/// similar to Agama's web UI. How this information is displayed depends on the presenter (see
+/// [ProgressMonitor.run]).
 pub struct ProgressMonitor<'a> {
-    pub proxies: Vec<ProgressProxy<'a>>,
+    manager_proxy: ProgressProxy<'a>,
+    software_proxy: ProgressProxy<'a>,
 }
 
 impl<'a> ProgressMonitor<'a> {
-    pub fn add_proxy(&mut self, proxy: ProgressProxy<'a>) {
-        self.proxies.push(proxy);
+    pub async fn new(connection: Connection) -> Result<ProgressMonitor<'a>, ServiceError> {
+        let manager_proxy = ProgressProxy::builder(&connection)
+            .path("/org/opensuse/Agama1/Manager")?
+            .destination("org.opensuse.Agama1")?
+            .build()
+            .await?;
+
+        let software_proxy = ProgressProxy::builder(&connection)
+            .path("/org/opensuse/Agama/Software1")?
+            .destination("org.opensuse.Agama.Software1")?
+            .build()
+            .await?;
+
+        Ok(Self {
+            manager_proxy,
+            software_proxy,
+        })
     }
 
-    /// Starts the progress monitor.
-    ///
-    /// It stops when all the services report that their current operations are finished.
+    /// Runs the monitor until the current operation finishes.
     pub async fn run(
         &mut self,
         mut presenter: impl ProgressPresenter,
     ) -> Result<(), Box<dyn Error>> {
+        presenter.start(&self.main_progress().await);
         let mut changes = self.build_stream().await;
-        presenter.start(&self.collect_progress().await?);
 
-        while let Some(_change) = changes.next().await {
-            presenter.update(&self.collect_progress().await?);
-            if self.is_finished().await {
-                return Ok(());
-            }
+        while let Some(stream) = changes.next().await {
+            match stream {
+                "/org/opensuse/Agama1/Manager" => {
+                    let progress = self.main_progress().await;
+                    if progress.finished {
+                        presenter.finish();
+                        return Ok(());
+                    } else {
+                        presenter.update_main(&progress);
+                    }
+                }
+                "/org/opensuse/Agama/Software1" => {
+                    presenter.update_detail(&self.detail_progress().await)
+                }
+                _ => eprintln!("Unknown"),
+            };
         }
 
         Ok(())
     }
 
-    async fn is_finished(&self) -> bool {
-        for proxy in &self.proxies {
-            if !proxy.finished().await.unwrap_or(false) {
-                return false;
-            }
-        }
-        true
+    /// Proxy that reports the progress.
+    async fn main_progress(&self) -> Progress {
+        Progress::from_proxy(&self.manager_proxy).await.unwrap()
     }
 
-    async fn collect_progress(&self) -> Result<Vec<Progress>, Box<dyn Error>> {
-        let mut progress = vec![];
-        for proxy in &self.proxies {
-            let proxy_progress = Progress::from_proxy(proxy).await?;
-            progress.push(proxy_progress);
-        }
-        Ok(progress)
+    /// Proxy that reports the progress detail.
+    async fn detail_progress(&self) -> Progress {
+        Progress::from_proxy(&self.software_proxy).await.unwrap()
     }
 
-    async fn build_stream(&self) -> SelectAll<PropertyStream<(u32, String)>> {
-        let mut streams = vec![];
-        for proxy in &self.proxies {
-            let s = proxy.receive_current_step_changed().await;
-            streams.push(s);
-        }
+    /// Builds an stream of progress changes.
+    ///
+    /// It listens for changes in the `Current` property and generates a stream identifying the
+    /// proxy where the change comes from.
+    async fn build_stream(&self) -> SelectAll<impl Stream<Item = &str> + '_> {
+        let mut streams = SelectAll::new();
 
-        select_all(streams)
+        let proxies = [&self.manager_proxy, &self.software_proxy];
+        for proxy in proxies.iter() {
+            let stream = proxy.receive_current_step_changed().await;
+            let path = proxy.path().as_str();
+            let tagged = stream.map(move |_| path);
+            streams.push(tagged);
+        }
+        streams
     }
 }
 
 /// Presents the progress to the user.
 pub trait ProgressPresenter {
-    /// Indicates the start of the progress reporting.
+    /// Starts the progress reporting.
     ///
-    /// * `progress`: initial progress for each service.
-    fn start(&mut self, progress: &[Progress]);
+    /// * `progress`: current main progress.
+    fn start(&mut self, progress: &Progress);
 
-    /// Indicates an update on the progress reporting.
+    /// Updates the progress.
     ///
-    /// * `progress`: updated progress for each service.
-    fn update(&mut self, progress: &[Progress]);
-}
+    /// * `progress`: current progress.
+    fn update_main(&mut self, progress: &Progress);
 
-/// Convenience function that builds a progress monitor for Agama services.
-///
-/// Bear in mind that only the services with long-running tasks are considered.
-pub async fn build_progress_monitor(
-    connection: Connection,
-) -> Result<ProgressMonitor<'static>, Box<dyn Error>> {
-    let builder = ProgressMonitorBuilder::new(connection)
-        .add_proxy("org.opensuse.Agama1", "/org/opensuse/Agama1/Manager")
-        .add_proxy(
-            "org.opensuse.Agama.Software1",
-            "/org/opensuse/Agama/Software1",
-        )
-        .add_proxy(
-            "org.opensuse.Agama.Storage1",
-            "/org/opensuse/Agama/Storage1",
-        );
-    builder.build().await
+    /// Updates the progress detail.
+    ///
+    /// * `progress`: current progress detail.
+    fn update_detail(&mut self, progress: &Progress);
+
+    /// Finishes the progress reporting.
+    fn finish(&mut self);
 }

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jul  7 14:12:03 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Improve the progress reporting (gh#openSUSE/agama#653).
+
+-------------------------------------------------------------------
 Thu Jul  6 09:13:47 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Improve the waiting logic and implement a retry mechanism for the


### PR DESCRIPTION
## Problem

The progress reporting in the CLI was not exactly user-friendly. It started as an experiment during Hack Week, and we did not have the time to look at it again.

## Solution

The work on the progress reporting is not finished but at least this PR is a step in the right (?) direction:

* Refactoring, simplifying and documenting the code related to progress reporting.
* Writing a reporting mechanism similar to the one in the web UI (with the same limitations too).

## Testing

- Tested manually

## Screenshots

| Old progress | New progress |
|-|-|
|![Screenshot from 2023-07-07 14-05-10](https://github.com/openSUSE/agama/assets/15836/4be9cb59-04e0-4b51-93a4-38d0dd317644)|![Screenshot from 2023-07-07 13-48-07](https://github.com/openSUSE/agama/assets/15836/959863f5-86c6-4d48-82b5-46d8c259646d)|

## What to do

- This mechanism might not work that well when retrying an action.
- Error reporting is still rather poor.
- The `main.rs` file deserves some love.