### PR TITLE
CLI: Show candidate devices

### DIFF
--- a/rust/agama-cli/src/printers.rs
+++ b/rust/agama-cli/src/printers.rs
@@ -46,7 +46,7 @@ pub struct JsonPrinter<T, W> {
     writer: W,
 }
 
-impl<T: Serialize + Debug, W: Write> Printer<T, W> for JsonPrinter<T, W> {
+impl<T: Serialize, W: Write> Printer<T, W> for JsonPrinter<T, W> {
     fn print(mut self: Box<Self>) -> anyhow::Result<()> {
         let json = serde_json::to_string(&self.content)?;
         Ok(writeln!(self.writer, "{}", json)?)
@@ -57,7 +57,7 @@ pub struct TextPrinter<T, W> {
     writer: W,
 }
 
-impl<T: Serialize + Debug, W: Write> Printer<T, W> for TextPrinter<T, W> {
+impl<T: Debug, W: Write> Printer<T, W> for TextPrinter<T, W> {
     fn print(mut self: Box<Self>) -> anyhow::Result<()> {
         Ok(writeln!(self.writer, "{:?}", &self.content)?)
     }
@@ -68,7 +68,7 @@ pub struct YamlPrinter<T, W> {
     writer: W,
 }
 
-impl<T: Serialize + Debug, W: Write> Printer<T, W> for YamlPrinter<T, W> {
+impl<T: Serialize, W: Write> Printer<T, W> for YamlPrinter<T, W> {
     fn print(self: Box<Self>) -> anyhow::Result<()> {
         Ok(serde_yaml::to_writer(self.writer, &self.content)?)
     }

--- a/rust/agama-cli/src/printers.rs
+++ b/rust/agama-cli/src/printers.rs
@@ -47,8 +47,9 @@ pub struct JsonPrinter<T, W> {
 }
 
 impl<T: Serialize + Debug, W: Write> Printer<T, W> for JsonPrinter<T, W> {
-    fn print(self: Box<Self>) -> anyhow::Result<()> {
-        Ok(serde_json::to_writer(self.writer, &self.content)?)
+    fn print(mut self: Box<Self>) -> anyhow::Result<()> {
+        let json = serde_json::to_string(&self.content)?;
+        Ok(writeln!(self.writer, "{}", json)?)
     }
 }
 pub struct TextPrinter<T, W> {
@@ -58,7 +59,7 @@ pub struct TextPrinter<T, W> {
 
 impl<T: Serialize + Debug, W: Write> Printer<T, W> for TextPrinter<T, W> {
     fn print(mut self: Box<Self>) -> anyhow::Result<()> {
-        Ok(write!(self.writer, "{:?}", &self.content)?)
+        Ok(writeln!(self.writer, "{:?}", &self.content)?)
     }
 }
 

--- a/rust/agama-lib/src/storage/settings.rs
+++ b/rust/agama-lib/src/storage/settings.rs
@@ -25,6 +25,12 @@ pub struct Device {
     pub name: String,
 }
 
+impl From<String> for Device {
+    fn from(value: String) -> Self {
+        Self { name: value }
+    }
+}
+
 impl TryFrom<SettingObject> for Device {
     type Error = SettingsError;
 

--- a/rust/agama-lib/src/storage/store.rs
+++ b/rust/agama-lib/src/storage/store.rs
@@ -17,9 +17,13 @@ impl<'a> StorageStore<'a> {
         })
     }
 
-    // TODO: read the settings from the service
     pub async fn load(&self) -> Result<StorageSettings, ServiceError> {
-        Ok(Default::default())
+        let names = self.storage_client.candidate_devices().await?;
+        let devices = names.into_iter().map(|n| n.into()).collect();
+        Ok(StorageSettings {
+            devices,
+            ..Default::default()
+        })
     }
 
     pub async fn store(&self, settings: &StorageSettings) -> Result<(), ServiceError> {

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 13 08:56:40 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Read the storage candidate devices and show them with
+  "agama config show" (gh#openSUSE/agama#658).
+
+-------------------------------------------------------------------
 Fri Jul  7 14:12:03 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Improve the progress reporting (gh#openSUSE/agama#653).


### PR DESCRIPTION
## Problem

The information about the selected storage candidate devices is not shown by `agama config show` command. 

Note: this is a Rust introductory card. The goal is to get familiar with the code and start writing some bits. The format of the storage settings (including the candidate devices) is going to be changed soon, see https://github.com/openSUSE/agama/pull/656.

## Solution

Loads the information about the candidate devices.

Bonus: print a new line for *text* and *json* format.

~~~
$ agama -f json config show 
{"user":{"fullName":"","userName":"","password":"","autologin":false},"root":{"sshPublicKey":null},
"software":{"product":"Tumbleweed"},"storage":{"lvm":null,"encryptionPassword":null,
"devices":[{"name":"/dev/vdb"}]},"network":{"connections":[{"id":"enp1s0","method":"auto"},
{"id":"lo","method":"manual","addresses":["127.0.0.1/8"]}]}}
$
~~~

## Testing

- Tested manually
