### PR TITLE
Use `async_std` channels and tasks

### DIFF
--- a/rust/agama-dbus-server/src/network/dbus/service.rs
+++ b/rust/agama-dbus-server/src/network/dbus/service.rs
@@ -3,7 +3,7 @@
 //! This module defines a D-Bus service which exposes Agama's network configuration.
 use crate::network::NetworkSystem;
 use agama_lib::connection_to;
-use std::{error::Error, thread};
+use std::error::Error;
 
 /// Represents the Agama networking D-Bus service.
 ///
@@ -20,19 +20,17 @@ impl NetworkService {
             .await
             .expect("Could not read network state");
 
-        thread::spawn(move || {
-            async_std::task::block_on(async {
-                network
-                    .setup()
-                    .await
-                    .expect("Could not set up the D-Bus tree");
-                connection
-                    .request_name(SERVICE_NAME)
-                    .await
-                    .unwrap_or_else(|_| panic!("Could not request name {SERVICE_NAME}"));
+        async_std::task::spawn(async move {
+            network
+                .setup()
+                .await
+                .expect("Could not set up the D-Bus tree");
+            connection
+                .request_name(SERVICE_NAME)
+                .await
+                .unwrap_or_else(|_| panic!("Could not request name {SERVICE_NAME}"));
 
-                network.listen().await;
-            })
+            network.listen().await;
         });
         Ok(())
     }

--- a/rust/agama-dbus-server/src/network/dbus/tree.rs
+++ b/rust/agama-dbus-server/src/network/dbus/tree.rs
@@ -3,10 +3,9 @@ use futures::lock::Mutex;
 use zbus::zvariant::{ObjectPath, OwnedObjectPath};
 
 use crate::network::{action::Action, dbus::interfaces, model::*};
+use async_std::{channel::Sender, sync::Arc};
 use log;
 use std::collections::HashMap;
-use std::sync::mpsc::Sender;
-use std::sync::Arc;
 
 const CONNECTIONS_PATH: &str = "/org/opensuse/Agama/Network1/connections";
 const DEVICES_PATH: &str = "/org/opensuse/Agama/Network1/devices";

--- a/setup-service.sh
+++ b/setup-service.sh
@@ -39,8 +39,7 @@ test -f /etc/zypp/repos.d/d_l_python.repo || \
   $SUDO zypper --non-interactive \
     addrepo https://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Tumbleweed/ d_l_python
 $SUDO zypper --non-interactive --gpg-auto-import-keys install gcc gcc-c++ make openssl-devel ruby-devel \
-  python-langtable-data \
-  git augeas-devel jemalloc-devel || exit 1
+  python-langtable-data git augeas-devel jemalloc-devel awk || exit 1
 
 # only install cargo if it is not available (avoid conflicts with rustup)
 which cargo || $SUDO zypper --non-interactive install cargo


### PR DESCRIPTION
Use `async_std` channels and tasks instead of the no-async aware options. Based on #664.