### PR TITLE
adapt dbus API to prepare for answers file and change use_defaults to…

### DIFF
--- a/doc/answers_example.yaml
+++ b/doc/answers_example.yaml
@@ -1,0 +1,3 @@
+-
+  class: storage.luks_activation
+  answer: "skip"

--- a/doc/answers_example.yaml
+++ b/doc/answers_example.yaml
@@ -1,3 +1,3 @@
--
-  class: storage.luks_activation
-  answer: "skip"
+answers:
+  - class: storage.luks_activation
+    answer: "skip"

--- a/doc/dbus/bus/org.opensuse.Agama.Questions1.bus.xml
+++ b/doc/dbus/bus/org.opensuse.Agama.Questions1.bus.xml
@@ -87,10 +87,13 @@
     <method name="Delete">
       <arg name="question" type="o" direction="in"/>
     </method>
-    <!--
-     sets questions to be answered by default answer instead of asking user
-     -->
-    <method name="UseDefaultAnswer">
+    <method name="AddAnswerFile">
+      <arg name="path" type="s" direction="in"/>
     </method>
+    <!--
+     property that defines if questions is interactive or automatically answered with
+     default answer
+     -->
+    <property name="Interactive" type="b" access="readwrite"/>
   </interface>
 </node>

--- a/doc/dbus/org.opensuse.Agama.Questions1.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Questions1.doc.xml
@@ -79,15 +79,30 @@ when the question is answered and the answer is successfully read.
     <method name="Delete">
       <arg name="question" direction="in" type="o"/>
     </method>
-
     <!--
-      UseDefaultAnswer:
+      Delete:
+      @question: object path of question that should be deleted.
 
-      Switches questions to be automatically answered by default answer.
-      After this method call each follow up question is immediatelly answered.
-      Useful for doing non interactive installation.
+      Deletes question. Useful when question is answered and service that asks
+      already read answer. Usually called by the one that previously created it.
     -->
-    <method name="UseDefaultAnswer">
+    <method name="Delete">
+      <arg name="question" type="o" direction="in"/>
     </method>
+    <!--
+      AddAnswerFile:
+      @path: Local fs path to answers file in yaml format.
+
+      Adds file with list of predefined answers that will be used to
+      automatically answer matching questions.
+    -->
+    <method name="AddAnswerFile">
+      <arg name="path" type="s" direction="in"/>
+    </method>
+    <!--
+     property that defines if questions is interactive or automatically answered with
+     default answer
+     -->
+    <property name="Interactive" type="b" access="readwrite"/>
   </interface>
 </node>

--- a/doc/dbus/org.opensuse.Agama.Questions1.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Questions1.doc.xml
@@ -76,9 +76,6 @@ when the question is answered and the answer is successfully read.
       <arg name="data" direction="in" type="a{ss}"/>
       <arg direction="out" type="o"/>
     </method>
-    <method name="Delete">
-      <arg name="question" direction="in" type="o"/>
-    </method>
     <!--
       Delete:
       @question: object path of question that should be deleted.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -36,6 +36,8 @@ dependencies = [
  "async-std",
  "log",
  "parking_lot",
+ "serde",
+ "serde_yaml",
  "simplelog",
  "systemd-journal-logger",
  "thiserror",
@@ -666,6 +668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +892,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,7 +941,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -1605,11 +1629,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.21"
+version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+checksum = "bd5f51e3fdb5b9cdd1577e1cb7a733474191b1aca6a72c2e50913241632c1180"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "itoa",
  "ryu",
  "serde",
@@ -1847,7 +1871,7 @@ version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "toml_datetime",
  "winnow",
 ]

--- a/rust/agama-cli/src/questions.rs
+++ b/rust/agama-cli/src/questions.rs
@@ -7,6 +7,9 @@ use clap::{Args, Subcommand, ValueEnum};
 pub enum QuestionsCommands {
     /// Set mode for answering questions.
     Mode(ModesArgs),
+    Answers {
+        path: String,
+    },
 }
 
 #[derive(Args, Debug)]
@@ -44,5 +47,9 @@ async fn set_mode(value: Modes) -> anyhow::Result<()> {
 pub async fn run(subcommand: QuestionsCommands) -> anyhow::Result<()> {
     match subcommand {
         QuestionsCommands::Mode(value) => set_mode(value.value).await,
+        QuestionsCommands::Answers { path } => {
+            log::info!("TODO: implement answers");
+            Ok(())
+        }
     }
 }

--- a/rust/agama-cli/src/questions.rs
+++ b/rust/agama-cli/src/questions.rs
@@ -47,7 +47,7 @@ async fn set_mode(value: Modes) -> anyhow::Result<()> {
 pub async fn run(subcommand: QuestionsCommands) -> anyhow::Result<()> {
     match subcommand {
         QuestionsCommands::Mode(value) => set_mode(value.value).await,
-        QuestionsCommands::Answers { path } => {
+        QuestionsCommands::Answers { path: _ } => {
             log::info!("TODO: implement answers");
             Ok(())
         }

--- a/rust/agama-cli/src/questions.rs
+++ b/rust/agama-cli/src/questions.rs
@@ -29,7 +29,7 @@ async fn set_mode(proxy: Questions1Proxy<'_>, value: Modes) -> anyhow::Result<()
     proxy
         .set_interactive(value == Modes::Interactive)
         .await
-        .context("Failed to set default answer")
+        .context("Failed to set mode for answering questions.")
 }
 
 async fn set_answers(proxy: Questions1Proxy<'_>, path: String) -> anyhow::Result<()> {
@@ -37,7 +37,7 @@ async fn set_answers(proxy: Questions1Proxy<'_>, path: String) -> anyhow::Result
     proxy
         .add_answer_file(path.as_str())
         .await
-        .context("Failed to set default answer")
+        .context("Failed to set answers from answers file")
 }
 
 pub async fn run(subcommand: QuestionsCommands) -> anyhow::Result<()> {

--- a/rust/agama-dbus-server/Cargo.toml
+++ b/rust/agama-dbus-server/Cargo.toml
@@ -18,3 +18,5 @@ async-std = { version = "1.12.0", features = ["attributes"]}
 uuid = { version = "1.3.4", features = ["v4"] }
 parking_lot = "0.12.1"
 thiserror = "1.0.40"
+serde = { version = "1.0.152", features = ["derive"] }
+serde_yaml = "0.9.24"

--- a/rust/agama-dbus-server/src/network/action.rs
+++ b/rust/agama-dbus-server/src/network/action.rs
@@ -3,7 +3,7 @@ use agama_lib::network::types::DeviceType;
 
 /// Networking actions, like adding, updating or removing connections.
 ///
-/// These actions are meant to be processed by [crate::system::NetworkSystem], updating the model
+/// These actions are meant to be processed by [crate::network::system::NetworkSystem], updating the model
 /// and the D-Bus tree as needed.
 #[derive(Debug)]
 pub enum Action {

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -82,7 +82,7 @@ impl Device {
     ///
     /// Possible values: 0 = loopback, 1 = ethernet, 2 = wireless.
     ///
-    /// See [crate::model::DeviceType].
+    /// See [agama_lib::network::types::DeviceType].
     #[dbus_interface(property, name = "Type")]
     pub fn device_type(&self) -> u8 {
         self.device.type_ as u8
@@ -124,7 +124,7 @@ impl Connections {
     /// Adds a new network connection.
     ///
     /// * `id`: connection name.
-    /// * `ty`: connection type (see [crate::model::DeviceType]).
+    /// * `ty`: connection type (see [agama_lib::network::types::DeviceType]).
     pub async fn add_connection(&mut self, id: String, ty: u8) -> zbus::fdo::Result<()> {
         let actions = self.actions.lock();
         actions
@@ -274,7 +274,7 @@ impl Ipv4 {
     ///
     /// Possible values: "disabled", "auto", "manual" or "link-local".
     ///
-    /// See [crate::model::IpMethod].
+    /// See [crate::network::model::IpMethod].
     #[dbus_interface(property)]
     pub fn method(&self) -> String {
         let connection = self.get_connection();
@@ -401,7 +401,7 @@ impl Wireless {
     ///
     /// Possible values: "unknown", "adhoc", "infrastructure", "ap" or "mesh".
     ///
-    /// See [crate::model::WirelessMode].
+    /// See [crate::network::model::WirelessMode].
     #[dbus_interface(property)]
     pub fn mode(&self) -> String {
         let connection = self.get_wireless();
@@ -442,7 +442,7 @@ impl Wireless {
     /// Possible values: "none", "owe", "ieee8021x", "wpa-psk", "sae", "wpa-eap",
     /// "wpa-eap-suite-b192".
     ///
-    /// See [crate::model::SecurityProtocol].
+    /// See [crate::network::model::SecurityProtocol].
     #[dbus_interface(property)]
     pub fn security(&self) -> String {
         let connection = self.get_wireless();

--- a/rust/agama-dbus-server/src/questions.rs
+++ b/rust/agama-dbus-server/src/questions.rs
@@ -81,7 +81,7 @@ enum QuestionType {
 }
 
 /// Trait for objects that can provide answers to all kind of Question.
-/// 
+///
 /// If not strategy is used or all defined strategies does not know answer,
 /// then users need to answer it themself.
 trait AnswerStrategy {
@@ -261,10 +261,8 @@ impl Questions {
             if !self.interactive() {
                 self.answer_strategies.pop();
             }
-        } else {
-            if self.interactive() {
-                self.answer_strategies.push(Box::new(DefaultAnswers {}));
-            }
+        } else if self.interactive() {
+            self.answer_strategies.push(Box::new(DefaultAnswers {}));
         }
     }
 

--- a/rust/agama-dbus-server/src/questions.rs
+++ b/rust/agama-dbus-server/src/questions.rs
@@ -82,6 +82,8 @@ enum QuestionType {
 
 /// Trait for objects that can provide answers to all kind of Question.
 trait AnswerStrategy {
+    /// Id for quick runtime inspection of strategy type
+    fn id(&self) -> u8;
     /// Provides answer for generic question
     ///
     /// I gets as argument the question to answer. Returned value is `answer`
@@ -103,7 +105,17 @@ trait AnswerStrategy {
 /// AnswerStrategy that provides as answer the default option.
 struct DefaultAnswers;
 
+impl DefaultAnswers {
+    pub fn id() -> u8 {
+        1
+    }
+}
+
 impl AnswerStrategy for DefaultAnswers {
+    fn id(&self) -> u8 {
+        DefaultAnswers::id()
+    }
+
     fn answer(&self, question: &GenericQuestion) -> Option<String> {
         Some(question.default_option.clone())
     }
@@ -227,10 +239,35 @@ impl Questions {
         Ok(())
     }
 
-    /// sets questions to be answered by default answer instead of asking user
-    async fn use_default_answer(&mut self) -> Result<(), Error> {
-        log::info!("Answer questions with default option");
-        self.answer_strategies.push(Box::new(DefaultAnswers {}));
+    /// property that defines if questions is interactive or automatically answered with
+    /// default answer
+    #[dbus_interface(property)]
+    fn interactive(&self) -> bool {
+        let last = self.answer_strategies.last();
+        if let Some(real_strategy) = last {
+            real_strategy.id() == DefaultAnswers::id()
+        } else {
+            false
+        }
+    }
+
+    #[dbus_interface(property)]
+    fn set_interactive(&mut self, value: bool) {
+        log::info!("set interactive to {}", value);
+        if value {
+            if !self.interactive() {
+                self.answer_strategies.pop();
+            }
+        } else {
+            if self.interactive() {
+                self.answer_strategies.push(Box::new(DefaultAnswers {}));
+            }
+        }
+    }
+
+    fn add_answer_file(&mut self, path: String) -> Result<(), zbus::fdo::Error> {
+        log::info!("Adding answer file {}", path);
+        log::info!("TODO: Not implemented yet.");
         Ok(())
     }
 }

--- a/rust/agama-dbus-server/src/questions.rs
+++ b/rust/agama-dbus-server/src/questions.rs
@@ -84,8 +84,7 @@ enum QuestionType {
 
 /// Trait for objects that can provide answers to all kind of Question.
 ///
-/// If not strategy is used or all defined strategies does not know answer,
-/// then users need to answer it themself.
+/// If no strategy is selected or the answer is unknown, then ask to the user.
 trait AnswerStrategy {
     /// Id for quick runtime inspection of strategy type
     fn id(&self) -> u8;

--- a/rust/agama-dbus-server/src/questions.rs
+++ b/rust/agama-dbus-server/src/questions.rs
@@ -256,12 +256,15 @@ impl Questions {
 
     #[dbus_interface(property)]
     fn set_interactive(&mut self, value: bool) {
+        if value != self.interactive() {
+            log::info!("interactive value unchanged - {}", value);
+            return;
+        }
+
         log::info!("set interactive to {}", value);
         if value {
-            if !self.interactive() {
-                self.answer_strategies.pop();
-            }
-        } else if self.interactive() {
+            self.answer_strategies.pop();
+        } else {
             self.answer_strategies.push(Box::new(DefaultAnswers {}));
         }
     }

--- a/rust/agama-dbus-server/src/questions.rs
+++ b/rust/agama-dbus-server/src/questions.rs
@@ -9,6 +9,8 @@ use anyhow::Context;
 use log;
 use zbus::{dbus_interface, fdo::ObjectManager, zvariant::ObjectPath, Connection};
 
+mod answers;
+
 #[derive(Clone, Debug)]
 struct GenericQuestionObject(questions::GenericQuestion);
 
@@ -269,10 +271,16 @@ impl Questions {
         }
     }
 
-    fn add_answer_file(&mut self, path: String) -> Result<(), zbus::fdo::Error> {
+    fn add_answer_file(&mut self, path: String) -> Result<(), Error> {
         log::info!("Adding answer file {}", path);
-        log::info!("TODO: Not implemented yet.");
-        Ok(())
+        let answers = answers::Answers::new_from_file(path.as_str());
+        match answers {
+            Ok(answers) => {
+                self.answer_strategies.push(Box::new(answers));
+                Ok(())
+            }
+            Err(e) => Err(e.into()),
+        }
     }
 }
 

--- a/rust/agama-dbus-server/src/questions.rs
+++ b/rust/agama-dbus-server/src/questions.rs
@@ -81,6 +81,9 @@ enum QuestionType {
 }
 
 /// Trait for objects that can provide answers to all kind of Question.
+/// 
+/// If not strategy is used or all defined strategies does not know answer,
+/// then users need to answer it themself.
 trait AnswerStrategy {
     /// Id for quick runtime inspection of strategy type
     fn id(&self) -> u8;
@@ -245,9 +248,9 @@ impl Questions {
     fn interactive(&self) -> bool {
         let last = self.answer_strategies.last();
         if let Some(real_strategy) = last {
-            real_strategy.id() == DefaultAnswers::id()
+            real_strategy.id() != DefaultAnswers::id()
         } else {
-            false
+            true
         }
     }
 

--- a/rust/agama-dbus-server/src/questions/answers.rs
+++ b/rust/agama-dbus-server/src/questions/answers.rs
@@ -17,7 +17,7 @@ struct Answer {
 /// Data structure holding list of Answer.
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Answers {
-    answers: Vec<Answer>
+    answers: Vec<Answer>,
 }
 
 impl Answers {

--- a/rust/agama-dbus-server/src/questions/answers.rs
+++ b/rust/agama-dbus-server/src/questions/answers.rs
@@ -73,11 +73,7 @@ impl crate::questions::AnswerStrategy for Answers {
 
     fn answer(&self, question: &agama_lib::questions::GenericQuestion) -> Option<String> {
         let answer = self.find_answer(question);
-        if let Some(answer) = answer {
-            Some(answer.answer.clone())
-        } else {
-            None
-        }
+        answer.map(|answer| answer.answer.clone())
     }
 
     fn answer_with_password(

--- a/rust/agama-dbus-server/src/questions/answers.rs
+++ b/rust/agama-dbus-server/src/questions/answers.rs
@@ -4,17 +4,24 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 /// Data structure for single yaml answer. For variables specification see
-/// corresponding GenericQuestion fields.
+/// corresponding [agama_lib::questions::GenericQuestion] fields.
+/// The *matcher* part is: `class`, `text`, `data`.
+/// The *answer* part is: `answer`, `password`.
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct Answer {
     pub class: Option<String>,
     pub text: Option<String>,
+    /// A matching GenericQuestion can have other data fields too
     pub data: Option<HashMap<String, String>>,
-    pub answer: String,           // answer text is only mandatory part of answer
-    pub password: Option<String>, // all possible mixins have to be here, so can be specified in answer
+    /// The answer text is the only mandatory part of an Answer
+    pub answer: String,
+    /// All possible mixins have to be here, so they can be specified in an Answer
+    pub password: Option<String>,
 }
 
 /// Data structure holding list of Answer.
+/// The first matching Answer is used, even if there is
+/// a better (more specific) match later in the list.
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Answers {
     answers: Vec<Answer>,
@@ -183,6 +190,8 @@ mod tests {
         assert_eq!(expected, answers.answer_with_password(&with_password));
     }
 
+    /// An Answer matches on *data* if all its keys and values are in the GenericQuestion *data*.
+    /// The GenericQuestion can have other *data* keys.
     #[test]
     fn test_partial_data_match() {
         let answers = get_answers();

--- a/rust/agama-dbus-server/src/questions/answers.rs
+++ b/rust/agama-dbus-server/src/questions/answers.rs
@@ -110,14 +110,14 @@ mod tests {
         Answers {
             answers: vec![
                 Answer {
-                    class: Some("test".to_string()),
+                    class: Some("without_data".to_string()),
                     data: None,
                     text: None,
                     answer: "Ok".to_string(),
                     password: Some("testing pwd".to_string()), // ignored for generic question
                 },
                 Answer {
-                    class: Some("test2".to_string()),
+                    class: Some("with_data".to_string()),
                     data: Some(HashMap::from([
                         ("data1".to_string(), "value1".to_string()),
                         ("data2".to_string(), "value2".to_string()),
@@ -127,7 +127,7 @@ mod tests {
                     password: None,
                 },
                 Answer {
-                    class: Some("test2".to_string()),
+                    class: Some("with_data".to_string()),
                     data: Some(HashMap::from([(
                         "data1".to_string(),
                         "another_value1".to_string(),
@@ -145,7 +145,7 @@ mod tests {
         let answers = get_answers();
         let question = GenericQuestion {
             id: 1,
-            class: "test".to_string(),
+            class: "without_data".to_string(),
             text: "JFYI we will kill all bugs during installation.".to_string(),
             options: vec!["Ok".to_string(), "Cancel".to_string()],
             default_option: "Cancel".to_string(),
@@ -175,7 +175,7 @@ mod tests {
         let answers = get_answers();
         let question = GenericQuestion {
             id: 1,
-            class: "test".to_string(),
+            class: "without_data".to_string(),
             text: "Please provide password for dooms day.".to_string(),
             options: vec!["Ok".to_string(), "Cancel".to_string()],
             default_option: "Cancel".to_string(),
@@ -197,7 +197,7 @@ mod tests {
         let answers = get_answers();
         let question = GenericQuestion {
             id: 1,
-            class: "test2".to_string(),
+            class: "with_data".to_string(),
             text: "Hard question?".to_string(),
             options: vec!["Ok2".to_string(), "Maybe".to_string(), "Cancel".to_string()],
             default_option: "Cancel".to_string(),
@@ -216,7 +216,7 @@ mod tests {
         let answers = get_answers();
         let question = GenericQuestion {
             id: 1,
-            class: "test2".to_string(),
+            class: "with_data".to_string(),
             text: "Hard question?".to_string(),
             options: vec!["Ok2".to_string(), "Maybe".to_string(), "Cancel".to_string()],
             default_option: "Cancel".to_string(),
@@ -235,7 +235,7 @@ mod tests {
         let answers = get_answers();
         let question = GenericQuestion {
             id: 1,
-            class: "test2".to_string(),
+            class: "with_data".to_string(),
             text: "Hard question?".to_string(),
             options: vec!["Ok2".to_string(), "Maybe".to_string(), "Cancel".to_string()],
             default_option: "Cancel".to_string(),
@@ -249,13 +249,37 @@ mod tests {
         assert_eq!(None, answers.answer(&question));
     }
 
+    // A "universal answer" with unspecified class+text+data is possible
+    #[test]
+    fn test_universal_match() {
+        let answers = Answers {
+            answers: vec![Answer {
+                class: None,
+                text: None,
+                data: None,
+                answer: "Yes".into(),
+                password: None,
+            }],
+        };
+        let question = GenericQuestion {
+            id: 1,
+            class: "without_data".to_string(),
+            text: "JFYI we will kill all bugs during installation.".to_string(),
+            options: vec!["Ok".to_string(), "Cancel".to_string()],
+            default_option: "Cancel".to_string(),
+            data: HashMap::new(),
+            answer: "".to_string(),
+        };
+        assert_eq!(Some("Yes".to_string()), answers.answer(&question));
+    }
+
     #[test]
     fn test_loading_yaml() {
         let file = r#"
             answers:
-              - class: "test"
+              - class: "without_data"
                 answer: "OK"
-              - class: "test2"
+              - class: "with_data"
                 data:
                   testk: testv
                   testk2: testv2

--- a/rust/agama-dbus-server/src/questions/answers.rs
+++ b/rust/agama-dbus-server/src/questions/answers.rs
@@ -17,7 +17,7 @@ struct Answer {
 /// Data structure holding list of Answer.
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Answers {
-    list: Vec<Answer>,
+    answers: Vec<Answer>
 }
 
 impl Answers {
@@ -34,7 +34,7 @@ impl Answers {
     }
 
     fn find_answer(&self, question: &agama_lib::questions::GenericQuestion) -> Option<&Answer> {
-        'main: for answerd in self.list.iter() {
+        'main: for answerd in self.answers.iter() {
             if let Some(v) = &answerd.class {
                 if !question.class.eq(v) {
                     continue;
@@ -101,7 +101,7 @@ mod tests {
     // set of fixtures for test
     fn get_answers() -> Answers {
         Answers {
-            list: vec![
+            answers: vec![
                 Answer {
                     class: Some("test".to_string()),
                     data: None,
@@ -238,5 +238,21 @@ mod tests {
             answer: "".to_string(),
         };
         assert_eq!(None, answers.answer(&question));
+    }
+
+    #[test]
+    fn test_loading_yaml() {
+        let file = r#"
+            answers:
+              - class: "test"
+                answer: "OK"
+              - class: "test2"
+                data:
+                  testk: testv
+                  testk2: testv2
+                answer: "Cancel"
+        "#;
+        let result: Answers = serde_yaml::from_str(file).expect("failed to load yaml string");
+        assert_eq!(result.answers.len(), 2);
     }
 }

--- a/rust/agama-dbus-server/src/questions/answers.rs
+++ b/rust/agama-dbus-server/src/questions/answers.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+/// Data structure for single yaml answer. For variables specification see
+/// corresponding GenericQuestion fields.
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct Answer {
+    pub class: Option<String>,
+    pub text: Option<String>,
+    pub data: Option<HashMap<String, String>>,
+    pub answer: String,           // answer text is only mandatory part of answer
+    pub password: Option<String>, // all possible mixins have to be here, so can be specified in answer
+}
+
+/// Data structure holding list of Answer.
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct Answers {
+    list: Vec<Answer>,
+}
+
+impl Answers {
+    pub fn new_from_file(path: &str) -> anyhow::Result<Self> {
+        let f = std::fs::File::open(path).context(format!("Failed to open {}", path))?;
+        let result: Self =
+            serde_yaml::from_reader(f).context(format!("Failed to parse values at {}", path))?;
+
+        Ok(result)
+    }
+
+    pub fn id() -> u8 {
+        2
+    }
+
+    fn find_answer(&self, question: &agama_lib::questions::GenericQuestion) -> Option<&Answer> {
+        'main: for answerd in self.list.iter() {
+            if let Some(v) = &answerd.class {
+                if !question.class.eq(v) {
+                    continue;
+                }
+            }
+            if let Some(v) = &answerd.text {
+                if !question.text.eq(v) {
+                    continue;
+                }
+            }
+            if let Some(v) = &answerd.data {
+                for (key, value) in v {
+                    // all keys defined in answer has to match
+                    let entry = question.data.get(key);
+                    if let Some(e_val) = entry {
+                        if !e_val.eq(value) {
+                            continue 'main;
+                        }
+                    } else {
+                        continue 'main;
+                    }
+                }
+            }
+
+            return Some(answerd);
+        }
+
+        None
+    }
+}
+
+impl crate::questions::AnswerStrategy for Answers {
+    fn id(&self) -> u8 {
+        Answers::id()
+    }
+
+    fn answer(&self, question: &agama_lib::questions::GenericQuestion) -> Option<String> {
+        let answer = self.find_answer(question);
+        if let Some(answer) = answer {
+            Some(answer.answer.clone())
+        } else {
+            None
+        }
+    }
+
+    fn answer_with_password(
+        &self,
+        question: &agama_lib::questions::WithPassword,
+    ) -> (Option<String>, Option<String>) {
+        // use here fact that with password share same matchers as generic one
+        let answer = self.find_answer(&question.base);
+        if let Some(answer) = answer {
+            (Some(answer.answer.clone()), answer.password.clone())
+        } else {
+            (None, None)
+        }
+    }
+}

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -111,7 +111,11 @@ trait Locale1 {
     fn set_vconsole_keyboard(&self, value: &str) -> zbus::Result<()>;
 }
 
-#[dbus_proxy(interface = "org.opensuse.Agama.Questions1", assume_defaults = true)]
+#[dbus_proxy(
+    interface = "org.opensuse.Agama.Questions1",
+    default_service = "org.opensuse.Agama.Questions",
+    default_path = "/org/opensuse/Agama/Questions1"
+)]
 trait Questions1 {
     /// AddAnswerFile method
     fn add_answer_file(&self, path: &str) -> zbus::Result<()>;

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -113,7 +113,7 @@ trait Locale1 {
 
 #[dbus_proxy(
     interface = "org.opensuse.Agama.Questions1",
-    default_service = "org.opensuse.Agama.Questions",
+    default_service = "org.opensuse.Agama.Questions1",
     default_path = "/org/opensuse/Agama/Questions1"
 )]
 trait Questions1 {

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -113,12 +113,15 @@ trait Locale1 {
 
 #[dbus_proxy(interface = "org.opensuse.Agama.Questions1", assume_defaults = true)]
 trait Questions1 {
+    /// AddAnswerFile method
+    fn add_answer_file(&self, path: &str) -> zbus::Result<()>;
+
     /// Delete method
     fn delete(&self, question: &zbus::zvariant::ObjectPath<'_>) -> zbus::Result<()>;
 
     /// New method
     #[dbus_proxy(name = "New")]
-    fn new_generic(
+    fn new_quetion(
         &self,
         class: &str,
         text: &str,
@@ -137,6 +140,8 @@ trait Questions1 {
         data: std::collections::HashMap<&str, &str>,
     ) -> zbus::Result<zbus::zvariant::OwnedObjectPath>;
 
-    /// UseDefaultAnswer method
-    fn use_default_answer(&self) -> zbus::Result<()>;
+    /// Interactive property
+    #[dbus_proxy(property)]
+    fn interactive(&self) -> zbus::Result<bool>;
+    fn set_interactive(&self, value: bool) -> zbus::Result<()>;
 }

--- a/rust/agama-lib/src/questions.rs
+++ b/rust/agama-lib/src/questions.rs
@@ -74,11 +74,13 @@ impl GenericQuestion {
 /// mixins arise to convert it to Question Struct that have optional mixins
 /// inside like
 ///
+/// ```no_compile
 /// struct Question {
 ///   base: GenericQuestion,
 ///   with_password: Option<WithPassword>,
 ///   another_mixin: Option<AnotherMixin>
 /// }
+/// ```
 ///
 /// This way all handling code can check if given mixin is used and
 /// act appropriate.

--- a/rust/agama-lib/src/questions.rs
+++ b/rust/agama-lib/src/questions.rs
@@ -1,11 +1,11 @@
-use std::collections::HashMap;
+//! Data model for Agama questions
 
-/// module holdings data model for agama questions
+use std::collections::HashMap;
 
 /// Basic generic question that fits question without special needs
 #[derive(Clone, Debug)]
 pub struct GenericQuestion {
-    /// numeric id used to indetify question on dbus
+    /// numeric id used to identify question on D-Bus
     pub id: u32,
     /// class of questions. Similar kinds of questions share same class.
     /// It is dot separated list of elements. Examples are

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jul 26 11:08:09 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- CLI: add to "questions" command "answers" subcommand to set
+  file with predefined answers
+- dbus-server: add "AddAnswersFile" method to Questions service
+  (gh#openSUSE/agama#669)
+
+-------------------------------------------------------------------
 Tue Jul 18 13:32:04 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Add to CLI "questions" subcommand with mode option to set


### PR DESCRIPTION
… interactive property


## Problem

We want to have support for predefined answers and it is missing.

https://trello.com/c/9plYc08k/3373-8-agama-add-support-for-unattended-questions


## Solution

Adapt dbus API to allow to add such file.


## Testing

- *Tested manually*
- *Unit tested*

## Follow-ups

- document all types of questions we have
- some tracking/reporting feature so user can see questions that was asked/answered.

