### PR TITLE
Add support to assign an interface or match settings to a connection

### DIFF
--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -260,6 +260,7 @@ impl Match {
         connection.match_config().driver.clone()
     }
 
+    #[dbus_interface(property)]
     pub async fn set_driver(&mut self, driver: Vec<String>) -> zbus::fdo::Result<()> {
         let mut connection = self.get_connection().await;
         let config = connection.match_config_mut();
@@ -274,6 +275,7 @@ impl Match {
         connection.match_config().path.clone()
     }
 
+    #[dbus_interface(property)]
     pub async fn set_path(&mut self, path: Vec<String>) -> zbus::fdo::Result<()> {
         let mut connection = self.get_connection().await;
         let config = connection.match_config_mut();
@@ -287,11 +289,27 @@ impl Match {
         connection.match_config().interface.clone()
     }
 
+    #[dbus_interface(property)]
+    pub async fn set_interface(&mut self, interface: Vec<String>) -> zbus::fdo::Result<()> {
+        let mut connection = self.get_connection().await;
+        let config = connection.match_config_mut();
+        config.interface = interface;
+        self.update_connection(connection).await
+    }
+
     /// List of kernel options
     #[dbus_interface(property)]
     pub async fn kernel(&self) -> Vec<String> {
         let connection = self.get_connection().await;
         connection.match_config().kernel.clone()
+    }
+
+    #[dbus_interface(property)]
+    pub async fn set_kernel(&mut self, kernel: Vec<String>) -> zbus::fdo::Result<()> {
+        let mut connection = self.get_connection().await;
+        let config = connection.match_config_mut();
+        config.kernel = kernel;
+        self.update_connection(connection).await
     }
 }
 

--- a/rust/agama-dbus-server/src/network/dbus/tree.rs
+++ b/rust/agama-dbus-server/src/network/dbus/tree.rs
@@ -104,6 +104,11 @@ impl Tree {
         )
         .await?;
 
+        self.add_interface(
+            &path,
+            interfaces::Match::new(self.actions.clone(), Arc::clone(&cloned)),
+        )
+        .await?;
         if let Connection::Wireless(_) = conn {
             self.add_interface(
                 &path,

--- a/rust/agama-dbus-server/src/network/dbus/tree.rs
+++ b/rust/agama-dbus-server/src/network/dbus/tree.rs
@@ -95,8 +95,11 @@ impl Tree {
         log::info!("Publishing network connection '{}'", id);
 
         let cloned = Arc::new(Mutex::new(conn.clone()));
-        self.add_interface(&path, interfaces::Connection::new(Arc::clone(&cloned)))
-            .await?;
+        self.add_interface(
+            &path,
+            interfaces::Connection::new(self.actions.clone(), Arc::clone(&cloned)),
+        )
+        .await?;
 
         self.add_interface(
             &path,

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -335,7 +335,7 @@ pub struct Ipv4Config {
     pub gateway: Option<Ipv4Addr>,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub struct MatchConfig {
     pub driver: Vec<String>,
     pub interface: Vec<String>,

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -262,6 +262,14 @@ impl Connection {
         self.base_mut().id = id.to_string()
     }
 
+    pub fn interface(&self) -> &str {
+        self.base().interface.as_str()
+    }
+
+    pub fn set_interface(&mut self, interface: &str) {
+        self.base_mut().interface = interface.to_string()
+    }
+
     pub fn uuid(&self) -> Uuid {
         self.base().uuid
     }
@@ -272,6 +280,14 @@ impl Connection {
 
     pub fn ipv4_mut(&mut self) -> &mut Ipv4Config {
         &mut self.base_mut().ipv4
+    }
+
+    pub fn match_config(&self) -> &MatchConfig {
+        &self.base().match_config
+    }
+
+    pub fn match_config_mut(&mut self) -> &mut MatchConfig {
+        &mut self.base_mut().match_config
     }
 
     pub fn remove(&mut self) {
@@ -294,6 +310,8 @@ pub struct BaseConnection {
     pub uuid: Uuid,
     pub ipv4: Ipv4Config,
     pub status: Status,
+    pub interface: String,
+    pub match_config: MatchConfig,
 }
 
 impl PartialEq for BaseConnection {
@@ -315,6 +333,14 @@ pub struct Ipv4Config {
     pub addresses: Vec<IpAddress>,
     pub nameservers: Vec<Ipv4Addr>,
     pub gateway: Option<Ipv4Addr>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct MatchConfig {
+    pub driver: Vec<String>,
+    pub interface: Vec<String>,
+    pub path: Vec<String>,
+    pub kernel: Vec<String>,
 }
 
 #[derive(Debug, Error)]

--- a/rust/agama-dbus-server/src/network/nm/dbus.rs
+++ b/rust/agama-dbus-server/src/network/nm/dbus.rs
@@ -177,42 +177,35 @@ fn wireless_config_to_dbus(conn: &WirelessConnection) -> NestedHash {
 ///
 /// * `match_config`: MatchConfig to convert.
 fn match_config_to_dbus(match_config: &MatchConfig) -> HashMap<&str, zvariant::Value> {
-    let mut match_config_dbus = HashMap::new();
-
     let drivers: Value = match_config
         .driver
         .iter()
-        .map(|dr| dr.to_string())
-        .collect::<Vec<String>>()
+        .cloned()
+        .collect::<Vec<_>>()
         .into();
-    match_config_dbus.insert("driver", drivers);
 
     let kernels: Value = match_config
         .kernel
         .iter()
-        .map(|dr| dr.to_string())
-        .collect::<Vec<String>>()
+        .cloned()
+        .collect::<Vec<_>>()
         .into();
-    match_config_dbus.insert("kernel-command-line", kernels);
 
-    let paths: Value = match_config
-        .path
-        .iter()
-        .map(|dr| dr.to_string())
-        .collect::<Vec<String>>()
-        .into();
-    match_config_dbus.insert("path", paths);
+    let paths: Value = match_config.path.iter().cloned().collect::<Vec<_>>().into();
 
     let interfaces: Value = match_config
         .interface
         .iter()
-        .map(|dr| dr.to_string())
-        .collect::<Vec<String>>()
+        .cloned()
+        .collect::<Vec<_>>()
         .into();
 
-    match_config_dbus.insert("interface-name", interfaces);
-
-    match_config_dbus
+    HashMap::from([
+        ("driver", drivers),
+        ("kernel-command-line", kernels),
+        ("path", paths),
+        ("interface-name", interfaces),
+    ])
 }
 
 fn base_connection_from_dbus(conn: &OwnedNestedHash) -> Option<BaseConnection> {
@@ -231,7 +224,7 @@ fn base_connection_from_dbus(conn: &OwnedNestedHash) -> Option<BaseConnection> {
 
     if let Some(interface) = connection.get("interface-name") {
         let interface: &str = interface.downcast_ref()?;
-        base_connection.interface = interface.parse().unwrap();
+        base_connection.interface = interface.to_string();
     }
 
     if let Some(match_config) = conn.get("match") {
@@ -254,7 +247,7 @@ fn match_config_from_dbus(
         let drivers = drivers.downcast_ref::<zbus::zvariant::Array>()?;
         for driver in drivers.get() {
             let driver: &str = driver.downcast_ref()?;
-            match_conf.driver.push(driver.parse().unwrap());
+            match_conf.driver.push(driver.to_string());
         }
     }
 
@@ -262,7 +255,7 @@ fn match_config_from_dbus(
         let interface_names = interface_names.downcast_ref::<zbus::zvariant::Array>()?;
         for name in interface_names.get() {
             let name: &str = name.downcast_ref()?;
-            match_conf.interface.push(name.parse().unwrap());
+            match_conf.interface.push(name.to_string());
         }
     }
 
@@ -270,7 +263,7 @@ fn match_config_from_dbus(
         let paths = paths.downcast_ref::<zbus::zvariant::Array>()?;
         for path in paths.get() {
             let path: &str = path.downcast_ref()?;
-            match_conf.path.push(path.parse().unwrap());
+            match_conf.path.push(path.to_string());
         }
     }
 
@@ -278,7 +271,7 @@ fn match_config_from_dbus(
         let options = kernel_options.downcast_ref::<zbus::zvariant::Array>()?;
         for option in options.get() {
             let option: &str = option.downcast_ref()?;
-            match_conf.kernel.push(option.parse().unwrap());
+            match_conf.kernel.push(option.to_string());
         }
     }
 

--- a/rust/agama-dbus-server/src/network/nm/dbus.rs
+++ b/rust/agama-dbus-server/src/network/nm/dbus.rs
@@ -248,9 +248,7 @@ fn base_connection_from_dbus(conn: &OwnedNestedHash) -> Option<BaseConnection> {
 fn match_config_from_dbus(
     match_config: &HashMap<String, zvariant::OwnedValue>,
 ) -> Option<MatchConfig> {
-    let mut match_conf = MatchConfig {
-        ..Default::default()
-    };
+    let mut match_conf = MatchConfig::default();
 
     if let Some(drivers) = match_config.get("driver") {
         let drivers = drivers.downcast_ref::<zbus::zvariant::Array>()?;

--- a/rust/agama-lib/share/examples/profile.json
+++ b/rust/agama-lib/share/examples/profile.json
@@ -27,6 +27,7 @@
       {
         "id": "Ethernet network device 1",
         "method": "manual",
+        "interface": "eth0",
         "addresses": [
           "192.168.122.100/24"
         ],

--- a/rust/agama-lib/share/examples/profile.jsonnet
+++ b/rust/agama-lib/share/examples/profile.jsonnet
@@ -63,7 +63,10 @@ local findBiggestDisk(disks) =
         ],
         nameservers: [
           '1.2.3.4'
-        ]
+        ],
+        match: {
+            path: ["pci-0000:00:19.0"]
+          }
       }
     ]
   }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -32,6 +32,10 @@
                 "description": "Connection ID",
                 "type": "string"
               },
+              "interface": {
+                "description": "The name of the network interface bound to this connection",
+                "type": "string"
+              },
               "method": {
                 "description": "IPv4 configuration method (e.g., 'auto')",
                 "type": "string",
@@ -84,6 +88,45 @@
                       "mesh",
                       "ap"
                     ]
+                  }
+                }
+              },
+              "match": {
+                "type": "object",
+                "description": "Match settings",
+                "additionalProperties": false,
+                "properties": {
+                  "kernel": {
+                    "type": "array",
+                    "items": {
+                      "description": "A list of kernel command line arguments to match",
+                      "type": "string",
+                      "additionalProperties": false
+                    }
+                  },
+                  "interface": {
+                    "type": "array",
+                    "items": {
+                      "description": "A list of interface names to match",
+                      "type": "string",
+                      "additionalProperties": false
+                    }
+                  },
+                  "driver": {
+                    "type": "array",
+                    "items": {
+                      "description": "A list of driver names to match",
+                      "type": "string",
+                      "additionalProperties": false
+                    }
+                  },
+                  "path": {
+                    "type": "array",
+                    "items": {
+                      "description": "A list of paths to match against the ID_PATH udev property of devices",
+                      "type": "string",
+                      "additionalProperties": false
+                    }
                   }
                 }
               }

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -240,7 +240,7 @@ impl<'a> NetworkClient<'a> {
             .build()
             .await?;
 
-        let paths: Vec<_> = match_settings.path.iter().map(String::as_ref).collect();
+        let paths: Vec<_> = match_settings.paths.iter().map(String::as_ref).collect();
         proxy.set_path(paths.as_slice()).await?;
 
         Ok(())

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -120,7 +120,7 @@ impl<'a> NetworkClient<'a> {
             .build()
             .await?;
         let match_settings = MatchSettings {
-            paths: match_proxy.path().await?,
+            path: match_proxy.path().await?,
             kernel: match_proxy.kernel().await?,
             interface: match_proxy.interface().await?,
             driver: match_proxy.driver().await?,
@@ -267,7 +267,7 @@ impl<'a> NetworkClient<'a> {
             .build()
             .await?;
 
-        let paths: Vec<_> = match_settings.paths.iter().map(String::as_ref).collect();
+        let paths: Vec<_> = match_settings.path.iter().map(String::as_ref).collect();
         proxy.set_path(paths.as_slice()).await?;
 
         Ok(())

--- a/rust/agama-lib/src/network/proxies.rs
+++ b/rust/agama-lib/src/network/proxies.rs
@@ -121,9 +121,9 @@ trait IPv4 {
 }
 
 #[dbus_proxy(
-    interface = "org.opensuse.Agama.Network1.Connection.Match",
-    default_service = "org.opensuse.Agama.Network1",
-    default_path = "/org/opensuse/Agama/Network1"
+    interface = "org.opensuse.Agama1.Network.Connection.Match",
+    default_service = "org.opensuse.Agama1.Network",
+    default_path = "/org/opensuse/Agama1/Network"
 )]
 trait Match {
     /// Driver property

--- a/rust/agama-lib/src/network/proxies.rs
+++ b/rust/agama-lib/src/network/proxies.rs
@@ -122,7 +122,7 @@ trait IPv4 {
 
 #[dbus_proxy(
     interface = "org.opensuse.Agama1.Network.Connection.Match",
-    default_service = "org.opensuse.Agama1.Network",
+    default_service = "org.opensuse.Agama1",
     default_path = "/org/opensuse/Agama1/Network"
 )]
 trait Match {

--- a/rust/agama-lib/src/network/proxies.rs
+++ b/rust/agama-lib/src/network/proxies.rs
@@ -79,6 +79,10 @@ trait Connection {
     /// Id property
     #[dbus_proxy(property)]
     fn id(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
+    fn interface(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
+    fn set_interface(&self, interface: &str) -> zbus::Result<()>;
 }
 
 #[dbus_proxy(
@@ -114,4 +118,29 @@ trait IPv4 {
     fn nameservers(&self) -> zbus::Result<Vec<String>>;
     #[dbus_proxy(property)]
     fn set_nameservers(&self, value: &[&str]) -> zbus::Result<()>;
+}
+
+#[dbus_proxy(
+    interface = "org.opensuse.Agama.Network1.Connection.Match",
+    default_service = "org.opensuse.Agama.Network1",
+    default_path = "/org/opensuse/Agama/Network1"
+)]
+trait Match {
+    /// Driver property
+    #[dbus_proxy(property)]
+    fn driver(&self) -> zbus::Result<Vec<String>>;
+
+    /// Interface property
+    #[dbus_proxy(property)]
+    fn interface(&self) -> zbus::Result<Vec<String>>;
+
+    /// Path property
+    #[dbus_proxy(property)]
+    fn path(&self) -> zbus::Result<Vec<String>>;
+    #[dbus_proxy(property)]
+    fn set_path(&self, value: &[&str]) -> zbus::Result<()>;
+
+    /// Path property
+    #[dbus_proxy(property)]
+    fn kernel(&self) -> zbus::Result<Vec<String>>;
 }

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -21,7 +21,7 @@ pub struct MatchSettings {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub driver: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub paths: Vec<String>,
+    pub path: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub kernel: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -30,7 +30,7 @@ pub struct MatchSettings {
 
 impl MatchSettings {
     pub fn is_empty(&self) -> bool {
-        self.paths.is_empty()
+        self.path.is_empty()
             && self.driver.is_empty()
             && self.kernel.is_empty()
             && self.interface.is_empty()

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -17,6 +17,27 @@ pub struct NetworkSettings {
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct MatchSettings {
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub driver: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub paths: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub kernel: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub interface: Vec<String>,
+}
+
+impl MatchSettings {
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+            && self.driver.is_empty()
+            && self.kernel.is_empty()
+            && self.interface.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct WirelessSettings {
     #[serde(skip_serializing_if = "String::is_empty")]
     pub password: String,
@@ -38,6 +59,10 @@ pub struct NetworkConnection {
     pub nameservers: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wireless: Option<WirelessSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interface: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_settings: Option<MatchSettings>,
 }
 
 impl NetworkConnection {

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep 13 09:27:22 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Allow to bind a connection to an specific interface through its
+  name or through a set of match settings (gh#opensSUSE/agama#723).
+
+-------------------------------------------------------------------
 Thu Aug 31 10:30:28 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use a single D-Bus service to expose locale, network and


### PR DESCRIPTION
## Problem

Agama allows to add/update network connections. However, it relies on **NetworkManager** to decide which interface to use. Alternatively, Agama should allow the user to assign a connection to an specific interface.

Instead of using just an interface name, **Agama** should offer some matching capabilities, just [like **NetworkManager**](https://manpages.debian.org/testing/network-manager/nm-settings.5.en.html#match_setting). How the API should look like is up to who implements the feature but the interface-name, the path and the driver should be supported.

- https://trello.com/c/H2ISHKvi/3395-2-agama-allow-assigning-a-network-configuration-to-an-specific-interface

## Solution

It has been added support to specify to which interfaces the connection should be bond to supporting it directly through the **interface name** attribute or through a set of match settings [as them are supported by **NetworkManager**](https://manpages.debian.org/testing/network-manager/nm-settings.5.en.html#match_setting).

```json
"network": {
    "connections": [
      {
        "id": "Ethernet network device 1",
        "method": "manual",
        "interface": "eth0",
        "addresses": [
          "192.168.122.100/24"
        ],
        "gateway": "192.168.122.1",
        "nameservers": [
          "192.168.122.1"
        ]
      }
    ]
  }
```

## Testing

- *Added a new unit test*
- *Tested manually*
