### PR TITLE
Use "lang" URL query for switching the language

### DIFF
--- a/web/src/L10nWrapper.jsx
+++ b/web/src/L10nWrapper.jsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// import React from "react";
+
+/**
+ * Helper function for storing the Cockpit language.
+ * @param {String} lang the new language tag (like "cs", "cs-cz",...)
+ */
+function setLang(lang) {
+  // code taken from Cockpit
+  const cookie = "CockpitLang=" + encodeURIComponent(lang) + "; path=/; expires=Sun, 16 Jul 3567 06:23:41 GMT";
+  document.cookie = cookie;
+  window.localStorage.setItem("cockpit.lang", lang);
+}
+
+/**
+ * Helper function for reloading the page.
+ */
+function reload() {
+  window.location.reload(true);
+}
+
+/**
+ * This is a helper component to set the language used in the UI. It uses the
+ * URL "lang" query parameter or the preferred language from the browser.
+ * To activate a new language it reloads the whole page.
+ *
+ * It behaves like a wrapper, it just wraps the children components, it does
+ * not render any real content.
+ *
+ * @param {React.ReactNode} [props.children] - content to display within the
+ * wrapper
+ */
+export default function L10nWrapper({ children }) {
+  // language from cookie, empty string if not set (regexp taken from Cockpit)
+  const langCookie = decodeURIComponent(document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*=\s*([^;]*).*$)|^.*$/, "$1"));
+  // "lang" query parameter from the URL, null if not set
+  let langQuery = (new URLSearchParams(window.location.search)).get("lang");
+
+  // set the language from the URL query
+  if (langQuery) {
+    // convert "pt_BR" to Cockpit compatible "pt-br"
+    langQuery = langQuery.toLowerCase().replace("_", "-");
+    if (langCookie !== langQuery) {
+      setLang(langQuery);
+      reload();
+    }
+  } else {
+    // if the language has not been configured yet use the preferred language
+    // from the browser, so far do it only in the development mode because there
+    // are not enough translations available
+    //
+    // TODO: use the navigator.languages list to find a supported language, the
+    // first preferred language might not be supported by Agama
+    if (process.env.NODE_ENV !== "production" && langCookie === "" && navigator.language) {
+      // convert browser language "pt-BR" to Cockpit compatible "pt-br"
+      setLang(navigator.language.toLowerCase());
+      reload();
+    }
+  }
+
+  return children;
+}

--- a/web/src/L10nWrapper.test.jsx
+++ b/web/src/L10nWrapper.test.jsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import L10nWrapper from "~/L10nWrapper";
+
+describe("L10nWrapper", () => {
+  // remember the original object, we need to temporarily replace it with a mock
+  const origLocation = window.location;
+
+  // mock window.location.reload
+  beforeAll(() => {
+    delete window.location;
+    window.location = {
+      reload: jest.fn(),
+    };
+  });
+
+  afterAll(() => {
+    window.location = origLocation;
+  });
+
+  // remove the Cockpit language cookie after each test
+  afterEach(() => {
+    // setting a cookie with already expired date removes it
+    document.cookie = "CockpitLang=; path=/; expires=" + new Date(0).toUTCString();
+  });
+
+  describe("when no URL query parameter is set", () => {
+    beforeEach(() => {
+      window.location.search = "";
+    });
+
+    describe("when the Cockpit language is already set", () => {
+      beforeEach(() => {
+        document.cookie = "CockpitLang=en-us; path=/;";
+      });
+
+      it("displays the children content and does not reload", async () => {
+        render(<L10nWrapper>Testing content</L10nWrapper>);
+
+        // children are displayed
+        await screen.findByText("Testing content");
+
+        expect(window.location.reload).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the Cockpit language is not set", () => {
+      it("sets the preferred language from browser and reloads", () => {
+        render(<L10nWrapper>Testing content</L10nWrapper>);
+
+        // jsdom uses "en-US" as the user preferred language
+        expect(document.cookie).toEqual("CockpitLang=en-us");
+        expect(window.location.reload).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("when the URL query parameter is set to '?lang=cs_CZ'", () => {
+    beforeEach(() => {
+      window.location.search = "?lang=cs_CZ";
+    });
+
+    describe("when the Cockpit language is already set to 'cs-cz'", () => {
+      beforeEach(() => {
+        document.cookie = "CockpitLang=cs-cz; path=/;";
+      });
+
+      it("displays the children content and does not reload", async () => {
+        render(<L10nWrapper>Testing content</L10nWrapper>);
+
+        // children are displayed
+        await screen.findByText("Testing content");
+
+        expect(document.cookie).toEqual("CockpitLang=cs-cz");
+        expect(window.location.reload).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the Cockpit language is set to 'en-us'", () => {
+      beforeEach(() => {
+        document.cookie = "CockpitLang=en-us; path=/;";
+      });
+
+      it("sets the 'cs-cz' language and reloads", () => {
+        render(<L10nWrapper>Testing content</L10nWrapper>);
+
+        expect(document.cookie).toEqual("CockpitLang=cs-cz");
+        expect(window.location.reload).toHaveBeenCalled();
+      });
+    });
+
+    describe("when the Cockpit language is not set", () => {
+      it("sets the 'cs-cz' language and reloads", () => {
+        render(<L10nWrapper>Testing content</L10nWrapper>);
+
+        // jsdom uses "en-US" as the user preferred language
+        expect(document.cookie).toEqual("CockpitLang=cs-cz");
+        expect(window.location.reload).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/web/src/L10nWrapper.test.jsx
+++ b/web/src/L10nWrapper.test.jsx
@@ -67,6 +67,8 @@ describe("L10nWrapper", () => {
     });
 
     describe("when the Cockpit language is not set", () => {
+      // so far this is only done in "test" and "development" environments,
+      // not in "production"!!
       it("sets the preferred language from browser and reloads", () => {
         render(<L10nWrapper>Testing content</L10nWrapper>);
 

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -39,6 +39,7 @@ import "@patternfly/patternfly/patternfly-base.scss";
 import App from "~/App";
 import Main from "~/Main";
 import DevServerWrapper from "~/DevServerWrapper";
+import L10nWrapper from "~/L10nWrapper";
 import { Overview } from "~/components/overview";
 import { ProductSelectionPage } from "~/components/software";
 import { ProposalPage as StoragePage, ISCSIPage, DASDPage, ZFCPPage } from "~/components/storage";
@@ -71,31 +72,33 @@ const container = document.getElementById("root");
 const root = createRoot(container);
 
 root.render(
-  <LoginWrapper>
-    <InstallerClientProvider client={createClient}>
-      <SoftwareProvider>
-        <NotificationProvider>
-          <HashRouter>
-            <Routes>
-              <Route path="/" element={<App />}>
-                <Route path="/" element={<Main />}>
-                  <Route index element={<Overview />} />
-                  <Route path="/overview" element={<Overview />} />
-                  <Route path="/l10n" element={<L10nPage />} />
-                  <Route path="/storage" element={<StoragePage />} />
-                  <Route path="/storage/iscsi" element={<ISCSIPage />} />
-                  <Route path="/storage/dasd" element={<DASDPage />} />
-                  <Route path="/storage/zfcp" element={<ZFCPPage />} />
-                  <Route path="/network" element={<NetworkPage />} />
-                  <Route path="/users" element={<UsersPage />} />
-                  <Route path="/issues" element={<IssuesPage />} />
+  <L10nWrapper>
+    <LoginWrapper>
+      <InstallerClientProvider client={createClient}>
+        <SoftwareProvider>
+          <NotificationProvider>
+            <HashRouter>
+              <Routes>
+                <Route path="/" element={<App />}>
+                  <Route path="/" element={<Main />}>
+                    <Route index element={<Overview />} />
+                    <Route path="/overview" element={<Overview />} />
+                    <Route path="/l10n" element={<L10nPage />} />
+                    <Route path="/storage" element={<StoragePage />} />
+                    <Route path="/storage/iscsi" element={<ISCSIPage />} />
+                    <Route path="/storage/dasd" element={<DASDPage />} />
+                    <Route path="/storage/zfcp" element={<ZFCPPage />} />
+                    <Route path="/network" element={<NetworkPage />} />
+                    <Route path="/users" element={<UsersPage />} />
+                    <Route path="/issues" element={<IssuesPage />} />
+                  </Route>
+                  <Route path="products" element={<ProductSelectionPage />} />
                 </Route>
-                <Route path="products" element={<ProductSelectionPage />} />
-              </Route>
-            </Routes>
-          </HashRouter>
-        </NotificationProvider>
-      </SoftwareProvider>
-    </InstallerClientProvider>
-  </LoginWrapper>
+              </Routes>
+            </HashRouter>
+          </NotificationProvider>
+        </SoftwareProvider>
+      </InstallerClientProvider>
+    </LoginWrapper>
+  </L10nWrapper>
 );


### PR DESCRIPTION
## Problem

- The web UI language cannot be easily changed, let's use the `lang` URL query parameter as a simple workaround
- In the development mode use the preferred language from browser for the initial setting. (Improve it and enable in production when we have enough translations available.)

## Notes

- The `<L10nWrapper>` component should be used at the very top in the document tree, it can potentially reload the page to activate the new language. That should happen ASAP.
- There are required some conversions between the usual Linux locales (`pt_BR`), the Cockpit locales (`pt-br`) and the browser locales (`pt-BR`)... :scream: 

## Testing

- Tested manually
- Added unit tests
