### PR TITLE
[RFC] Integration tests for `agama-dbus-server`

### DIFF
--- a/rust/agama-dbus-server/src/main.rs
+++ b/rust/agama-dbus-server/src/main.rs
@@ -1,4 +1,4 @@
-use agama_dbus_server::{locale, network::NetworkService, questions};
+use agama_dbus_server::{locale, network, questions};
 
 use log::LevelFilter;
 use std::future::pending;
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     log::info!("Started questions interface");
     let _conn = locale::start_service(ADDRESS).await?;
     log::info!("Started locale interface");
-    NetworkService::start(ADDRESS).await?;
+    network::start_service(ADDRESS).await?;
     log::info!("Started network interface");
 
     // Do other things or go to wait forever

--- a/rust/agama-dbus-server/src/network.rs
+++ b/rust/agama-dbus-server/src/network.rs
@@ -51,3 +51,10 @@ pub use adapter::Adapter;
 pub use dbus::NetworkService;
 pub use model::NetworkState;
 pub use system::NetworkSystem;
+
+pub async fn start_service(address: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let adapter = NetworkManagerAdapter::from_system()
+        .await
+        .expect("Could not connect to NetworkManager to read the configuration.");
+    NetworkService::start(address, adapter).await
+}

--- a/rust/agama-dbus-server/src/network.rs
+++ b/rust/agama-dbus-server/src/network.rs
@@ -50,6 +50,7 @@ pub use action::Action;
 pub use adapter::Adapter;
 pub use dbus::NetworkService;
 pub use model::NetworkState;
+pub use nm::NetworkManagerAdapter;
 pub use system::NetworkSystem;
 
 pub async fn start_service(address: &str) -> Result<(), Box<dyn std::error::Error>> {

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -19,6 +19,7 @@ use std::net::{AddrParseError, Ipv4Addr};
 use zbus::{
     dbus_interface,
     zvariant::{ObjectPath, OwnedObjectPath},
+    SignalContext,
 };
 
 /// D-Bus interface for the network devices collection
@@ -126,7 +127,7 @@ impl Connections {
     pub async fn add_connection(&mut self, id: String, ty: u8) -> zbus::fdo::Result<()> {
         let actions = self.actions.lock().await;
         actions
-            .send(Action::AddConnection(id, ty.try_into()?))
+            .send(Action::AddConnection(id.clone(), ty.try_into()?))
             .await
             .unwrap();
         Ok(())
@@ -163,6 +164,13 @@ impl Connections {
         actions.send(Action::Apply).await.unwrap();
         Ok(())
     }
+
+    #[dbus_interface(signal)]
+    pub async fn connection_added(
+        ctxt: &SignalContext<'_>,
+        id: &str,
+        path: &str,
+    ) -> zbus::Result<()>;
 }
 
 /// D-Bus interface for a network connection

--- a/rust/agama-dbus-server/src/network/dbus/service.rs
+++ b/rust/agama-dbus-server/src/network/dbus/service.rs
@@ -1,7 +1,7 @@
 //! Network D-Bus service.
 //!
 //! This module defines a D-Bus service which exposes Agama's network configuration.
-use crate::network::{nm::NetworkManagerAdapter, NetworkSystem};
+use crate::network::{Adapter, NetworkSystem};
 use agama_lib::connection_to;
 use std::error::Error;
 
@@ -12,12 +12,12 @@ pub struct NetworkService;
 
 impl NetworkService {
     /// Starts listening and dispatching events on the D-Bus connection.
-    pub async fn start(address: &str) -> Result<(), Box<dyn Error>> {
+    pub async fn start<T: Adapter + std::marker::Send + 'static>(
+        address: &str,
+        adapter: T,
+    ) -> Result<(), Box<dyn Error>> {
         const SERVICE_NAME: &str = "org.opensuse.Agama.Network1";
 
-        let adapter = NetworkManagerAdapter::from_system()
-            .await
-            .expect("Could not connect to NetworkManager to read the configuration.");
         let connection = connection_to(address).await?;
         let mut network = NetworkSystem::new(connection.clone(), adapter);
 

--- a/rust/agama-dbus-server/src/network/dbus/tree.rs
+++ b/rust/agama-dbus-server/src/network/dbus/tree.rs
@@ -125,7 +125,7 @@ impl Tree {
     pub async fn remove_connection(&mut self, id: &str) -> Result<(), ServiceError> {
         let mut objects = self.objects.lock().await;
         let Some(path) = objects.connection_path(id) else {
-            return Ok(())
+            return Ok(());
         };
         self.remove_connection_on(path.as_str()).await?;
         objects.deregister_connection(id).unwrap();

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use thiserror::Error;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct NetworkState {
     pub devices: Vec<Device>,
     pub connections: Vec<Connection>,

--- a/rust/agama-dbus-server/src/network/system.rs
+++ b/rust/agama-dbus-server/src/network/system.rs
@@ -66,7 +66,7 @@ impl<T: Adapter> NetworkSystem<T> {
         match action {
             Action::AddConnection(name, ty) => {
                 let mut conn = Connection::new(name, ty);
-                self.tree.add_connection(&mut conn).await?;
+                self.tree.add_connection(&mut conn, true).await?;
                 self.state.add_connection(conn)?;
             }
             Action::UpdateConnection(conn) => {

--- a/rust/agama-dbus-server/tests/common/mod.rs
+++ b/rust/agama-dbus-server/tests/common/mod.rs
@@ -1,6 +1,7 @@
 use agama_lib::{connection_to, error::ServiceError};
 use async_std::stream::StreamExt;
 use std::process::{Child, Command};
+use std::time::Duration;
 use uuid::Uuid;
 use zbus::{MatchRule, MessageStream, MessageType};
 
@@ -80,8 +81,8 @@ impl DBusServer {
     /// Waits until the D-Bus daemon is ready.
     // TODO: implement proper waiting instead of just using a sleep
     fn wait(&self) {
-        let wait_time = std::time::Duration::from_millis(500);
-        std::thread::sleep(wait_time);
+        const WAIT_TIME: Duration = Duration::from_millis(500);
+        std::thread::sleep(WAIT_TIME);
     }
 
     /// Builds a message stream.

--- a/rust/agama-dbus-server/tests/common/mod.rs
+++ b/rust/agama-dbus-server/tests/common/mod.rs
@@ -1,0 +1,49 @@
+use std::process::{Child, Command};
+use uuid::Uuid;
+
+pub struct DBusServer {
+    child: Option<Child>,
+    pub address: String,
+}
+
+impl DBusServer {
+    pub fn start_server() -> Self {
+        let mut server = Self::new();
+        server.start();
+        println!("Starting the server at {}", &server.address);
+        server
+    }
+
+    pub fn new() -> Self {
+        let uuid = Uuid::new_v4();
+        Self {
+            address: format!("unix:path=/tmp/agama-tests-{uuid}"),
+            child: None,
+        }
+    }
+
+    pub fn start(&mut self) {
+        let child = Command::new("/usr/bin/dbus-daemon")
+            .args([
+                "--config-file",
+                "../share/dbus-test.conf",
+                "--address",
+                &self.address,
+            ])
+            .spawn()
+            .expect("to start the testing D-Bus daemon");
+        self.child = Some(child);
+    }
+
+    pub fn stop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            child.kill().unwrap();
+        }
+    }
+}
+
+impl Drop for DBusServer {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}

--- a/rust/agama-dbus-server/tests/common/mod.rs
+++ b/rust/agama-dbus-server/tests/common/mod.rs
@@ -1,28 +1,42 @@
+use agama_lib::{connection_to, error::ServiceError};
+use async_std::stream::StreamExt;
 use std::process::{Child, Command};
 use uuid::Uuid;
+use zbus::{MatchRule, MessageStream, MessageType};
 
+/// D-Bus server to be used on tests.
+///
+/// This struct takes care of starting, stopping and monitoring dbus-daemon to be used on
+/// integration tests. Each server uses a different socket, so they do not collide.
 pub struct DBusServer {
     child: Option<Child>,
+    messages: Option<MessageStream>,
     pub address: String,
 }
 
 impl DBusServer {
-    pub fn start_server() -> Self {
+    /// Builds and starts a server.
+    pub async fn start_server() -> Result<Self, ServiceError> {
         let mut server = Self::new();
-        server.start();
+        server.start().await?;
         println!("Starting the server at {}", &server.address);
-        server
+        Ok(server)
     }
 
+    /// Builds a new server.
+    ///
+    /// To start the server, check the `start` function.
     pub fn new() -> Self {
         let uuid = Uuid::new_v4();
         Self {
             address: format!("unix:path=/tmp/agama-tests-{uuid}"),
             child: None,
+            messages: None,
         }
     }
 
-    pub fn start(&mut self) {
+    /// Starts the server.
+    pub async fn start(&mut self) -> Result<(), ServiceError> {
         let child = Command::new("/usr/bin/dbus-daemon")
             .args([
                 "--config-file",
@@ -33,12 +47,52 @@ impl DBusServer {
             .spawn()
             .expect("to start the testing D-Bus daemon");
         self.child = Some(child);
+        self.wait();
+        self.messages = Some(self.build_message_stream().await?);
+        Ok(())
     }
 
+    /// Stops the server.
     pub fn stop(&mut self) {
         if let Some(mut child) = self.child.take() {
             child.kill().unwrap();
         }
+        self.messages = None;
+    }
+
+    /// Waits for a server to be available.
+    ///
+    /// * `name`: service name (e.g., "org.opensuse.Agama.Network1").
+    pub async fn wait_for_service(&mut self, name: &str) {
+        let Some(ref mut messages) = self.messages else {
+            return;
+        };
+
+        loop {
+            let signal = messages.next().await.unwrap().unwrap();
+            let (sname, _, _): (String, String, String) = signal.body().unwrap();
+            if &sname == name {
+                return;
+            }
+        }
+    }
+
+    /// Waits until the D-Bus daemon is ready.
+    // TODO: implement proper waiting instead of just using a sleep
+    fn wait(&self) {
+        let wait_time = std::time::Duration::from_millis(500);
+        std::thread::sleep(wait_time);
+    }
+
+    /// Builds a message stream.
+    async fn build_message_stream(&self) -> Result<MessageStream, ServiceError> {
+        let conn = connection_to(&self.address).await?;
+        let rule = MatchRule::builder()
+            .msg_type(MessageType::Signal)
+            .sender("org.freedesktop.DBus")?
+            .member("NameOwnerChanged")?
+            .build();
+        Ok(MessageStream::for_match_rule(rule, &conn, None).await?)
     }
 }
 

--- a/rust/agama-dbus-server/tests/network.rs
+++ b/rust/agama-dbus-server/tests/network.rs
@@ -23,7 +23,7 @@ impl Adapter for NetworkTestAdapter {
 
 #[test]
 async fn test_read_connections() {
-    let server = DBusServer::start_server();
+    let mut server = DBusServer::start_server().await.unwrap();
 
     let device = model::Device {
         name: String::from("eth0"),
@@ -33,16 +33,10 @@ async fn test_read_connections() {
     let state = NetworkState::new(vec![device], vec![eth0]);
     let adapter = NetworkTestAdapter(state);
 
-    // TODO: Find a better way to detect when the server started
-    let ten_millis = std::time::Duration::from_millis(1000);
-    std::thread::sleep(ten_millis);
-
     let _service = NetworkService::start(&server.address, adapter)
         .await
         .unwrap();
-
-    let ten_millis = std::time::Duration::from_millis(1000);
-    std::thread::sleep(ten_millis);
+    server.wait_for_service("org.opensuse.Agama.Network1").await;
 
     let connection = connection_to(&server.address).await.unwrap();
     let client = NetworkClient::new(connection.clone()).await.unwrap();
@@ -55,21 +49,15 @@ async fn test_read_connections() {
 
 #[test]
 async fn test_add_connection() {
-    let server = DBusServer::start_server();
+    let mut server = DBusServer::start_server().await.unwrap();
 
     let state = NetworkState::default();
     let adapter = NetworkTestAdapter(state);
 
-    // TODO: Find a better way to detect when the server started
-    let ten_millis = std::time::Duration::from_millis(100);
-    std::thread::sleep(ten_millis);
-
     let _service = NetworkService::start(&server.address, adapter)
         .await
         .unwrap();
-
-    let ten_millis = std::time::Duration::from_millis(1000);
-    std::thread::sleep(ten_millis);
+    server.wait_for_service("org.opensuse.Agama.Network1").await;
 
     let connection = connection_to(&server.address).await.unwrap();
     let client = NetworkClient::new(connection.clone()).await.unwrap();

--- a/rust/agama-dbus-server/tests/network.rs
+++ b/rust/agama-dbus-server/tests/network.rs
@@ -1,0 +1,95 @@
+mod common;
+
+use self::common::DBusServer;
+use agama_dbus_server::network::{self, model, Adapter, NetworkService, NetworkState};
+use agama_lib::{
+    connection_to,
+    network::{settings, types::DeviceType, NetworkClient},
+};
+use async_std::test;
+
+#[derive(Default)]
+pub struct NetworkTestAdapter(network::NetworkState);
+
+impl Adapter for NetworkTestAdapter {
+    fn read(&self) -> Result<network::NetworkState, Box<dyn std::error::Error>> {
+        Ok(self.0.clone())
+    }
+
+    fn write(&self, _network: &network::NetworkState) -> Result<(), Box<dyn std::error::Error>> {
+        unimplemented!("Not used in tests");
+    }
+}
+
+#[test]
+async fn test_read_connections() {
+    let server = DBusServer::start_server();
+
+    let device = model::Device {
+        name: String::from("eth0"),
+        type_: DeviceType::Ethernet,
+    };
+    let eth0 = model::Connection::new("eth0".to_string(), DeviceType::Ethernet);
+    let state = NetworkState::new(vec![device], vec![eth0]);
+    let adapter = NetworkTestAdapter(state);
+
+    // TODO: Find a better way to detect when the server started
+    let ten_millis = std::time::Duration::from_millis(1000);
+    std::thread::sleep(ten_millis);
+
+    let _service = NetworkService::start(&server.address, adapter)
+        .await
+        .unwrap();
+
+    let ten_millis = std::time::Duration::from_millis(1000);
+    std::thread::sleep(ten_millis);
+
+    let connection = connection_to(&server.address).await.unwrap();
+    let client = NetworkClient::new(connection.clone()).await.unwrap();
+    let conns = client.connections().await.unwrap();
+    assert_eq!(conns.len(), 1);
+    let dbus_eth0 = conns.first().unwrap();
+    assert_eq!(dbus_eth0.id, "eth0");
+    assert_eq!(dbus_eth0.device_type(), DeviceType::Ethernet);
+}
+
+#[test]
+async fn test_add_connection() {
+    let server = DBusServer::start_server();
+
+    let state = NetworkState::default();
+    let adapter = NetworkTestAdapter(state);
+
+    // TODO: Find a better way to detect when the server started
+    let ten_millis = std::time::Duration::from_millis(100);
+    std::thread::sleep(ten_millis);
+
+    let _service = NetworkService::start(&server.address, adapter)
+        .await
+        .unwrap();
+
+    let ten_millis = std::time::Duration::from_millis(1000);
+    std::thread::sleep(ten_millis);
+
+    let connection = connection_to(&server.address).await.unwrap();
+    let client = NetworkClient::new(connection.clone()).await.unwrap();
+
+    let wlan0 = settings::NetworkConnection {
+        id: "wlan0".to_string(),
+        method: Some("auto".to_string()),
+        wireless: Some(settings::WirelessSettings {
+            password: "123456".to_string(),
+            security: "wpa-psk".to_string(),
+            ssid: "TEST".to_string(),
+            mode: "infrastructure".to_string(),
+        }),
+        ..Default::default()
+    };
+    client.add_or_update_connection(&wlan0).await.unwrap();
+
+    let conns = client.connections().await.unwrap();
+    assert_eq!(conns.len(), 1);
+    let conn = conns.first().unwrap();
+    assert_eq!(conn.id, "wlan0");
+    assert_eq!(conn.device_type(), DeviceType::Wireless);
+}

--- a/rust/agama-lib/src/lib.rs
+++ b/rust/agama-lib/src/lib.rs
@@ -50,6 +50,6 @@ pub async fn connection_to(address: &str) -> Result<zbus::Connection, ServiceErr
     let connection = zbus::ConnectionBuilder::address(address)?
         .build()
         .await
-        .map_err(|e| ServiceError::DBusConnectionError(ADDRESS.to_string(), e))?;
+        .map_err(|e| ServiceError::DBusConnectionError(address.to_string(), e))?;
     Ok(connection)
 }

--- a/rust/agama-lib/src/network.rs
+++ b/rust/agama-lib/src/network.rs
@@ -2,7 +2,7 @@
 
 mod client;
 mod proxies;
-mod settings;
+pub mod settings;
 mod store;
 pub mod types;
 

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -123,6 +123,7 @@ impl<'a> NetworkClient<'a> {
         self.connections_proxy
             .add_connection(&conn.id, conn.device_type() as u8)
             .await?;
+        // FIXME: this method might not work because the object might time some time to appear.
         Ok(self.connections_proxy.get_connection(&conn.id).await?)
     }
 

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -193,20 +193,4 @@ impl<'a> NetworkClient<'a> {
         proxy.set_password(&wireless.password).await?;
         Ok(())
     }
-
-    // Replace with a better implemenation based on signals.
-    // async fn wait_for_connection(&self, id: &str) -> Result<OwnedObjectPath, ServiceError> {
-    //     loop {
-    //         let mut retries = 0;
-    //         match self.connections_proxy.get_connection(&id).await {
-    //             Ok(path) => return Ok(path),
-    //             Err(e) => {
-    //                 retries += 1;
-    //                 if retries > 3 {
-    //                     return Err(e.into());
-    //                 };
-    //             }
-    //         }
-    //     }
-    // }
 }

--- a/rust/agama-lib/src/network/proxies.rs
+++ b/rust/agama-lib/src/network/proxies.rs
@@ -28,6 +28,10 @@ trait Connections {
 
     /// RemoveConnection method
     fn remove_connection(&self, uuid: &str) -> zbus::Result<()>;
+
+    /// ConnectionAdded signal
+    #[dbus_proxy(signal)]
+    fn connection_added(&self, id: &str, path: &str) -> zbus::Result<()>;
 }
 
 #[dbus_proxy(

--- a/rust/share/dbus-test.conf
+++ b/rust/share/dbus-test.conf
@@ -1,0 +1,82 @@
+<!-- This configuration file controls the Agama Installer message bus.
+     It is based on /usr/share/dbus-1/session.conf but including some changes:
+     - Type is set to "org.opensuse.Agama".
+     - Removed the policy section for the default context.
+     - Added a new policy section for the root user.
+     - The local-session.conf file is not read. -->
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>org.opensuse.Agama</type>
+
+  <!-- If we fork, keep the user's original umask to avoid affecting
+       the behavior of child processes. -->
+  <keep_umask/>
+
+  <listen>unix:tmpdir=/tmp</listen>
+
+  <!-- On Unix systems, the most secure authentication mechanism is
+  EXTERNAL, which uses credential-passing over Unix sockets.
+
+  This authentication mechanism is not available on Windows,
+  is not suitable for use with the tcp: or nonce-tcp: transports,
+  and will not work on obscure flavours of Unix that do not have
+  a supported credentials-passing mechanism. On those platforms/transports,
+  comment out the <auth> element to allow fallback to DBUS_COOKIE_SHA1. -->
+  <auth>EXTERNAL</auth>
+
+  <!-- only root can own the services -->
+  <policy context="default">
+    <!-- Allow everything to be sent -->
+    <allow send_destination="*" eavesdrop="true"/>
+
+    <!-- Allow everything to be received -->
+    <allow eavesdrop="true"/>
+
+    <allow own="org.opensuse.Agama1" />
+    <allow own="org.opensuse.Agama.Locale1" />
+    <allow own="org.opensuse.Agama.Questions1" />
+    <allow own="org.opensuse.Agama.Software1" />
+    <allow own="org.opensuse.Agama.Network1" />
+    <allow own="org.opensuse.Agama.Storage1" />
+    <allow own="org.opensuse.Agama.Users1" />
+
+    <!-- only root can send anything to the services -->
+    <allow send_destination="org.opensuse.Agama1" />
+    <allow send_destination="org.opensuse.Agama.Locale1" />
+    <allow send_destination="org.opensuse.Agama.Questions1" />
+    <allow send_destination="org.opensuse.Agama.Network1" />
+    <allow send_destination="org.opensuse.Agama.Software1" />
+    <allow send_destination="org.opensuse.Agama.Storage1" />
+    <allow send_destination="org.opensuse.Agama.Users1" />
+  </policy>
+
+  <include if_selinux_enabled="yes" selinux_root_relative="yes">contexts/dbus_contexts</include>
+
+  <!-- For the session bus, override the default relatively-low limits 
+       with essentially infinite limits, since the bus is just running 
+       as the user anyway, using up bus resources is not something we need 
+       to worry about. In some cases, we do set the limits lower than 
+       "all available memory" if exceeding the limit is almost certainly a bug, 
+       having the bus enforce a limit is nicer than a huge memory leak. But the 
+       intent is that these limits should never be hit. -->
+
+  <!-- the memory limits are 1G instead of say 4G because they can't exceed 32-bit signed int max -->
+  <limit name="max_incoming_bytes">1000000000</limit>
+  <limit name="max_incoming_unix_fds">250000000</limit>
+  <limit name="max_outgoing_bytes">1000000000</limit>
+  <limit name="max_outgoing_unix_fds">250000000</limit>
+  <limit name="max_message_size">1000000000</limit>
+  <!-- We do not override max_message_unix_fds here since the in-kernel
+       limit is also relatively low -->
+  <limit name="service_start_timeout">120000</limit>  
+  <limit name="auth_timeout">240000</limit>
+  <limit name="pending_fd_timeout">150000</limit>
+  <limit name="max_completed_connections">100000</limit>  
+  <limit name="max_incomplete_connections">10000</limit>
+  <limit name="max_connections_per_user">100000</limit>
+  <limit name="max_pending_service_starts">10000</limit>
+  <limit name="max_names_per_connection">50000</limit>
+  <limit name="max_match_rules_per_connection">50000</limit>
+  <limit name="max_replies_per_connection">50000</limit>
+</busconfig>


### PR DESCRIPTION
## Problem

Test coverage of the Rust code is pretty low (around 16%). In Ruby we are used to inject and mock the dependencies. In Rust that's perfectly possible if you rely a lot on traits. But if that's not the case, it can be much more challenging.

See [mockall](https://crates.io/crates/mockall) documentation for examples.

## Solution

Using unit tests to cover code that does not rely on D-Bus or other external dependencies is pretty straightforward. We should keep doing that.

However, you are in trouble when you depend on a connection or a proxy. For those cases, I decided to go with [Rust integration tests](https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html).

This PR includes some minimal infrastructure to test the `agama-dbus-daemon` package. It sets up a [D-Bus server](https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html) that you can use for testing.

## Results

* After writing two simple test cases, I **found a bug** and raised the coverage **from 16% to 36%**. Not bad.
* To make the code testable, I had to allow injecting a network adapter (fortunately, we already had the concept of `Adapter`) to the `NetworkSystem`. I wrote a `NetworkTestAdapter` that allows setting up a custom network state.

## Future

* Extend the tests to cover other services and try to extract common patterns. We can extend our test harness to support them.
* Improve error handling and get rid of `unwrap()` or `expect()` calls where it makes sense.
* As an experiment, I would like to split the `DBusServer` struct into two different ones: `RunningDBusServer` and `DBusServer`.