### PR TITLE
Support for special testing "xx" language

### DIFF
--- a/web/src/L10nWrapper.jsx
+++ b/web/src/L10nWrapper.jsx
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-// import React from "react";
+import cockpit from "./lib/cockpit";
 
 /**
  * Helper function for storing the Cockpit language.
@@ -60,7 +60,12 @@ export default function L10nWrapper({ children }) {
   if (langQuery) {
     // convert "pt_BR" to Cockpit compatible "pt-br"
     langQuery = langQuery.toLowerCase().replace("_", "-");
-    if (langCookie !== langQuery) {
+
+    // special handling for the testing "xx" language
+    if (langQuery === "xx" || langQuery === "xx-xx") {
+      // just activate the language, there are no real translations to load
+      cockpit.language = "xx";
+    } else if (langCookie !== langQuery) {
       setLang(langQuery);
       reload();
     }

--- a/web/src/i18n.js
+++ b/web/src/i18n.js
@@ -28,13 +28,51 @@
 import cockpit from "./lib/cockpit";
 
 /**
+ * Tests whether a special testing language is used.
+ *
+ * @returns {boolean} true if the testing language is set
+ */
+const isTestingLanguage = () => cockpit.language === "xx";
+
+/**
+ * "Translate" the string to special "xx" testing language.
+ * It just replaces all alpha characters with "x".
+ * It keeps the percent placeholders like "%s" or "%d" unmodified.
+ *
+ * @param {string} str input string
+ * @returns {string} "translated" string
+ */
+const xTranslate = (str) => {
+  let result = "";
+
+  let wasPercent = false;
+  for (let index = 0; index < str.length; index++) {
+    const char = str[index];
+
+    if (wasPercent) {
+      result += char;
+      wasPercent = false;
+    } else {
+      if (char === "%") {
+        result += char;
+        wasPercent = true;
+      } else {
+        result += char.replace(/[a-z]/, "x").replace(/[A-Z]/, "X");
+      }
+    }
+  }
+
+  return result;
+};
+
+/**
  * Returns a translated text in the current locale or the original text if the
  * translation is not found.
  *
  * @param {string} str the input string to translate
  * @return {string} translated or original text
  */
-const _ = (str) => cockpit.gettext(str);
+const _ = (str) => isTestingLanguage() ? xTranslate(str) : cockpit.gettext(str);
 
 /**
  * Similar to the _() function. This variant returns singular or plural form
@@ -47,7 +85,11 @@ const _ = (str) => cockpit.gettext(str);
  *   singular or plural form
  * @return {string} translated or original text
  */
-const n_ = (str1, strN, n) => cockpit.ngettext(str1, strN, n);
+const n_ = (str1, strN, n) => {
+  return isTestingLanguage()
+    ? xTranslate((n === 1) ? str1 : strN)
+    : cockpit.ngettext(str1, strN, n);
+};
 
 /**
  * This is a no-op function, it can be used only for marking the text for


### PR DESCRIPTION
## Problem

- It is difficult to find out which texts are marked for translation
- Or to find out untranslated string

## Solution

- "Translate" all texts in the `_()` and `n_()` functions, just convert them to X sequences
  - Just be careful of special `%s` or `%d` sequences, those should be kept

## Notes

- This of course handles only the texts generated by the web UI itself, it cannot mark the texts coming from the backed

## Screenshots

- Use `?lang=xx` URL parameter, this can be entered only manually, we should never allow this in the UI

![xx_lang](https://github.com/openSUSE/agama/assets/907998/a166b804-bf5a-43d8-92e9-dc943ba32652)


