### PR TITLE
Fixed the "Weblate Merge PO" GitHub Action

### DIFF
--- a/.github/workflows/weblate-merge-po.yml
+++ b/.github/workflows/weblate-merge-po.yml
@@ -59,6 +59,7 @@ jobs:
           find web/po -name '*.po' -exec git rm '{}' ';'
 
           # copy the new ones
+          mkdir -p web/po
           cp -a ../agama-weblate/web/*.po web/po
           git add web/po/*.po
 


### PR DESCRIPTION
## Problem

- Fixes [failing GitHub Action](https://github.com/openSUSE/agama/actions/runs/5724232875/job/15510323141#step:8:12)
- The `git rm` command (before the `cp` command) deletes the whole directory if all files are removed
- We need to create it back