### PR TITLE
obs-release.yml - Fix the glob to also run for simple "v3" tag

### DIFF
--- a/.github/workflows/obs-release.yml
+++ b/.github/workflows/obs-release.yml
@@ -8,7 +8,7 @@ on:
   # runs when creating a release tag
   push:
     tags:
-      - v[0-9]+.**
+      - v[0-9]*
 
 jobs:
   # Note: cockpit-agama-playwright is currently not submitted


### PR DESCRIPTION
## Problem

The release action was not called for simple "v3" tag

## Solution

Simplify the glob to match any tag starting `v` and a number.