### PR TITLE
Refactor `find_answer`

### DIFF
--- a/rust/agama-dbus-server/src/questions/answers.rs
+++ b/rust/agama-dbus-server/src/questions/answers.rs
@@ -26,13 +26,13 @@ impl Answer {
     /// * `question`: question to compare with.
     pub fn responds(&self, question: &GenericQuestion) -> bool {
         if let Some(class) = &self.class {
-            if !question.class.eq(class) {
+            if question.class != *class {
                 return false;
             }
         }
 
         if let Some(text) = &self.text {
-            if !question.text.eq(text) {
+            if question.text != *text {
                 return false;
             }
         }
@@ -43,7 +43,7 @@ impl Answer {
                     return false;
                 };
 
-                e_val.eq(value)
+                e_val == value
             });
         }
 

--- a/rust/agama-dbus-server/src/questions/answers.rs
+++ b/rust/agama-dbus-server/src/questions/answers.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use agama_lib::questions::GenericQuestion;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
@@ -17,6 +18,37 @@ struct Answer {
     pub answer: String,
     /// All possible mixins have to be here, so they can be specified in an Answer
     pub password: Option<String>,
+}
+
+impl Answer {
+    /// Determines whether the answer responds to the given question.
+    ///
+    /// * `question`: question to compare with.
+    pub fn responds(&self, question: &GenericQuestion) -> bool {
+        if let Some(class) = &self.class {
+            if !question.class.eq(class) {
+                return false;
+            }
+        }
+
+        if let Some(text) = &self.text {
+            if !question.text.eq(text) {
+                return false;
+            }
+        }
+
+        if let Some(data) = &self.data {
+            return data.iter().all(|(key, value)| {
+                let Some(e_val) = question.data.get(key) else {
+                    return false;
+                };
+
+                e_val.eq(value)
+            });
+        }
+
+        true
+    }
 }
 
 /// Data structure holding list of Answer.
@@ -41,35 +73,7 @@ impl Answers {
     }
 
     fn find_answer(&self, question: &agama_lib::questions::GenericQuestion) -> Option<&Answer> {
-        'main: for answerd in self.answers.iter() {
-            if let Some(v) = &answerd.class {
-                if !question.class.eq(v) {
-                    continue;
-                }
-            }
-            if let Some(v) = &answerd.text {
-                if !question.text.eq(v) {
-                    continue;
-                }
-            }
-            if let Some(v) = &answerd.data {
-                for (key, value) in v {
-                    // all keys defined in answer has to match
-                    let entry = question.data.get(key);
-                    if let Some(e_val) = entry {
-                        if !e_val.eq(value) {
-                            continue 'main;
-                        }
-                    } else {
-                        continue 'main;
-                    }
-                }
-            }
-
-            return Some(answerd);
-        }
-
-        None
+        self.answers.iter().find(|a| a.responds(&question))
     }
 }
 

--- a/rust/agama-dbus-server/src/questions/answers.rs
+++ b/rust/agama-dbus-server/src/questions/answers.rs
@@ -72,7 +72,7 @@ impl Answers {
         2
     }
 
-    fn find_answer(&self, question: &agama_lib::questions::GenericQuestion) -> Option<&Answer> {
+    fn find_answer(&self, question: &GenericQuestion) -> Option<&Answer> {
         self.answers.iter().find(|a| a.responds(&question))
     }
 }
@@ -82,7 +82,7 @@ impl crate::questions::AnswerStrategy for Answers {
         Answers::id()
     }
 
-    fn answer(&self, question: &agama_lib::questions::GenericQuestion) -> Option<String> {
+    fn answer(&self, question: &GenericQuestion) -> Option<String> {
         let answer = self.find_answer(question);
         answer.map(|answer| answer.answer.clone())
     }


### PR DESCRIPTION
## Problem

While checking the [answers](https://github.com/openSUSE/agama/blob/57d328bdd6cdf418ae2e0c92aa3bfe3f1bfcc45e/rust/agama-dbus-server/src/questions/answers.rs) module, I discovered we were using a [labeled for](https://doc.rust-lang.org/rust-by-example/flow_control/loop/nested.html). That's perfectly fine, but coming from Ruby I felt that we could use a higher-level approach.

I took it as a refactoring exercise given that the original implementation was OK.

## Solution

* Move the logic to determine whether an answer responds to a question (just moving that code to a different function allows us to avoid the nested `for`). Moreover, I think the logic belongs to `Question` or `Answer`.
* Replace the `for` structs with calls to `find` and `all`, as they express the intention better.
* Import (use) the `GenericQuestion` to avoid spelling the whole module name (`agama_lib::questions::GenericQuestion` vs `GenericQuestion`). If tomorrow we decide to change the `GenericQuestion` to a different place, we need to update all the references. Not to mention that the lines are rather long and harder to read.

## Testing

- The module has quite some tests (thanks!) and they pass.