### PR TITLE
CI: Move the documentation check to a separate job

### DIFF
--- a/.github/workflows/ci-doc-check.yml
+++ b/.github/workflows/ci-doc-check.yml
@@ -1,0 +1,78 @@
+name: "CI - Documentation Check"
+
+on:
+  push:
+    paths:
+      # NOTE: GitHub Actions do not allow using YAML references, the same path
+      # list is used below for the pull request event. Keep both lists in sync!!
+
+      # this file as well
+      - .github/workflows/ci-doc-check.yml
+      # all Ruby files
+      - service/Gemfile*
+      - service/*.gemspec
+      - service/**.rb
+      # the D-Bus introspection files
+      - doc/dbus/**.xml
+
+  pull_request:
+    paths:
+      # NOTE: GitHub Actions do not allow using YAML references, the same path
+      # list is used above for the push event. Keep both lists in sync!!
+
+      # this file as well
+      - .github/workflows/ci-doc-check.yml
+      # all Ruby files
+      - service/Gemfile*
+      - service/*.gemspec
+      - service/**.rb
+      # the D-Bus introspection files
+      - doc/dbus/**.xml
+
+jobs:
+  doc_check:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [ "tumbleweed" ]
+
+    container:
+      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
+
+    steps:
+
+    - name: Git Checkout
+      uses: actions/checkout@v3
+
+    - name: Fix the file owner
+      # fix the file owner
+      run:  chown -R -c 0 .
+
+    - name: Configure and refresh repositories
+      # disable unused repositories to have faster refresh
+      run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && zypper ref
+
+    - name: Install Ruby development files and XML tooling
+      run: zypper --non-interactive install gcc gcc-c++ make libopenssl-devel ruby-devel augeas-devel xmlstarlet
+
+    - name: Cache RubyGems
+      uses: actions/cache@v3
+      with:
+        key: "Gemfile-${{ hashFiles('service/Gemfile.lock') }}"
+        path: service/vendor/bundle
+
+    - name: Install RubyGems
+      run: |
+        bundle config set --local path 'vendor/bundle'
+        bundle install
+      working-directory: ./service
+
+    - name: Generate doc
+      run: bundle exec yardoc --fail-on-warning
+      working-directory: ./service
+
+    - name: Check that introspected API and its docs have not diverged
+      run: make check
+      working-directory: ./doc

--- a/.github/workflows/ci-doc-check.yml
+++ b/.github/workflows/ci-doc-check.yml
@@ -33,13 +33,8 @@ jobs:
   doc_check:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        distro: [ "tumbleweed" ]
-
     container:
-      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
+      image: registry.opensuse.org/opensuse/tumbleweed:latest
 
     steps:
 
@@ -55,7 +50,9 @@ jobs:
       run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && zypper ref
 
     - name: Install Ruby development files and XML tooling
-      run: zypper --non-interactive install gcc gcc-c++ make libopenssl-devel ruby-devel augeas-devel xmlstarlet
+      run: zypper --non-interactive install --no-recommends
+           gcc gcc-c++ make libopenssl-devel ruby-devel augeas-devel diff
+           libxslt-devel libxml2-devel xmlstarlet
 
     - name: Cache RubyGems
       uses: actions/cache@v3
@@ -64,6 +61,8 @@ jobs:
         path: service/vendor/bundle
 
     - name: Install RubyGems
+      env:
+        NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
       run: |
         bundle config set --local path 'vendor/bundle'
         bundle install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,44 +98,6 @@ jobs:
         flag-name: backend
         parallel: true
 
-  ruby_doc:
-    runs-on: ubuntu-latest
-    env:
-      COVERAGE: 1
-
-    defaults:
-      run:
-        working-directory: ./service
-
-    strategy:
-      fail-fast: false
-      matrix:
-        distro: [ "tumbleweed" ]
-
-    container:
-      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
-
-    steps:
-
-    - name: Git Checkout
-      uses: actions/checkout@v3
-
-    - name: Configure and refresh repositories
-      # disable unused repositories to have faster refresh
-      run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && ( zypper ref || zypper ref || zypper ref )
-
-    - name: Install Ruby development files and XML tooling
-      run: zypper --non-interactive install gcc gcc-c++ make openssl-devel ruby-devel npm augeas-devel xmlstarlet
-
-    - name: Install RubyGems dependencies
-      run: bundle config set --local with 'development' && bundle install
-
-    - name: Generate doc
-      run: bundle exec yardoc --fail-on-warning
-
-    - name: Check that introspected API and its docs have not diverged
-      run: make -C ../doc check
-
   rust_ci:
     runs-on: ubuntu-latest
     env:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI Status](https://github.com/openSUSE/agama/actions/workflows/ci.yml/badge.svg)](https://github.com/openSUSE/agama/actions/workflows/ci.yml)
 [![CI - Rubocop](https://github.com/openSUSE/agama/actions/workflows/ci-rubocop.yml/badge.svg)](https://github.com/openSUSE/agama/actions/workflows/ci-rubocop.yml)
+[![CI - Documentation Check](https://github.com/openSUSE/agama/actions/workflows/ci-doc-check.yml/badge.svg)](https://github.com/openSUSE/agama/actions/workflows/ci-doc-check.yml)
 [![CI - Integration Tests](https://github.com/openSUSE/agama/actions/workflows/ci-integration-tests.yml/badge.svg)](https://github.com/openSUSE/agama/actions/workflows/ci-integration-tests.yml)
 [![Coverage Status](https://coveralls.io/repos/github/openSUSE/agama/badge.svg?branch=master)](https://coveralls.io/github/openSUSE/agama?branch=master)
 [![GitHub Pages](https://github.com/openSUSE/agama/actions/workflows/github-pages.yml/badge.svg)](https://github.com/openSUSE/agama/actions/workflows/github-pages.yml)
@@ -64,13 +65,15 @@ Agama is a new Linux installer born in the core of the YaST team. It is designed
 
 ## Table of Content
 
-* [Why a New Installer](#why-a-new-installer)
-* [Architecture](#architecture)
-* [How to Run](#how-to-run)
-  * [Live ISO Image](#live-iso-image)
-  * [Manual Configuration](#manual-configuration)
-* [How to Contribute](#how-to-contribute)
-* [Development Notes](#development-notes)
+- [Agama: A Service-based Linux Installer](#agama-a-service-based-linux-installer)
+  - [Table of Content](#table-of-content)
+  - [Why a New Installer](#why-a-new-installer)
+  - [Architecture](#architecture)
+  - [How to run](#how-to-run)
+    - [Live ISO Image](#live-iso-image)
+    - [Manual Configuration](#manual-configuration)
+  - [How to Contribute](#how-to-contribute)
+  - [Development Notes](#development-notes)
 
 ## Why a New Installer
 

--- a/README.md
+++ b/README.md
@@ -65,15 +65,13 @@ Agama is a new Linux installer born in the core of the YaST team. It is designed
 
 ## Table of Content
 
-- [Agama: A Service-based Linux Installer](#agama-a-service-based-linux-installer)
-  - [Table of Content](#table-of-content)
-  - [Why a New Installer](#why-a-new-installer)
-  - [Architecture](#architecture)
-  - [How to run](#how-to-run)
-    - [Live ISO Image](#live-iso-image)
-    - [Manual Configuration](#manual-configuration)
-  - [How to Contribute](#how-to-contribute)
-  - [Development Notes](#development-notes)
+* [Why a New Installer](#why-a-new-installer)
+* [Architecture](#architecture)
+* [How to Run](#how-to-run)
+  * [Live ISO Image](#live-iso-image)
+  * [Manual Configuration](#manual-configuration)
+* [How to Contribute](#how-to-contribute)
+* [Development Notes](#development-notes)
 
 ## Why a New Installer
 


### PR DESCRIPTION
## CI Improvements

- Run the `yardoc` check and the D-Bus documentation check only when a respective file is updated
- This saves some unnecessary builds and makes CI checks faster
- Cache the installed RubyGems, this reduces the installation time from [~1m40s](https://github.com/openSUSE/agama/actions/runs/5810817100/job/15752607772#step:7:1) to [~4s](https://github.com/openSUSE/agama/actions/runs/5811209387/job/15754019772#step:8:1) (!)
- Use the smaller Tumbleweed base image - it needs to install more packages (8s -> 24s = +16s), but the Docker image download is much faster (~2m -> 10s = -110s) so overall it is about 1-2 minutes faster
