### PR TITLE
Fix Unknown method: SetInteractive for `agama questions mode non-interactive` (#709)

### DIFF
--- a/rust/agama-dbus-server/src/network/nm/proxies.rs
+++ b/rust/agama-dbus-server/src/network/nm/proxies.rs
@@ -162,6 +162,7 @@ trait NetworkManager {
     /// ConnectivityCheckEnabled property
     #[dbus_proxy(property)]
     fn connectivity_check_enabled(&self) -> zbus::Result<bool>;
+    #[dbus_proxy(property)]
     fn set_connectivity_check_enabled(&self, value: bool) -> zbus::Result<()>;
 
     /// ConnectivityCheckUri property
@@ -177,6 +178,7 @@ trait NetworkManager {
     fn global_dns_configuration(
         &self,
     ) -> zbus::Result<std::collections::HashMap<String, zbus::zvariant::OwnedValue>>;
+    #[dbus_proxy(property)]
     fn set_global_dns_configuration(
         &self,
         value: std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
@@ -221,6 +223,7 @@ trait NetworkManager {
     /// WimaxEnabled property
     #[dbus_proxy(property)]
     fn wimax_enabled(&self) -> zbus::Result<bool>;
+    #[dbus_proxy(property)]
     fn set_wimax_enabled(&self, value: bool) -> zbus::Result<()>;
 
     /// WimaxHardwareEnabled property
@@ -230,6 +233,7 @@ trait NetworkManager {
     /// WirelessEnabled property
     #[dbus_proxy(property)]
     fn wireless_enabled(&self) -> zbus::Result<bool>;
+    #[dbus_proxy(property)]
     fn set_wireless_enabled(&self, value: bool) -> zbus::Result<()>;
 
     /// WirelessHardwareEnabled property
@@ -239,6 +243,7 @@ trait NetworkManager {
     /// WwanEnabled property
     #[dbus_proxy(property)]
     fn wwan_enabled(&self) -> zbus::Result<bool>;
+    #[dbus_proxy(property)]
     fn set_wwan_enabled(&self, value: bool) -> zbus::Result<()>;
 
     /// WwanHardwareEnabled property
@@ -291,6 +296,7 @@ trait Device {
     /// Autoconnect property
     #[dbus_proxy(property)]
     fn autoconnect(&self) -> zbus::Result<bool>;
+    #[dbus_proxy(property)]
     fn set_autoconnect(&self, value: bool) -> zbus::Result<()>;
 
     /// AvailableConnections property
@@ -374,6 +380,7 @@ trait Device {
     /// Managed property
     #[dbus_proxy(property)]
     fn managed(&self) -> zbus::Result<bool>;
+    #[dbus_proxy(property)]
     fn set_managed(&self, value: bool) -> zbus::Result<()>;
 
     /// Metered property

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -147,5 +147,6 @@ trait Questions1 {
     /// Interactive property
     #[dbus_proxy(property)]
     fn interactive(&self) -> zbus::Result<bool>;
+    #[dbus_proxy(property)]
     fn set_interactive(&self, value: bool) -> zbus::Result<()>;
 }


### PR DESCRIPTION

## Problem

See #709:

When I use our CLI,  `agama questions mode non-interactive`
It calls a `org.opensuse.Agama.Questions1.SetInteractive` _method_ on `/org/opensuse/Agama/Questions1` but [the actual API is an `Interactive` _property_](https://github.com/openSUSE/agama/blob/55a84ba36b2c723bb63143ab92468db95a425706/doc/dbus/org.opensuse.Agama.Questions1.doc.xml#L103).

## Solution

Fix the generated proxies to include a `dbus_proxy(property)` attribute.

(other `proxies.rs` files either do not have writable properties or already have this fix applied)

An upstream fix for https://github.com/dbus2/zbus will follow.

## Testing

Tested manually:

```console
567764a093c4:/checkout # rust/target/debug/agama questions mode non-interactive
Failed to set mode for answering questions.

Caused by:
    org.freedesktop.DBus.Error.UnknownMethod: Unknown method 'SetInteractive'
567764a093c4:/checkout # [apply this fix]
567764a093c4:/checkout # (cd rust; cargo b)
   Compiling agama-lib v1.0.0 (/checkout/rust/agama-lib)
   Compiling agama-cli v1.0.0 (/checkout/rust/agama-cli)
   Compiling agama-dbus-server v0.1.0 (/checkout/rust/agama-dbus-server)
    Finished dev [unoptimized + debuginfo] target(s) in 13.53s
567764a093c4:/checkout # rust/target/debug/agama questions mode non-interactive
11:47:52 [INFO] interactive value unchanged - false
```

## Screenshots

See above.
