### PR TITLE
Load Agama translations

### DIFF
--- a/web/src/index.html
+++ b/web/src/index.html
@@ -10,5 +10,11 @@
   <body>
     <div id="root"></div>
     <script type="module" src="./index.js"></script>
+    <!--
+      The Cockpit server returns "po.<LANG>.js" content for the "po.js" request,
+      the requested language is obtained from the "CockpitLang" cookie sent in
+      the HTTP header. For missing translations it returns an empty string.
+    -->
+    <script src="po.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Problem

- The Agama translations are not loaded from the server
- Changing the language has no effect although the translations are present on the server

## Solution

- Load the `po.js` file with translations

## Notes

- Cockpit handles loading of the right translations on the server side, see the note in the HTML code
- The HTML comment is currently present also in the built production code, later I'll reconfigure webpack to also minify HTML files
- The `defer` attribute is needed because the JS modules (`index.js`) are deferred by default. We need to defer also       loading the localization code otherwise calling `cockpit.locale()` inside `po.js` would fail because it would not be defined yet. The `cockpit.js` file is bundled in the `index.js` file so that file needs to be loaded before the translations.


## Testing

- Tested manually
- For switching the language use the original Cockpit language selector
  - Change the URL to point to the `/cockpit/@localhost/shell/index.html` path
  - This displays the full Cockpit web UI
  - Use the `Session` menu in the top right corner, select the `Display language` option
  - In the popup list select `čeština` (Czech)
  - Then go back to Agama (either revert the URL path to simple `/` or click the `Agama` label in the left side bar
- To display a Czech translation use the option menu (the hamburger icon in the top right corner) and select `Diagnostic tools` -> `Show Log`. So far there are just few translations to test, see the [web/po/cs.po](https://github.com/openSUSE/agama/blob/master/web/po/cs.po) file.
- The displayed popup with YaST logs contains `Zavřít` translation for the `Close` button


## Screenshots

The "Close" button with the Czech translation activated

![agama_cz](https://github.com/openSUSE/agama/assets/907998/5e6fcc11-4201-43d0-926e-c25e2ff67342)


