### PR TITLE
Cli automatic answers to questions

### DIFF
--- a/rust/agama-cli/src/commands.rs
+++ b/rust/agama-cli/src/commands.rs
@@ -1,5 +1,6 @@
 use crate::config::ConfigCommands;
 use crate::profile::ProfileCommands;
+use crate::questions::QuestionsCommands;
 use clap::Subcommand;
 
 #[derive(Subcommand, Debug)]
@@ -20,4 +21,7 @@ pub enum Commands {
     /// Autoinstallation profile handling
     #[command(subcommand)]
     Profile(ProfileCommands),
+    /// Questions handling
+    #[command(subcommand)]
+    Questions(QuestionsCommands),
 }

--- a/rust/agama-cli/src/main.rs
+++ b/rust/agama-cli/src/main.rs
@@ -6,6 +6,7 @@ mod error;
 mod printers;
 mod profile;
 mod progress;
+mod questions;
 
 use crate::error::CliError;
 use agama_lib::error::ServiceError;
@@ -22,6 +23,7 @@ use std::{
     thread::sleep,
     time::Duration,
 };
+use questions::run as run_questions_cmd;
 
 #[derive(Parser)]
 #[command(name = "agama", version, about, long_about = None)]
@@ -128,6 +130,7 @@ async fn run_command(cli: Cli) -> anyhow::Result<()> {
             let manager = build_manager().await?;
             block_on(install(&manager, 3))
         }
+        Commands::Questions(subcommand) => block_on(run_questions_cmd(subcommand)),
         _ => unimplemented!(),
     }
 }

--- a/rust/agama-cli/src/questions.rs
+++ b/rust/agama-cli/src/questions.rs
@@ -1,0 +1,28 @@
+use anyhow::{Ok,Context};
+use clap::Subcommand;
+use agama_lib::connection;
+use agama_lib::proxies::Questions1Proxy;
+
+#[derive(Subcommand, Debug)]
+pub enum QuestionsCommands {
+    /// To use default answers for questions.
+    UseDefaults,
+}
+
+// TODO when more commands is added, refactor and add it to agama-lib and share a bit of functionality
+async fn use_defaults() -> anyhow::Result<()> {
+    let connection = connection().await.context("Connection to DBus failed.")?;
+    let proxy = Questions1Proxy::new(&connection).await.context("Failed to connect to Questions service")?;
+
+    // TODO: how to print dbus error in that anyhow?
+    proxy.use_default_answer().await.context("Failed to set default answer")?;
+
+
+    Ok(())
+}
+
+pub async fn run(subcommand: QuestionsCommands) -> anyhow::Result<()> {
+    match subcommand {
+        QuestionsCommands::UseDefaults => use_defaults().await,
+    }
+}

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -111,30 +111,32 @@ trait Locale1 {
     fn set_vconsole_keyboard(&self, value: &str) -> zbus::Result<()>;
 }
 
-#[dbus_proxy(
-    interface = "org.opensuse.Agama.Questions1",
-    default_service = "org.opensuse.Agama.Questions1",
-    default_path = "/org/opensuse/Agama/Questions1"
-)]
+#[dbus_proxy(interface = "org.opensuse.Agama.Questions1", assume_defaults = true)]
 trait Questions1 {
     /// Delete method
     fn delete(&self, question: &zbus::zvariant::ObjectPath<'_>) -> zbus::Result<()>;
 
     /// New method
     #[dbus_proxy(name = "New")]
-    fn create(
+    fn new_generic(
         &self,
+        class: &str,
         text: &str,
         options: &[&str],
-        default_option: &[&str],
+        default_option: &str,
+        data: std::collections::HashMap<&str, &str>,
     ) -> zbus::Result<zbus::zvariant::OwnedObjectPath>;
 
-    /// NewLuksActivation method
-    fn new_luks_activation(
+    /// NewWithPassword method
+    fn new_with_password(
         &self,
-        device: &str,
-        label: &str,
-        size: &str,
-        attempt: u8,
+        class: &str,
+        text: &str,
+        options: &[&str],
+        default_option: &str,
+        data: std::collections::HashMap<&str, &str>,
     ) -> zbus::Result<zbus::zvariant::OwnedObjectPath>;
+
+    /// UseDefaultAnswer method
+    fn use_default_answer(&self) -> zbus::Result<()>;
 }


### PR DESCRIPTION
## Problem

Add to CLI ability to use default answers for questions. As we do not have yet in place questions handling, it will be for near future only way to answer it on CLI.


## Solution

Add command `agama questions use-defaults`. It is not as described at https://github.com/openSUSE/agama/blob/master/doc/cli_guidelines.md because currently auto answering can be only set on dbus API. Also there is risk of collision as auto answering is global for all questions, not just ones caused by given CLI command, so it can confuse user. And last but not least it can lead to some confusion where to use --non-interactive as sometimes it is hard to know what settings can cause reprobe or some action that can lead to answer.


## Testing

- *Tested manually*

