### PR TITLE
fix wrong name in rake install

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -134,7 +134,7 @@ if ENV["YUPDATE_FORCE"] == "1" || File.exist?("/.packages.initrd") || live_iso?
         sh "cp share/dbus.conf /usr/share/dbus-1/agama.conf"
 
         # update the systemd service file
-        source_file = "share/systemd.service"
+        source_file = "share/agama.service"
         target_file = "/usr/lib/systemd/system/agama.service"
 
         unless FileUtils.identical?(source_file, target_file)


### PR DESCRIPTION
Trivial fix of name after rename in https://github.com/openSUSE/agama/commit/1d94bef08279b1788db5bf142c26047139896673