### PR TITLE
CLI: improve error reporting

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13,6 +13,7 @@ name = "agama-cli"
 version = "1.0.0"
 dependencies = [
  "agama-lib",
+ "anyhow",
  "async-std",
  "clap",
  "console",

--- a/rust/agama-cli/Cargo.toml
+++ b/rust/agama-cli/Cargo.toml
@@ -16,6 +16,7 @@ async-std = { version ="1.12.0", features = ["attributes"] }
 thiserror = "1.0.39"
 convert_case = "0.6.0"
 console = "0.15.7"
+anyhow = "1.0.71"
 
 [[bin]]
 name = "agama"

--- a/rust/agama-cli/src/main.rs
+++ b/rust/agama-cli/src/main.rs
@@ -17,9 +17,12 @@ use config::run as run_config_cmd;
 use printers::Format;
 use profile::run as run_profile_cmd;
 use progress::InstallerProgress;
-use std::error::Error;
-use std::thread::sleep;
-use std::time::Duration;
+use std::{
+    error::Error,
+    process::{ExitCode, Termination},
+    thread::sleep,
+    time::Duration,
+};
 
 #[derive(Parser)]
 #[command(name = "agama", version, about, long_about = None)]
@@ -130,13 +133,27 @@ async fn run_command(cli: Cli) -> Result<(), Box<dyn Error>> {
     }
 }
 
+/// Represents the result of execution.
+pub enum CliResult {
+    /// Successful execution.
+    Ok = 0,
+    /// Something went wrong.
+    Error = 1,
+}
+
+impl Termination for CliResult {
+    fn report(self) -> ExitCode {
+        ExitCode::from(self as u8)
+    }
+}
+
 #[async_std::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> CliResult {
     let cli = Cli::parse();
 
     if let Err(error) = run_command(cli).await {
         eprintln!("{}", error);
-        return Err(error);
+        return CliResult::Error;
     }
-    Ok(())
+    CliResult::Ok
 }

--- a/rust/agama-cli/src/printers.rs
+++ b/rust/agama-cli/src/printers.rs
@@ -1,5 +1,5 @@
+use anyhow;
 use serde::Serialize;
-use std::error;
 use std::fmt::Debug;
 use std::io::Write;
 
@@ -16,7 +16,7 @@ use std::io::Write;
 /// print(user, io::stdout(), Some(Format::Json))
 ///   .expect("Something went wrong!")
 /// ```
-pub fn print<T, W>(content: T, writer: W, format: Format) -> Result<(), Box<dyn error::Error>>
+pub fn print<T, W>(content: T, writer: W, format: Format) -> anyhow::Result<()>
 where
     T: serde::Serialize + Debug,
     W: Write,
@@ -38,7 +38,7 @@ pub enum Format {
 }
 
 pub trait Printer<T, W> {
-    fn print(self: Box<Self>) -> Result<(), Box<dyn error::Error>>;
+    fn print(self: Box<Self>) -> anyhow::Result<()>;
 }
 
 pub struct JsonPrinter<T, W> {
@@ -47,7 +47,7 @@ pub struct JsonPrinter<T, W> {
 }
 
 impl<T: Serialize + Debug, W: Write> Printer<T, W> for JsonPrinter<T, W> {
-    fn print(self: Box<Self>) -> Result<(), Box<dyn error::Error>> {
+    fn print(self: Box<Self>) -> anyhow::Result<()> {
         Ok(serde_json::to_writer(self.writer, &self.content)?)
     }
 }
@@ -57,7 +57,7 @@ pub struct TextPrinter<T, W> {
 }
 
 impl<T: Serialize + Debug, W: Write> Printer<T, W> for TextPrinter<T, W> {
-    fn print(mut self: Box<Self>) -> Result<(), Box<dyn error::Error>> {
+    fn print(mut self: Box<Self>) -> anyhow::Result<()> {
         Ok(write!(self.writer, "{:?}", &self.content)?)
     }
 }
@@ -68,7 +68,7 @@ pub struct YamlPrinter<T, W> {
 }
 
 impl<T: Serialize + Debug, W: Write> Printer<T, W> for YamlPrinter<T, W> {
-    fn print(self: Box<Self>) -> Result<(), Box<dyn error::Error>> {
+    fn print(self: Box<Self>) -> anyhow::Result<()> {
         Ok(serde_yaml::to_writer(self.writer, &self.content)?)
     }
 }

--- a/rust/agama-cli/src/profile.rs
+++ b/rust/agama-cli/src/profile.rs
@@ -1,5 +1,5 @@
-use agama_lib::error::ProfileError;
 use agama_lib::profile::{download, ProfileEvaluator, ProfileValidator, ValidationResult};
+use anyhow::{anyhow, Context};
 use clap::Subcommand;
 use std::path::Path;
 
@@ -15,7 +15,7 @@ pub enum ProfileCommands {
     Evaluate { path: String },
 }
 
-fn validate(path: String) -> Result<(), ProfileError> {
+fn validate(path: String) -> anyhow::Result<()> {
     let validator = ProfileValidator::default_schema()?;
     let path = Path::new(&path);
     let result = validator.validate_file(path)?;
@@ -33,14 +33,14 @@ fn validate(path: String) -> Result<(), ProfileError> {
     Ok(())
 }
 
-fn evaluate(path: String) -> Result<(), ProfileError> {
+fn evaluate(path: String) -> anyhow::Result<()> {
     let evaluator = ProfileEvaluator {};
-    evaluator.evaluate(Path::new(&path))
+    Ok(evaluator.evaluate(Path::new(&path))?)
 }
 
-pub fn run(subcommand: ProfileCommands) -> Result<(), ProfileError> {
+pub fn run(subcommand: ProfileCommands) -> anyhow::Result<()> {
     match subcommand {
-        ProfileCommands::Download { url } => download(&url),
+        ProfileCommands::Download { url } => Ok(download(&url)?),
         ProfileCommands::Validate { path } => validate(path),
         ProfileCommands::Evaluate { path } => evaluate(path),
     }

--- a/rust/agama-cli/src/profile.rs
+++ b/rust/agama-cli/src/profile.rs
@@ -1,5 +1,5 @@
 use agama_lib::profile::{download, ProfileEvaluator, ProfileValidator, ValidationResult};
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use clap::Subcommand;
 use std::path::Path;
 
@@ -18,13 +18,15 @@ pub enum ProfileCommands {
 fn validate(path: String) -> anyhow::Result<()> {
     let validator = ProfileValidator::default_schema()?;
     let path = Path::new(&path);
-    let result = validator.validate_file(path)?;
+    let result = validator
+        .validate_file(path)
+        .context("Could not validate the profile")?;
     match result {
         ValidationResult::Valid => {
             println!("The profile is valid")
         }
         ValidationResult::NotValid(errors) => {
-            println!("The profile is not valid. Please, check the following errors:\n");
+            eprintln!("The profile is not valid. Please, check the following errors:\n");
             for error in errors {
                 println!("* {error}")
             }
@@ -35,7 +37,10 @@ fn validate(path: String) -> anyhow::Result<()> {
 
 fn evaluate(path: String) -> anyhow::Result<()> {
     let evaluator = ProfileEvaluator {};
-    Ok(evaluator.evaluate(Path::new(&path))?)
+    evaluator
+        .evaluate(Path::new(&path))
+        .context(format!("Could not evaluate the profile"))?;
+    Ok(())
 }
 
 pub fn run(subcommand: ProfileCommands) -> anyhow::Result<()> {

--- a/rust/agama-derive/src/lib.rs
+++ b/rust/agama-derive/src/lib.rs
@@ -52,10 +52,10 @@ fn expand_set_fn(field_name: &Vec<Ident>) -> TokenStream2 {
     }
 
     quote! {
-        fn set(&mut self, attr: &str, value: crate::settings::SettingValue) -> Result<(), &'static str> {
+        fn set(&mut self, attr: &str, value: crate::settings::SettingValue) -> Result<(), crate::settings::SettingsError> {
             match attr {
                 #(stringify!(#field_name) => self.#field_name = value.try_into()?,)*
-                _ => return Err("unknown attribute")
+                _ => return Err(SettingsError::UnknownAttribute(attr.to_string()))
             };
             Ok(())
         }
@@ -85,10 +85,10 @@ fn expand_add_fn(field_name: &Vec<Ident>) -> TokenStream2 {
     }
 
     quote! {
-        fn add(&mut self, attr: &str, value: SettingObject) -> Result<(), &'static str> {
+        fn add(&mut self, attr: &str, value: SettingObject) -> Result<(), crate::settings::SettingsError> {
             match attr {
                 #(stringify!(#field_name) => self.#field_name.push(value.try_into()?),)*
-                _ => return Err("unknown attribute")
+                _ => return Err(SettingsError::UnknownCollection(attr.to_string()))
             };
             Ok(())
         }

--- a/rust/agama-lib/src/error.rs
+++ b/rust/agama-lib/src/error.rs
@@ -20,13 +20,11 @@ pub enum ServiceError {
 
 #[derive(Error, Debug)]
 pub enum ProfileError {
-    #[error("Cannot read the profile '{0}'")]
+    #[error("Could not read the profile")]
     Unreachable(#[from] curl::Error),
-    #[error("No hardware information available: '{0}'")]
-    NoHardwareInfo(io::Error),
-    #[error("Could not evaluate the profile: '{0}'")]
-    EvaluationError(io::Error),
-    #[error("Input/output error: '{0}'")]
+    #[error("Jsonnet evaluation failed:\n{0}")]
+    EvaluationError(String),
+    #[error("I/O error: '{0}'")]
     InputOutputError(#[from] io::Error),
     #[error("The profile is not a valid JSON file")]
     FormatError(#[from] serde_json::Error),

--- a/rust/agama-lib/src/error.rs
+++ b/rust/agama-lib/src/error.rs
@@ -8,10 +8,14 @@ use zbus;
 pub enum ServiceError {
     #[error("D-Bus service error: {0}")]
     DBus(#[from] zbus::Error),
+    #[error("Unknown product '{0}'. Available products: '{1:?}'")]
+    UnknownProduct(String, Vec<String>),
     // it's fine to say only "Error" because the original
     // specific error will be printed too
     #[error("Error: {0}")]
     Anyhow(#[from] anyhow::Error),
+    #[error("Wrong user parameters: '{0:?}'")]
+    WrongUser(Vec<String>),
 }
 
 #[derive(Error, Debug)]
@@ -26,12 +30,4 @@ pub enum ProfileError {
     InputOutputError(#[from] io::Error),
     #[error("The profile is not a valid JSON file")]
     FormatError(#[from] serde_json::Error),
-}
-
-#[derive(Error, Debug)]
-pub enum WrongParameter {
-    #[error("Unknown product '{0}'. Available products: '{1:?}'")]
-    UnknownProduct(String, Vec<String>),
-    #[error("Wrong user parameters: '{0:?}'")]
-    WrongUser(Vec<String>),
 }

--- a/rust/agama-lib/src/install_settings.rs
+++ b/rust/agama-lib/src/install_settings.rs
@@ -1,7 +1,7 @@
 //! Configuration settings handling
 //!
 //! This module implements the mechanisms to load and store the installation settings.
-use crate::settings::{SettingObject, SettingValue, Settings};
+use crate::settings::{SettingObject, SettingValue, Settings, SettingsError};
 use crate::{
     network::NetworkSettings, software::SoftwareSettings, storage::StorageSettings,
     users::UserSettings,
@@ -93,7 +93,7 @@ impl InstallSettings {
 }
 
 impl Settings for InstallSettings {
-    fn add(&mut self, attr: &str, value: SettingObject) -> Result<(), &'static str> {
+    fn add(&mut self, attr: &str, value: SettingObject) -> Result<(), SettingsError> {
         if let Some((ns, id)) = attr.split_once('.') {
             match ns {
                 "network" => {
@@ -112,13 +112,13 @@ impl Settings for InstallSettings {
                     let storage = self.storage.get_or_insert(Default::default());
                     storage.add(id, value)?
                 }
-                _ => return Err("unknown attribute"),
+                _ => return Err(SettingsError::UnknownCollection(attr.to_string())),
             }
         }
         Ok(())
     }
 
-    fn set(&mut self, attr: &str, value: SettingValue) -> Result<(), &'static str> {
+    fn set(&mut self, attr: &str, value: SettingValue) -> Result<(), SettingsError> {
         if let Some((ns, id)) = attr.split_once('.') {
             match ns {
                 "network" => {
@@ -143,7 +143,7 @@ impl Settings for InstallSettings {
                     let storage = self.storage.get_or_insert(Default::default());
                     storage.set(id, value)?
                 }
-                _ => return Err("unknown attribute"),
+                _ => return Err(SettingsError::UnknownAttribute(attr.to_string())),
             }
         }
         Ok(())

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -1,7 +1,7 @@
 //! Representation of the network settings
 
 use super::types::DeviceType;
-use crate::settings::{SettingObject, SettingValue, Settings};
+use crate::settings::{SettingObject, SettingValue, Settings, SettingsError};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::default::Default;
@@ -15,10 +15,10 @@ pub struct NetworkSettings {
 }
 
 impl Settings for NetworkSettings {
-    fn add(&mut self, attr: &str, value: SettingObject) -> Result<(), &'static str> {
+    fn add(&mut self, attr: &str, value: SettingObject) -> Result<(), SettingsError> {
         match attr {
             "connections" => self.connections.push(value.try_into()?),
-            _ => return Err("unknown attribute"),
+            _ => return Err(SettingsError::UnknownAttribute(attr.to_string())),
         };
         Ok(())
     }
@@ -70,11 +70,11 @@ impl NetworkConnection {
 }
 
 impl TryFrom<SettingObject> for NetworkConnection {
-    type Error = &'static str;
+    type Error = SettingsError;
 
     fn try_from(value: SettingObject) -> Result<Self, Self::Error> {
         let Some(id) = value.get("id") else {
-            return Err("The 'id' key is missing");
+            return Err(SettingsError::MissingKey("id".to_string()));
         };
 
         let default_method = SettingValue("disabled".to_string());

--- a/rust/agama-lib/src/network/store.rs
+++ b/rust/agama-lib/src/network/store.rs
@@ -1,6 +1,5 @@
 use crate::error::ServiceError;
 use crate::network::{NetworkClient, NetworkSettings};
-use std::error::Error;
 use zbus::Connection;
 
 /// Loads and stores the network settings from/to the D-Bus service.
@@ -16,7 +15,7 @@ impl<'a> NetworkStore<'a> {
     }
 
     // TODO: read the settings from the service
-    pub async fn load(&self) -> Result<NetworkSettings, Box<dyn Error>> {
+    pub async fn load(&self) -> Result<NetworkSettings, ServiceError> {
         let connections = self.network_client.connections().await?;
 
         Ok(NetworkSettings {
@@ -25,7 +24,7 @@ impl<'a> NetworkStore<'a> {
         })
     }
 
-    pub async fn store(&self, settings: &NetworkSettings) -> Result<(), Box<dyn Error>> {
+    pub async fn store(&self, settings: &NetworkSettings) -> Result<(), ServiceError> {
         for conn in &settings.connections {
             self.network_client.add_or_update_connection(&conn).await?;
         }

--- a/rust/agama-lib/src/profile.rs
+++ b/rust/agama-lib/src/profile.rs
@@ -1,4 +1,5 @@
 use crate::error::ProfileError;
+use anyhow::Context;
 use curl::easy::Easy;
 use jsonschema::JSONSchema;
 use log::info;
@@ -101,7 +102,7 @@ impl ProfileValidator {
 pub struct ProfileEvaluator {}
 
 impl ProfileEvaluator {
-    pub fn evaluate(&self, profile_path: &Path) -> Result<(), ProfileError> {
+    pub fn evaluate(&self, profile_path: &Path) -> anyhow::Result<()> {
         let dir = tempdir()?;
 
         let working_path = dir.path().join("profile.jsonnet");
@@ -109,13 +110,18 @@ impl ProfileEvaluator {
 
         let hwinfo_path = dir.path().join("hw.libsonnet");
         self.write_hwinfo(&hwinfo_path)
-            .map_err(ProfileError::NoHardwareInfo)?;
+            .context("Failed to read system's hardware information")?;
 
         let result = Command::new("/usr/bin/jsonnet")
             .arg("profile.jsonnet")
             .current_dir(&dir)
             .output()
-            .map_err(ProfileError::EvaluationError)?;
+            .context("Failed to run jsonnet")?;
+        if !result.status.success() {
+            let message =
+                String::from_utf8(result.stderr).context("Invalid UTF-8 sequence from jsonnet")?;
+            return Err(ProfileError::EvaluationError(message).into());
+        }
         io::stdout().write_all(&result.stdout)?;
         Ok(())
     }
@@ -124,10 +130,11 @@ impl ProfileEvaluator {
     //
     // TODO: we need a better way to generate this information, as lshw and hwinfo are not usable
     // out of the box.
-    fn write_hwinfo(&self, path: &Path) -> Result<(), io::Error> {
+    fn write_hwinfo(&self, path: &Path) -> anyhow::Result<()> {
         let result = Command::new("/usr/sbin/lshw")
             .args(["-json", "-class", "disk"])
-            .output()?;
+            .output()
+            .context("Failed to run lshw")?;
         let mut file = fs::File::create(path)?;
         file.write(b"{ \"disks\":\n")?;
         file.write_all(&result.stdout)?;

--- a/rust/agama-lib/src/progress.rs
+++ b/rust/agama-lib/src/progress.rs
@@ -46,7 +46,6 @@ use crate::error::ServiceError;
 use crate::proxies::ProgressProxy;
 use futures::stream::{SelectAll, StreamExt};
 use futures_util::{future::try_join3, Stream};
-use std::error::Error;
 use zbus::Connection;
 
 /// Represents the progress for an Agama service.
@@ -107,10 +106,7 @@ impl<'a> ProgressMonitor<'a> {
     }
 
     /// Runs the monitor until the current operation finishes.
-    pub async fn run(
-        &mut self,
-        mut presenter: impl ProgressPresenter,
-    ) -> Result<(), Box<dyn Error>> {
+    pub async fn run(&mut self, mut presenter: impl ProgressPresenter) -> Result<(), ServiceError> {
         presenter.start(&self.main_progress().await);
         let mut changes = self.build_stream().await;
 

--- a/rust/agama-lib/src/software/settings.rs
+++ b/rust/agama-lib/src/software/settings.rs
@@ -1,6 +1,6 @@
 //! Representation of the software settings
 
-use crate::settings::Settings;
+use crate::settings::{Settings, SettingsError};
 use agama_derive::Settings;
 use serde::{Deserialize, Serialize};
 

--- a/rust/agama-lib/src/software/store.rs
+++ b/rust/agama-lib/src/software/store.rs
@@ -1,8 +1,7 @@
 //! Implements the store for the storage settings.
 
 use super::{SoftwareClient, SoftwareSettings};
-use crate::error::{ServiceError, WrongParameter};
-use std::error::Error;
+use crate::error::ServiceError;
 use zbus::Connection;
 
 /// Loads and stores the software settings from/to the D-Bus service.
@@ -17,7 +16,7 @@ impl<'a> SoftwareStore<'a> {
         })
     }
 
-    pub async fn load(&self) -> Result<SoftwareSettings, Box<dyn Error>> {
+    pub async fn load(&self) -> Result<SoftwareSettings, ServiceError> {
         let product = self.software_client.product().await?;
 
         Ok(SoftwareSettings {
@@ -25,17 +24,14 @@ impl<'a> SoftwareStore<'a> {
         })
     }
 
-    pub async fn store(&self, settings: &SoftwareSettings) -> Result<(), Box<dyn Error>> {
+    pub async fn store(&self, settings: &SoftwareSettings) -> Result<(), ServiceError> {
         if let Some(product) = &settings.product {
             let products = self.software_client.products().await?;
             let ids: Vec<String> = products.into_iter().map(|p| p.id).collect();
             if ids.contains(&product) {
                 self.software_client.select_product(product).await?;
             } else {
-                return Err(Box::new(WrongParameter::UnknownProduct(
-                    product.clone(),
-                    ids,
-                )));
+                return Err(ServiceError::UnknownProduct(product.clone(), ids));
             }
         }
         Ok(())

--- a/rust/agama-lib/src/storage/settings.rs
+++ b/rust/agama-lib/src/storage/settings.rs
@@ -1,6 +1,6 @@
 //! Representation of the storage settings
 
-use crate::settings::{SettingObject, Settings};
+use crate::settings::{SettingObject, Settings, SettingsError};
 use agama_derive::Settings;
 use serde::{Deserialize, Serialize};
 
@@ -26,14 +26,14 @@ pub struct Device {
 }
 
 impl TryFrom<SettingObject> for Device {
-    type Error = &'static str;
+    type Error = SettingsError;
 
     fn try_from(value: SettingObject) -> Result<Self, Self::Error> {
         match value.get("name") {
             Some(name) => Ok(Device {
                 name: name.clone().try_into()?,
             }),
-            None => Err("'name' key not found"),
+            _ => return Err(SettingsError::MissingKey("name".to_string())),
         }
     }
 }

--- a/rust/agama-lib/src/storage/store.rs
+++ b/rust/agama-lib/src/storage/store.rs
@@ -3,7 +3,6 @@
 use super::{StorageClient, StorageSettings};
 use crate::error::ServiceError;
 use std::default::Default;
-use std::error::Error;
 use zbus::Connection;
 
 /// Loads and stores the storage settings from/to the D-Bus service.
@@ -19,11 +18,11 @@ impl<'a> StorageStore<'a> {
     }
 
     // TODO: read the settings from the service
-    pub async fn load(&self) -> Result<StorageSettings, Box<dyn Error>> {
+    pub async fn load(&self) -> Result<StorageSettings, ServiceError> {
         Ok(Default::default())
     }
 
-    pub async fn store(&self, settings: &StorageSettings) -> Result<(), Box<dyn Error>> {
+    pub async fn store(&self, settings: &StorageSettings) -> Result<(), ServiceError> {
         self.storage_client
             .calculate(
                 settings.devices.iter().map(|d| d.name.clone()).collect(),

--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -5,7 +5,6 @@ use crate::install_settings::{InstallSettings, Scope};
 use crate::{
     network::NetworkStore, software::SoftwareStore, storage::StorageStore, users::UsersStore,
 };
-use std::error::Error;
 use zbus::Connection;
 
 /// Struct that loads/stores the settings from/to the D-Bus services.
@@ -32,7 +31,7 @@ impl<'a> Store<'a> {
     }
 
     /// Loads the installation settings from the D-Bus service
-    pub async fn load(&self, only: Option<Vec<Scope>>) -> Result<InstallSettings, Box<dyn Error>> {
+    pub async fn load(&self, only: Option<Vec<Scope>>) -> Result<InstallSettings, ServiceError> {
         let scopes = match only {
             Some(scopes) => scopes,
             None => Scope::all().to_vec(),
@@ -59,7 +58,7 @@ impl<'a> Store<'a> {
     }
 
     /// Stores the given installation settings in the D-Bus service
-    pub async fn store(&self, settings: &InstallSettings) -> Result<(), Box<dyn Error>> {
+    pub async fn store(&self, settings: &InstallSettings) -> Result<(), ServiceError> {
         if let Some(network) = &settings.network {
             self.network.store(network).await?;
         }

--- a/rust/agama-lib/src/users/client.rs
+++ b/rust/agama-lib/src/users/client.rs
@@ -2,7 +2,7 @@
 
 use super::proxies::Users1Proxy;
 use crate::error::ServiceError;
-use crate::settings::{SettingValue, Settings};
+use crate::settings::{SettingValue, Settings, SettingsError};
 use serde::Serialize;
 use zbus::Connection;
 
@@ -43,13 +43,13 @@ impl FirstUser {
 }
 
 impl Settings for FirstUser {
-    fn set(&mut self, attr: &str, value: SettingValue) -> Result<(), &'static str> {
+    fn set(&mut self, attr: &str, value: SettingValue) -> Result<(), SettingsError> {
         match attr {
             "full_name" => self.full_name = value.try_into()?,
             "user_name" => self.user_name = value.try_into()?,
             "password" => self.password = value.try_into()?,
             "autologin" => self.autologin = value.try_into()?,
-            _ => return Err("unknown attribute"),
+            _ => return Err(SettingsError::UnknownAttribute(attr.to_string())),
         }
         Ok(())
     }

--- a/rust/agama-lib/src/users/settings.rs
+++ b/rust/agama-lib/src/users/settings.rs
@@ -1,4 +1,4 @@
-use crate::settings::{SettingValue, Settings};
+use crate::settings::{SettingValue, Settings, SettingsError};
 use agama_derive::Settings;
 use serde::{Deserialize, Serialize};
 
@@ -14,7 +14,7 @@ pub struct UserSettings {
 }
 
 impl Settings for UserSettings {
-    fn set(&mut self, attr: &str, value: SettingValue) -> Result<(), &'static str> {
+    fn set(&mut self, attr: &str, value: SettingValue) -> Result<(), SettingsError> {
         if let Some((ns, id)) = attr.split_once('.') {
             match ns {
                 "user" => {
@@ -25,7 +25,7 @@ impl Settings for UserSettings {
                     let root_user = self.root.get_or_insert(Default::default());
                     root_user.set(id, value)?
                 }
-                _ => return Err("unknown attribute"),
+                _ => return Err(SettingsError::UnknownAttribute(attr.to_string())),
             }
         }
         Ok(())


### PR DESCRIPTION
## Problem

CLI error reporting is rather poor. In some cases, the errors are pretty hard to read (e.g., when it cannot connect to the D-Bus server) and, in other cases, the problem is not properly reported (e.g., when lshw or jsonnet are missing or when the jsonnet invocation fails).

The anyhow crate helps with reporting the problems, including a backtrace if supported. We should make use of its reporting capabilities.

Errors to focus on:

* ServiceError, which is anyone coming from the D-Bus layer.
* Missing binaries (`lshw`, jsonnet).
* Cannot download a profile (from libcurl).
* Failing commands (e.g., running jsonnet).

## Solution

### Better CLI errors

`agama-cli` uses now [anyhow](https://crates.io/crates/anyhow) to report the errors. Let's see some examples:

```
# agama profile download http://missing-domain.net/profile.jsonnet
Could not read the profile

Caused by:
    [6] Couldn't resolve host name (Could not resolve host: missing-domain.net)

# agama profile evaluate bad.jsonnet
Could not evaluate the profile

Caused by:
    Jsonnet evaluation failed:
    profile.jsonnet:39:15-30 Unknown variable: findBiggestDisk
    
            name: findBiggestDisk(agama.disks),

# agama config show
Could not connect to Agama bus at 'unix:path=/run/agama/bus'

Caused by:
    0: I/O error: No such file or directory (os error 2)
    1: No such file or directory (os error 2)
```

### Exit code

`agama-cli` now returns an exit code which is especially important when using the CLI in scripts. As usual, it returns 0 for success and 1 for errors.

```
Unknown product 'Unknown'. Available products: '["ALP-Bedrock", "ALP-Micro", "Tumbleweed", "Leap16"]'
$ echo $?
1
```

### Stop using &str as error types

In Rust, anything can be used as an error. Nothing stops you from using, e.g., a string slice (`&str`) as your error type. We used this approach when handling settings from the command line. This PR introduces a new `SettingsError` enum instead.

### Partially get rid of `Box<dyn Error>`

We have replaced `Box<dyn Error>` with concrete error types.

## Testing

- *Tested manually*