### PR TITLE
Improve error handling

### DIFF
--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -80,6 +80,18 @@ fn parse_config_command(subcommand: ConfigCommands) -> Result<ConfigAction, CliE
     }
 }
 
+/// Split the elements on '=' to make a hash of them.
+///
+/// ```
+/// let happy_in = vec!["one=first".to_string(), "two=second".to_string()];
+/// let happy_out = HashMap::from([
+///     ("one".to_string(), "first".to_string()),
+///     ("two".to_string(), "second".to_string())
+/// ]);
+/// let r = parse_keys_values(happy_in);
+/// assert!(r.is_ok());
+/// assert_eq!(r.unwrap(), happy_out);
+/// ```
 fn parse_keys_values(keys_values: Vec<String>) -> Result<HashMap<String, String>, CliError> {
     let mut changes = HashMap::new();
     for s in keys_values {
@@ -89,6 +101,22 @@ fn parse_keys_values(keys_values: Vec<String>) -> Result<HashMap<String, String>
         changes.insert(key.to_string(), value.to_string());
     }
     Ok(changes)
+}
+
+#[test]
+fn test_parse_keys_values() {
+    // an empty list is fine
+    let empty_vec = Vec::<String>::new();
+    let empty_hash = HashMap::<String, String>::new();
+    let r = parse_keys_values(empty_vec);
+    assert!(r.is_ok());
+    assert_eq!(r.unwrap(), empty_hash);
+
+    // an empty member fails
+    let empty_string = vec!["".to_string(), "two=second".to_string()];
+    let r = parse_keys_values(empty_string);
+    assert!(r.is_err());
+    assert_eq!(format!("{}", r.unwrap_err()), "Missing the '=' separator in ''");
 }
 
 fn key_to_scope(key: &str) -> Result<Scope, Box<dyn Error>> {

--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -81,17 +81,6 @@ fn parse_config_command(subcommand: ConfigCommands) -> Result<ConfigAction, CliE
 }
 
 /// Split the elements on '=' to make a hash of them.
-///
-/// ```
-/// let happy_in = vec!["one=first".to_string(), "two=second".to_string()];
-/// let happy_out = HashMap::from([
-///     ("one".to_string(), "first".to_string()),
-///     ("two".to_string(), "second".to_string())
-/// ]);
-/// let r = parse_keys_values(happy_in);
-/// assert!(r.is_ok());
-/// assert_eq!(r.unwrap(), happy_out);
-/// ```
 fn parse_keys_values(keys_values: Vec<String>) -> Result<HashMap<String, String>, CliError> {
     let mut changes = HashMap::new();
     for s in keys_values {
@@ -105,6 +94,16 @@ fn parse_keys_values(keys_values: Vec<String>) -> Result<HashMap<String, String>
 
 #[test]
 fn test_parse_keys_values() {
+    // happy path, make a hash out of the vec
+    let happy_in = vec!["one=first".to_string(), "two=second".to_string()];
+    let happy_out = HashMap::from([
+        ("one".to_string(), "first".to_string()),
+        ("two".to_string(), "second".to_string())
+    ]);
+    let r = parse_keys_values(happy_in);
+    assert!(r.is_ok());
+    assert_eq!(r.unwrap(), happy_out);
+
     // an empty list is fine
     let empty_vec = Vec::<String>::new();
     let empty_hash = HashMap::<String, String>::new();

--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -34,7 +34,8 @@ pub enum ConfigAction {
 pub async fn run(subcommand: ConfigCommands, format: Format) -> anyhow::Result<()> {
     let store = SettingsStore::new(connection().await?).await?;
 
-    match parse_config_command(subcommand) {
+    let command = parse_config_command(subcommand)?;
+    match command {
         ConfigAction::Set(changes) => {
             let scopes = changes
                 .keys()
@@ -68,26 +69,26 @@ pub async fn run(subcommand: ConfigCommands, format: Format) -> anyhow::Result<(
     }
 }
 
-fn parse_config_command(subcommand: ConfigCommands) -> ConfigAction {
+fn parse_config_command(subcommand: ConfigCommands) -> Result<ConfigAction, CliError> {
     match subcommand {
-        ConfigCommands::Add { key, values } => ConfigAction::Add(key, parse_keys_values(values)),
-        ConfigCommands::Show => ConfigAction::Show,
-        ConfigCommands::Set { values } => ConfigAction::Set(parse_keys_values(values)),
-        ConfigCommands::Load { path } => ConfigAction::Load(path),
+        ConfigCommands::Add { key, values } => {
+            Ok(ConfigAction::Add(key, parse_keys_values(values)?))
+        }
+        ConfigCommands::Show => Ok(ConfigAction::Show),
+        ConfigCommands::Set { values } => Ok(ConfigAction::Set(parse_keys_values(values)?)),
+        ConfigCommands::Load { path } => Ok(ConfigAction::Load(path)),
     }
 }
 
-fn parse_keys_values(keys_values: Vec<String>) -> HashMap<String, String> {
-    keys_values
-        .iter()
-        .filter_map(|s| {
-            if let Some((key, value)) = s.split_once('=') {
-                Some((key.to_string(), value.to_string()))
-            } else {
-                None
-            }
-        })
-        .collect()
+fn parse_keys_values(keys_values: Vec<String>) -> Result<HashMap<String, String>, CliError> {
+    let mut changes = HashMap::new();
+    for s in keys_values {
+        let Some((key, value)) = s.split_once('=') else {
+            return Err(CliError::MissingSeparator(s));
+        };
+        changes.insert(key.to_string(), value.to_string());
+    }
+    Ok(changes)
 }
 
 fn key_to_scope(key: &str) -> Result<Scope, Box<dyn Error>> {

--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -98,7 +98,7 @@ fn test_parse_keys_values() {
     let happy_in = vec!["one=first".to_string(), "two=second".to_string()];
     let happy_out = HashMap::from([
         ("one".to_string(), "first".to_string()),
-        ("two".to_string(), "second".to_string())
+        ("two".to_string(), "second".to_string()),
     ]);
     let r = parse_keys_values(happy_in);
     assert!(r.is_ok());
@@ -115,7 +115,10 @@ fn test_parse_keys_values() {
     let empty_string = vec!["".to_string(), "two=second".to_string()];
     let r = parse_keys_values(empty_string);
     assert!(r.is_err());
-    assert_eq!(format!("{}", r.unwrap_err()), "Missing the '=' separator in ''");
+    assert_eq!(
+        format!("{}", r.unwrap_err()),
+        "Missing the '=' separator in ''"
+    );
 }
 
 fn key_to_scope(key: &str) -> Result<Scope, Box<dyn Error>> {

--- a/rust/agama-cli/src/error.rs
+++ b/rust/agama-cli/src/error.rs
@@ -8,4 +8,6 @@ pub enum CliError {
     ValidationError,
     #[error("Could not start the installation")]
     InstallationError,
+    #[error("Missing the '=' separator in '{0}'")]
+    MissingSeparator(String),
 }

--- a/rust/agama-derive/src/lib.rs
+++ b/rust/agama-derive/src/lib.rs
@@ -1,3 +1,33 @@
+//! Implements a derive macro to implement the Settings from the `agama_settings` crate.
+//!
+//! ```no_compile
+//! use agama_settings::{Settings, settings::Settings};
+//!
+//! #[derive(Default, Settings)]
+//! struct UserSettings {
+//!   name: Option<String>,
+//!   enabled: Option<bool>
+//! }
+//!
+//! #[derive(Default, Settings)]
+//! struct InstallSettings {
+//!   #[settings(nested, alias = "first_user")]
+//!   user: Option<UserSettings>,
+//!   reboot: Option<bool>
+//!   product: Option<String>,
+//!   #[settings(collection)]
+//!   packages: Vec<String>
+//! }
+//!
+//! ## Supported attributes
+//!
+//! * `nested`: the field is another struct that implements `Settings`.
+//! * `collection`: the attribute is a vector of elements of type T. You might need to implement
+//!   `TryFrom<SettingObject> for T` for your custom types.
+//! * `flatten`: the field is flatten (in serde jargon).
+//! * `alias`: and alternative name for the field. It can be specified several times.
+//! ```
+
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;

--- a/rust/agama-lib/src/install_settings.rs
+++ b/rust/agama-lib/src/install_settings.rs
@@ -62,7 +62,7 @@ impl FromStr for Scope {
 #[serde(rename_all = "camelCase")]
 pub struct InstallSettings {
     #[serde(default, flatten)]
-    #[settings(nested)]
+    #[settings(nested, flatten, alias = "root")]
     pub user: Option<UserSettings>,
     #[serde(default)]
     #[settings(nested)]

--- a/rust/agama-lib/src/users/settings.rs
+++ b/rust/agama-lib/src/users/settings.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct UserSettings {
     #[serde(rename = "user")]
-    #[settings(nested)]
+    #[settings(nested, alias = "user")]
     pub first_user: Option<FirstUserSettings>,
     #[settings(nested)]
     pub root: Option<RootUserSettings>,

--- a/rust/agama-settings/src/lib.rs
+++ b/rust/agama-settings/src/lib.rs
@@ -1,3 +1,60 @@
+//! This module offers a mechanism to easily map the values from the command
+//! line to proper installation settings.
+//!
+//! In Agama, the installation settings are modeled using structs with optional fields and vectors.
+//! To specify a value in the command line, the user needs to specify:
+//!
+//! * a setting ID (`"users.name"`, `"storage.lvm"`, and so on), that must be used to find the
+//!   setting.
+//! * a value, which is captured as a string (`"Foo Bar"`, `"true"`, etc.) and it should be
+//!   converted to the proper type.
+//!
+//! Implementing the [Settings](crate::settings::Settings) trait adds support for setting the value
+//! in an straightforward way, taking care of the conversions automatically. The newtype
+//! [SettingValue] takes care of such a conversion.
+//!
+//! ## Example
+//!
+//! The best way to understand how it works is to see it in action. In the example below, there is
+//! a simplified `InstallSettings` struct that is composed by the user settings, which is another
+//! struct, and a boolean field.
+//!
+//! In this case, the trait is automatically derived, implementing a `set` method that allows
+//! setting configuration value by specifying:
+//!
+//! * An ID, like `users.name`.
+//! * A string-based value, which is automatically converted to the corresponding type in the
+//! struct.
+//!
+//! ```
+//! use agama_settings::{Settings, settings::{SettingValue, Settings}};
+//!
+//! #[derive(Default, Settings)]
+//! struct UserSettings {
+//!   name: Option<String>,
+//!   enabled: Option<bool>
+//! }
+//!
+//! #[derive(Default, Settings)]
+//! struct InstallSettings {
+//!   #[settings(nested)]
+//!   user: Option<UserSettings>,
+//!   reboot: Option<bool>
+//! }
+//!
+//! let user = UserSettings { name: Some(String::from("foo")), enabled: Some(false) };
+//! let mut settings = InstallSettings { user: Some(user), reboot: None };
+//!
+//! settings.set("user.name", SettingValue("foo.bar".to_string()));
+//! settings.set("user.enabled", SettingValue("true".to_string()));
+//! settings.set("reboot", SettingValue("true".to_string()));
+//!
+//! let user = settings.user.unwrap();
+//! assert_eq!(user.name, Some("foo.bar".to_string()));
+//! assert_eq!(user.enabled, Some(true));
+//! assert_eq!(settings.reboot, Some(true));
+//! ```
+
 pub mod error;
 pub mod settings;
 


### PR DESCRIPTION
* An attempt to address some of the issues reported in #688.
* Fix handling of users/root settings: the CLI ignored the settings but did not report any problem. This bug was introduced in #666. I needed to extend the derive macro to support `flatten` (in serde jargon) fields.
* Extend the `agama_settings` documentation to explain better how it works.

<details>
<summary>Click for a documentation screenshot :wink:</summary>

![Screenshot from 2023-08-04 13-42-54](https://github.com/openSUSE/agama/assets/15836/5eaf1826-e928-4e59-92fe-d8570125d3b7)
</details>
