### PR TITLE
Improve the reporting of D-Bus connection error

### DIFF
--- a/rust/agama-lib/src/error.rs
+++ b/rust/agama-lib/src/error.rs
@@ -6,8 +6,10 @@ use zbus;
 
 #[derive(Error, Debug)]
 pub enum ServiceError {
-    #[error("D-Bus service error: {0}")]
+    #[error("D-Bus service error")]
     DBus(#[from] zbus::Error),
+    #[error("Could not connect to Agama bus at '{0}'")]
+    DBusConnectionError(String, #[source] zbus::Error),
     #[error("Unknown product '{0}'. Available products: '{1:?}'")]
     UnknownProduct(String, Vec<String>),
     // it's fine to say only "Error" because the original
@@ -24,7 +26,7 @@ pub enum ProfileError {
     Unreachable(#[from] curl::Error),
     #[error("Jsonnet evaluation failed:\n{0}")]
     EvaluationError(String),
-    #[error("I/O error: '{0}'")]
+    #[error("I/O error")]
     InputOutputError(#[from] io::Error),
     #[error("The profile is not a valid JSON file")]
     FormatError(#[from] serde_json::Error),

--- a/rust/agama-lib/src/lib.rs
+++ b/rust/agama-lib/src/lib.rs
@@ -40,7 +40,6 @@ mod store;
 pub use store::Store;
 
 use crate::error::ServiceError;
-use anyhow::Context;
 
 const ADDRESS: &str = "unix:path=/run/agama/bus";
 
@@ -52,6 +51,6 @@ pub async fn connection_to(address: &str) -> Result<zbus::Connection, ServiceErr
     let connection = zbus::ConnectionBuilder::address(address)?
         .build()
         .await
-        .context(format!("Connecting to Agama bus at {ADDRESS}"))?;
+        .map_err(|e| ServiceError::DBusConnectionError(ADDRESS.to_string(), e))?;
     Ok(connection)
 }


### PR DESCRIPTION
Improve the error reporting when a D-Bus connection cannot be established. By the way, it updates the changes file (I forgot to do it on #659).

Before:

```
Error: Connecting to Agama bus at unix:path=/run/agama/bus

Caused by:
    0: Connecting to Agama bus at unix:path=/run/agama/bus
    1: I/O error: Broken pipe (os error 32)
    2: Broken pipe (os error 32)
```

Now:

```
Could not connect to Agama bus at 'unix:path=/run/agama/bus'

Caused by:
    0: I/O error: Broken pipe (os error 32)
    1: Broken pipe (os error 32)
```