### PR TITLE
Run the Rubocop CI check only when a Ruby file is changed

### DIFF
--- a/.github/workflows/ci-rubocop.yml
+++ b/.github/workflows/ci-rubocop.yml
@@ -12,7 +12,7 @@ on:
       - service/.rubocop.yml
       # all Ruby files
       - service/Gemfile
-      - service/bin/agamactl
+      - service/bin/**
       - service/**.rb
 
   pull_request:
@@ -26,7 +26,7 @@ on:
       - service/.rubocop.yml
       # all Ruby files
       - service/Gemfile
-      - service/bin/agamactl
+      - service/bin/**
       - service/**.rb
 
 jobs:

--- a/.github/workflows/ci-rubocop.yml
+++ b/.github/workflows/ci-rubocop.yml
@@ -1,0 +1,54 @@
+name: "CI - Rubocop"
+
+on:
+  push:
+    paths:
+      # NOTE: GitHub Actions do not allow using YAML references, the same path
+      # list is used below for the pull request event. Keep both lists in sync!!
+
+      # this file as well
+      - .github/workflows/ci-rubocop.yml
+      # Rubocop configuration
+      - service/.rubocop.yml
+      # all Ruby files
+      - service/Gemfile
+      - service/bin/agamactl
+      - service/**.rb
+
+  pull_request:
+    paths:
+      # NOTE: GitHub Actions do not allow using YAML references, the same path
+      # list is used above for the push event. Keep both lists in sync!!
+
+      # this file as well
+      - .github/workflows/ci-rubocop.yml
+      # Rubocop configuration
+      - service/.rubocop.yml
+      # all Ruby files
+      - service/Gemfile
+      - service/bin/agamactl
+      - service/**.rb
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./service
+
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [ "leap_latest" ]
+
+    container:
+      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
+
+    steps:
+
+    - name: Git Checkout
+      uses: actions/checkout@v3
+
+    - name: Rubocop
+      run: /usr/bin/rubocop.*-1.24.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,29 +98,6 @@ jobs:
         flag-name: backend
         parallel: true
 
-  ruby_linter:
-    runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        working-directory: ./service
-
-    strategy:
-      fail-fast: false
-      matrix:
-        distro: [ "leap_latest" ]
-
-    container:
-      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
-
-    steps:
-
-    - name: Git Checkout
-      uses: actions/checkout@v3
-
-    - name: Rubocop
-      run: /usr/bin/rubocop.*-1.24.1
-
   ruby_doc:
     runs-on: ubuntu-latest
     env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 **Checks**
 
 [![CI Status](https://github.com/openSUSE/agama/actions/workflows/ci.yml/badge.svg)](https://github.com/openSUSE/agama/actions/workflows/ci.yml)
+[![CI - Rubocop](https://github.com/openSUSE/agama/actions/workflows/ci-rubocop.yml/badge.svg)](https://github.com/openSUSE/agama/actions/workflows/ci-rubocop.yml)
 [![CI - Integration Tests](https://github.com/openSUSE/agama/actions/workflows/ci-integration-tests.yml/badge.svg)](https://github.com/openSUSE/agama/actions/workflows/ci-integration-tests.yml)
 [![Coverage Status](https://coveralls.io/repos/github/openSUSE/agama/badge.svg?branch=master)](https://coveralls.io/github/openSUSE/agama?branch=master)
 [![GitHub Pages](https://github.com/openSUSE/agama/actions/workflows/github-pages.yml/badge.svg)](https://github.com/openSUSE/agama/actions/workflows/github-pages.yml)


### PR DESCRIPTION
## Problem

- The Rubocop check is run always, even when no Ruby file is modified
- This makes CI slower and wastes some server resources

## Solution

- Put the Rubocop job into a separate file and use the `path` specifiers so it is run only when a matching file is updated
