### PR TITLE
Proxy install

### DIFF
--- a/service/lib/agama/helpers.rb
+++ b/service/lib/agama/helpers.rb
@@ -45,5 +45,24 @@ module Agama
         Yast::WFM.SCRClose(handle)
       end
     end
+
+    # Run a block in the local system
+    #
+    # @param block [Proc] Block to run on the local system
+    def on_local(&block)
+      Yast.import "WFM"
+      old_handle = Yast::WFM.SCRGetDefault
+      handle = Yast::WFM.SCROpen("chroot=/:scr", false)
+      Yast::WFM.SCRSetDefault(handle)
+
+      begin
+        block.call
+      rescue StandardError => e
+        logger.error "Error while running on target tasks: #{e.inspect}"
+      ensure
+        Yast::WFM.SCRSetDefault(old_handle)
+        Yast::WFM.SCRClose(handle)
+      end
+    end
   end
 end

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -104,12 +104,11 @@ module Agama
 
       progress.step("Partitioning") do
         storage.install
+        proxy.propose
         # propose software after /mnt is already separated, so it uses proper
         # target
         software.propose
       end
-
-      ProxySetup.instance.propose
 
       progress.step("Installing Software") { software.install }
 
@@ -138,6 +137,13 @@ module Agama
           service_status_recorder.save(client.service.name, status)
         end
       end
+    end
+
+    # ProxySetup instance
+    #
+    # @return [ProxySetup]
+    def proxy
+      ProxySetup.instance
     end
 
     # Language manager

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "agama/config"
 require "agama/network"
+require "agama/proxy_setup"
 require "agama/with_progress"
 require "agama/installation_phase"
 require "agama/service_status_recorder"

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -109,6 +109,8 @@ module Agama
         software.propose
       end
 
+      ProxySetup.instance.propose
+
       progress.step("Installing Software") { software.install }
 
       on_target do

--- a/service/lib/agama/network.rb
+++ b/service/lib/agama/network.rb
@@ -23,6 +23,7 @@ require "singleton"
 require "yast"
 require "yast2/systemd/service"
 require "y2network/proposal_settings"
+require "agama/proxy_setup"
 
 Yast.import "Installation"
 
@@ -41,6 +42,8 @@ module Agama
     def install
       copy_files
       enable_service
+
+      ProxySetup.instance.install
     end
 
   private

--- a/service/lib/agama/proxy_setup.rb
+++ b/service/lib/agama/proxy_setup.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "uri"
 require "fileutils"
+require "agama/helpers"
 
 module Agama
   # This class is responsible of parsing the proxy url from the kernel cmdline or configured
@@ -31,6 +32,7 @@ module Agama
     include Singleton
     include Yast
     include Logger
+    include Helpers
 
     CMDLINE_PATH = "/proc/cmdline"
     CMDLINE_MENU_CONF = "/etc/cmdline-menu.conf"
@@ -54,11 +56,13 @@ module Agama
     end
 
     def install
-      Proxy.Read
-      return unless Proxy.enabled
+      on_local do
+        Proxy.Read
+        return unless Proxy.enabled
 
-      copy_files
-      add_packages
+        copy_files
+        add_packages
+      end
     end
 
   private

--- a/service/lib/agama/proxy_setup.rb
+++ b/service/lib/agama/proxy_setup.rb
@@ -66,10 +66,8 @@ module Agama
     def install
       return unless Proxy.enabled
 
-      on_local do
-        copy_files
-        enable_services
-      end
+      on_local { copy_files }
+      enable_services
     end
 
   private
@@ -148,6 +146,7 @@ module Agama
         return
       end
 
+      Yast::Execute.on_target!("systemctl", "enable", "setup-systemd-proxy-env.service")
       Yast::Execute.on_target!("systemctl", "enable", "setup-systemd-proxy-env.path")
     end
   end

--- a/service/lib/agama/proxy_setup.rb
+++ b/service/lib/agama/proxy_setup.rb
@@ -33,6 +33,8 @@ module Agama
 
     CMDLINE_PATH = "/proc/cmdline"
     CMDLINE_MENU_CONF = "/etc/cmdline-menu.conf"
+    PACKAGES = ["microos-tools"].freeze
+    CONFIG_PATH = "/etc/sysconfig/proxy"
 
     # @return [URI::Generic]
     attr_accessor :proxy
@@ -104,6 +106,22 @@ module Agama
       log.debug "Writing proxy settings: #{settings}"
 
       Proxy.Write
+    end
+
+    def install
+      return unless proxy
+
+      copy_files
+      add_packages
+    end
+
+    def add_packages
+      log.info "Selecting these packages for installation: #{PACKAGES}"
+      Yast::PackagesProposal.SetResolvables(PROPOSAL_ID, :package, PACKAGES)
+    end
+
+    def copy_files
+      FileUtils.cp(CONFIG_PATH, File.join(Yast::Installation.destdir, CONFIG_PATH))
     end
   end
 end

--- a/service/lib/agama/proxy_setup.rb
+++ b/service/lib/agama/proxy_setup.rb
@@ -43,6 +43,8 @@ module Agama
     # @return [URI::Generic]
     attr_accessor :proxy
 
+    alias_method :logger, :log
+
     # Constructor
     def initialize
       Yast.import "Proxy"
@@ -142,7 +144,7 @@ module Agama
     def enable_services
       service = Yast2::Systemd::Service.find("setup-systemd-proxy-env")
       if service.nil?
-        logger.error "setup-systemd-proxy-env service was not found"
+        log.error "setup-systemd-proxy-env service was not found"
         return
       end
 

--- a/service/lib/agama/proxy_setup.rb
+++ b/service/lib/agama/proxy_setup.rb
@@ -58,7 +58,7 @@ module Agama
     end
 
     def propose
-      on_target { add_packages } if Proxy.enabled
+      add_packages if Proxy.enabled
     end
 
     def install

--- a/service/lib/agama/proxy_setup.rb
+++ b/service/lib/agama/proxy_setup.rb
@@ -109,7 +109,8 @@ module Agama
     end
 
     def install
-      return unless proxy
+      Proxy.Read
+      return unless Proxy.enabled
 
       copy_files
       add_packages
@@ -121,6 +122,7 @@ module Agama
     end
 
     def copy_files
+      log.info "Copying proxy configuration to the target system"
       FileUtils.cp(CONFIG_PATH, File.join(Yast::Installation.destdir, CONFIG_PATH))
     end
   end

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 28 07:59:26 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Copy the proxy configuration to the target system when needed
+  (bsc#1212677, gh#openSUSE/agama#711).
+
+-------------------------------------------------------------------
 Wed Aug 23 10:39:46 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Install the ppc64-diag package when running on ppc64le (related

--- a/service/test/agama/manager_test.rb
+++ b/service/test/agama/manager_test.rb
@@ -34,6 +34,9 @@ describe Agama::Manager do
   end
   let(:config) { Agama::Config.from_file(config_path) }
   let(:logger) { Logger.new($stdout, level: :warn) }
+  let(:proxy) do
+    instance_double(Agama::ProxySetup, propose: nil, install: nil)
+  end
 
   let(:software) do
     instance_double(
@@ -61,6 +64,7 @@ describe Agama::Manager do
 
   before do
     allow(Agama::Network).to receive(:new).and_return(network)
+    allow(Agama::ProxySetup).to receive(:instance).and_return(proxy)
     allow(Agama::DBus::Clients::Locale).to receive(:new).and_return(locale)
     allow(Agama::DBus::Clients::Software).to receive(:new).and_return(software)
     allow(Agama::DBus::Clients::Storage).to receive(:new).and_return(storage)
@@ -113,6 +117,12 @@ describe Agama::Manager do
     it "sets the installation phase to install" do
       subject.install_phase
       expect(subject.installation_phase.install?).to eq(true)
+    end
+
+    it "calls #propose on proxy and software modules" do
+      expect(proxy).to receive(:propose)
+      expect(software).to receive(:propose)
+      subject.install_phase
     end
 
     it "calls #install (or #write) method of each module" do

--- a/service/test/agama/proxy_setup_test.rb
+++ b/service/test/agama/proxy_setup_test.rb
@@ -76,7 +76,7 @@ describe Agama::ProxySetup do
     end
   end
 
-  describe "#install" do
+  describe "#propose" do
     let(:config) do
       {
         "enabled" => false
@@ -88,10 +88,34 @@ describe Agama::ProxySetup do
       allow(Yast::Installation).to receive(:destdir).and_return("/mnt")
     end
 
-    it "reads the current Proxy configuration from the inst-sys" do
-      expect(Yast::Proxy).to receive(:Read)
+    context "when the use of proxy is enabled" do
+      let(:config) do
+        {
+          "enabled"    => true,
+          "http_proxy" => "http://192.168.122.1:3128"
+        }
+      end
 
-      proxy.install
+      it "adds microos-tools package to the set of resolvables" do
+        expect(Yast::PackagesProposal).to receive(:SetResolvables) do |_, _, packages|
+          expect(packages).to contain_exactly("microos-tools")
+        end
+
+        proxy.propose
+      end
+    end
+  end
+
+  describe "#install" do
+    let(:config) do
+      {
+        "enabled" => false
+      }
+    end
+
+    before do
+      Yast::Proxy.Import(config)
+      allow(Yast::Installation).to receive(:destdir).and_return("/mnt")
     end
 
     context "when the use of proxy is disabled" do


### PR DESCRIPTION
## Problem

In #696 we added support for configuring the proxy when booting the installation system but the configuration is lost after the  installation.

- https://trello.com/c/gmOcIc0b/3404-5-agama-proxy-configuration-first-simplistic-approach


## Solution

The proxy configuration will be copied to the target system when a proxy is used as well as the **microos-tools** package will be installed.


## Testing

- *Added a new unit test*
- *Tested manually*

