### PR TITLE
Fix pattern names for Dolomite 1.0 Milestone2

### DIFF
--- a/service/etc/agama.yaml
+++ b/service/etc/agama.yaml
@@ -150,9 +150,8 @@ ALP-Dolomite:
         archs: ppc
 
     mandatory_patterns:
-      - patterns-alp-base
-      - patterns-alp-cockpit
-      - patterns-alp-hardware
+      - alp_base
+      - alp_hardware
     optional_patterns: null # no optional pattern shared
     mandatory_packages:
       - package: device-mapper # Apparently needed if devices at /dev/mapper are used at boot (eg. FDE)
@@ -171,7 +170,7 @@ ALP-Dolomite:
       #     - apparmor
       selinux:
         patterns:
-          - patterns-alp-selinux
+          - alp_selinux
         policy: enforcing
       none:
         patterns: null


### PR DESCRIPTION
## Problem

#674 updated the configuration for ALP Dolomite. Unfortunately the names of the patterns are wrong:

- The real name schema for patterns is `alp_whatever` and not `patterns-alp-whatever`
- The package `alp_cockpit` is not in the repository

## Solution

Use the real names of the existing patterns from the repository

## Testing

Tested manually