### PR TITLE
Fix manager service status during startup

### DIFF
--- a/rust/agama-cli/src/main.rs
+++ b/rust/agama-cli/src/main.rs
@@ -54,12 +54,12 @@ async fn install(manager: &ManagerClient<'_>, max_attempts: u8) -> anyhow::Resul
         println!("Agama's manager is busy. Waiting until it is ready...");
     }
 
+    // Make sure that the manager is ready
+    manager.wait().await?;
+
     if !manager.can_install().await? {
         return Err(CliError::ValidationError)?;
     }
-
-    // Display the progress (if needed) and makes sure that the manager is ready
-    manager.wait().await?;
 
     let progress = task::spawn(async { show_progress().await });
     // Try to start the installation up to max_attempts times.

--- a/service/lib/agama/dbus/manager.rb
+++ b/service/lib/agama/dbus/manager.rb
@@ -133,6 +133,13 @@ module Agama
         backend.busy_services
       end
 
+      # Redefines #service_status to use the one from the backend
+      #
+      # @return [DBus::ServiceStatus]
+      def service_status
+        backend.service_status
+      end
+
     private
 
       # @return [Agama::Manager]

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Mon Aug 21 11:15:50 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Set the manager service as busy during the startup phase when
-  a single product is available (bsc#1213194).
+- Set the manager service as busy during the startup phase
+  (bsc#1213194).
 
 -------------------------------------------------------------------
 Fri Aug 18 14:17:13 UTC 2023 - Knut Anderssen <kanderssen@suse.com>

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 21 11:15:50 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Set the manager service as busy during the startup phase when
+  a single product is available (bsc#1213194).
+
+-------------------------------------------------------------------
 Fri Aug 18 14:17:13 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Add proxy setup support (bsc#1212677, gh#openSUSE/agama#696).

--- a/service/test/agama/dbus/manager_test.rb
+++ b/service/test/agama/dbus/manager_test.rb
@@ -29,13 +29,15 @@ describe Agama::DBus::Manager do
   subject { described_class.new(backend, logger) }
 
   let(:logger) { Logger.new($stdout, level: :warn) }
+  let(:service_status) { Agama::DBus::ServiceStatus.new.idle }
 
   let(:backend) do
     instance_double(Agama::Manager,
       installation_phase:        installation_phase,
       software:                  software_client,
       on_services_status_change: nil,
-      valid?:                    true)
+      valid?:                    true,
+      service_status:            service_status)
   end
 
   let(:installation_phase) { Agama::InstallationPhase.new }
@@ -98,7 +100,7 @@ describe Agama::DBus::Manager do
   describe "#config_phase" do
     context "when the service is idle" do
       before do
-        subject.service_status.idle
+        service_status.idle
       end
 
       it "runs the config phase, setting the service as busy meanwhile" do
@@ -112,11 +114,11 @@ describe Agama::DBus::Manager do
 
     context "when the service is busy" do
       before do
-        subject.service_status.busy
+        service_status.busy
       end
 
       it "raises a D-Bus error" do
-        expect { subject.config_phase }.to raise_error(::DBus::Error)
+        expect { subject.config_phase }.to raise_error(DBus::Error)
       end
     end
   end
@@ -124,7 +126,7 @@ describe Agama::DBus::Manager do
   describe "#install_phase" do
     context "when the service is idle" do
       before do
-        subject.service_status.idle
+        service_status.idle
       end
 
       it "runs the install phase, setting the service as busy meanwhile" do
@@ -148,11 +150,11 @@ describe Agama::DBus::Manager do
 
     context "when the service is busy" do
       before do
-        subject.service_status.busy
+        service_status.busy
       end
 
       it "raises a D-Bus error" do
-        expect { subject.install_phase }.to raise_error(::DBus::Error)
+        expect { subject.install_phase }.to raise_error(DBus::Error)
       end
     end
   end


### PR DESCRIPTION
## Problem

See #707, "Manager status on single-product scenarios".

## Solution

Let the manager set the service status outside of D-Bus. It does not solve all timing issues, but the `Could not start the installation...` should not happen.

## Testing

- Fixed unit tests
- Tested manually