### PR TITLE
Form now scrolls up if warning is shown

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -2,7 +2,7 @@
 Sat Aug 12 11:35:12 UTC 2023 - Balsa Asanovic <balsaasanovic95@gmail.com>
 
 - Added scroll up functionality to the discover iSCSI form when
-  the warning shows up after the submit action.
+  the warning shows up after the submit action
   (gh#openSUSE/agama#468).
   
 -------------------------------------------------------------------

--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sat Aug 12 11:35:12 UTC 2023 - Balsa Asanovic <balsaasanovic95@gmail.com>
+
+- Added scroll up functionality to the discover iSCSI form when
+  the warning shows up after the submit action.
+  (gh#openSUSE/agama#468).
+  
+-------------------------------------------------------------------
 Wed Aug  2 18:59:16 UTC 2023 - Balsa Asanovic <balsaasanovic95@gmail.com>
 
 - Introduced functionality to close Dropdown automatically

--- a/web/src/components/storage/iscsi/DiscoverForm.jsx
+++ b/web/src/components/storage/iscsi/DiscoverForm.jsx
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Alert,
   Form, FormGroup,
@@ -46,10 +46,20 @@ export default function DiscoverForm({ onSubmit: onSubmitProp, onCancel }) {
   const [isLoading, setIsLoading] = useState(false);
   const [isFailed, setIsFailed] = useState(false);
   const [isValidAuth, setIsValidAuth] = useState(true);
+  const alertRef = useRef(null);
 
   useEffect(() => {
     setData(savedData);
   }, [setData, savedData]);
+
+  useEffect(() => {
+    // Scroll the alert into view
+    if (isFailed)
+      alertRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "start"
+      });
+  });
 
   const updateData = (key, value) => setData({ ...data, [key]: value });
   const onAddressChange = v => updateData("address", v);
@@ -89,9 +99,15 @@ export default function DiscoverForm({ onSubmit: onSubmitProp, onCancel }) {
     <Popup isOpen title="Discover iSCSI Targets">
       <Form id={id} onSubmit={onSubmit}>
         { isFailed &&
-          <Alert variant="warning" isInline title="Something went wrong">
-            <p>Make sure you provide the correct values</p>
-          </Alert> }
+          <div ref={alertRef}>
+            <Alert
+              variant="warning"
+              isInline
+              title="Something went wrong"
+            >
+              <p>Make sure you provide the correct values</p>
+            </Alert>
+          </div> }
         <FormGroup
           fieldId="address"
           label="IP address"


### PR DESCRIPTION
## Problem

Forms generally show errors on top, so when the submit is clicked again if the error is shown again, it seems as if nothing happens.

fixes #468 

## Solution

I've attached a useRef hook to the alert and whenever the component is rendered with the error it will scroll up to it.

## Testing

No unit test for this component.
Tested manually.

## Screenshots

![image](https://github.com/openSUSE/agama/assets/112288843/35c7c439-d6c8-4098-b0e9-8deb5e40e9d8)
![image](https://github.com/openSUSE/agama/assets/112288843/7237fd61-04e6-4bb7-97ca-948208beb1b1)


