### PR TITLE
weblate-merge-po.yml - fixed PO file validation

### DIFF
--- a/.github/workflows/weblate-merge-po.yml
+++ b/.github/workflows/weblate-merge-po.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Validate the PO files
         working-directory: ./agama
-        run:  msgfmt --check-format -o /dev/null web/po/*.po
+        run:  ls web/po/*.po | xargs -n1 msgfmt --check-format -o /dev/null
 
       # any changes besides the timestamps in the PO files?
       - name: Check changes


### PR DESCRIPTION
## Problem

- The PO file validation in the GitHub Action fails
- See https://github.com/openSUSE/agama/actions/runs/5988472539/job/16243691592#step:9:5


## Solution

- Each PO file needs to be checked individually otherwise `msgfmt` complains about duplicate messages.
- Note: We cannot use `find -exec` because it ignores errors in the child processes

## Testing

- Tested manually
