### PR TITLE
Webpack dev server: Fixed locale handling (null check)

### DIFF
--- a/web/src/lib/webpack-po-handler.js
+++ b/web/src/lib/webpack-po-handler.js
@@ -14,7 +14,7 @@ module.exports = function (req, res) {
   const language = req.headers.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*=\s*([^;]*).*$)|^.*$/, "$1") || "";
   // the cookie uses "pt-br" format while the PO file is "pt_BR" :-/
   let [lang, country] = language.split("-");
-  if (country) country = country.toUpperCase();
+  country = country?.toUpperCase();
 
   // first check the full locale ("pt_BR") PO file
   if (fs.existsSync(path.join(__dirname, "..", "..", "po", `${lang}_${country}.po`))) {

--- a/web/src/lib/webpack-po-handler.js
+++ b/web/src/lib/webpack-po-handler.js
@@ -14,7 +14,7 @@ module.exports = function (req, res) {
   const language = req.headers.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*=\s*([^;]*).*$)|^.*$/, "$1") || "";
   // the cookie uses "pt-br" format while the PO file is "pt_BR" :-/
   let [lang, country] = language.split("-");
-  country = country.toUpperCase();
+  if (country) country = country.toUpperCase();
 
   // first check the full locale ("pt_BR") PO file
   if (fs.existsSync(path.join(__dirname, "..", "..", "po", `${lang}_${country}.po`))) {


### PR DESCRIPTION
Properly handle locales with just a language code without country (e.g. "cs").

In that case `country` is `null` and calling `toUpperCase()` fails... :open_mouth: 
