### PR TITLE
Do not consider the arch when filtering the config

### DIFF
--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug  7 10:52:35 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not consider the architecture when filtering the configuration
+  file through the filter-config.rb script (gh#openSUSE/agama#691).
+
+-------------------------------------------------------------------
 Wed Aug  2 10:03:13 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 3

--- a/service/share/filter-config.rb
+++ b/service/share/filter-config.rb
@@ -41,17 +41,17 @@ unless File.exist?(path)
   exit(2)
 end
 
-config = Agama::Config.from_file(path)
+config = YAML.load_file(path)
 
-unknown_products = product_ids - config.products.keys
+unknown_products = product_ids - config["products"].keys
 unless unknown_products.empty?
   warn(format("The following products are unknown: %{products}.",
     products: unknown_products.join(", ")))
   exit(3)
 end
 
-keys_to_filter = (["products"] + config.products.keys) - product_ids
-products = product_ids.reduce({}) { |all, id| all.merge(id => config.data["products"][id]) }
+keys_to_filter = (["products"] + config["products"].keys) - product_ids
+products = product_ids.reduce({}) { |all, id| all.merge(id => config["products"][id]) }
 new_config = { "products" => products }
-new_config.merge!(config.pure_data.reject { |k, _v| keys_to_filter.include?(k) })
+new_config.merge!(config.reject { |k, _v| keys_to_filter.include?(k) })
 puts YAML.dump(new_config)


### PR DESCRIPTION
## Problem

The `filter-config.rb` script uses `Agama::Config` to load the configuration before filtering for the wanted products. The problem is that such a class filters out the unsupported architectures, which causes the script to render different configuration files depending on the arch where it runs.

What is worse, when a product is unavailable for a given architecture, it causes the script to fail. For instance, as Leap16 is not supported in `ppc64le`, the following invocation fails:

`filter-config.rb /etc/agama.yaml Tumbleweed Leap16`

The desired result should be the YAML file containing TW and Leap16 products. Agama will filter `Leap16` when running on a `ppc64le` machine.

## Solution

Load and process the configuration file as plain YAML.

## Testing

- *Tested manually*