### PR TITLE
Use the i18next eslint plugin

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -20,8 +20,9 @@
         },
         "sourceType": "module"
     },
-    "plugins": ["flowtype", "react", "react-hooks", "@typescript-eslint"],
+    "plugins": ["flowtype", "i18next", "react", "react-hooks", "@typescript-eslint"],
     "rules": {
+        "i18next/no-literal-string": "error",
         "indent": ["error", 2,
             {
                 "ObjectExpression": "first",
@@ -58,6 +59,15 @@
         "space-before-function-paren": "off",
         "n/no-callback-literal": "off"
     },
+    "overrides": [
+      {
+        // do not check translations in the testing or development files
+        "files": ["*.test.*", "test-utils.js", "DevServerWrapper.jsx"],
+        "rules": {
+          "i18next/no-literal-string": "off"
+        }
+      }
+    ],
     "globals": {
         "require": false,
         "module": false,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -55,6 +55,7 @@
         "eslint-config-standard-jsx": "^11.0.0",
         "eslint-config-standard-react": "^13.0.0",
         "eslint-plugin-flowtype": "^8.0.3",
+        "eslint-plugin-i18next": "^6.0.3",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-n": "^15.5.1",
         "eslint-plugin-node": "^11.1.0",
@@ -8152,6 +8153,19 @@
         "eslint": "^8.1.0"
       }
     },
+    "node_modules/eslint-plugin-i18next": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-i18next/-/eslint-plugin-i18next-6.0.3.tgz",
+      "integrity": "sha512-RtQXYfg6PZCjejIQ/YG+dUj/x15jPhufJ9hUDGH0kCpJ6CkVMAWOQ9exU1CrbPmzeykxLjrXkjAaOZF/V7+DOA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "requireindex": "~1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/eslint-plugin-import": {
       "version": "2.27.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
@@ -15329,6 +15343,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.5"
       }
     },
     "node_modules/requires-port": {
@@ -24305,6 +24328,16 @@
         "string-natural-compare": "^3.0.1"
       }
     },
+    "eslint-plugin-i18next": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-i18next/-/eslint-plugin-i18next-6.0.3.tgz",
+      "integrity": "sha512-RtQXYfg6PZCjejIQ/YG+dUj/x15jPhufJ9hUDGH0kCpJ6CkVMAWOQ9exU1CrbPmzeykxLjrXkjAaOZF/V7+DOA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "requireindex": "~1.1.0"
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.27.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
@@ -29429,6 +29462,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
       "dev": true
     },
     "requires-port": {

--- a/web/package.json
+++ b/web/package.json
@@ -56,6 +56,7 @@
     "eslint-config-standard-jsx": "^11.0.0",
     "eslint-config-standard-react": "^13.0.0",
     "eslint-plugin-flowtype": "^8.0.3",
+    "eslint-plugin-i18next": "^6.0.3",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-n": "^15.5.1",
     "eslint-plugin-node": "^11.1.0",

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -96,6 +96,8 @@ function App() {
       </Sidebar>
 
       <Layout>
+        {/* this is the name of the tool, do not translate it */}
+        {/* eslint-disable-next-line i18next/no-literal-string */}
         <Title>Agama</Title>
         <Content />
       </Layout>

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -115,6 +115,8 @@ export default function Sidebar ({ children }) {
     }
 
     targetInfo = (
+      /* this is only displayed in the development mode, not in production, do not translate it */
+      /* eslint-disable-next-line i18next/no-literal-string */
       <Text>
         Target server: { " " }
         <Button isInline variant="link" component="a" href={ targetUrl } target="_blank">

--- a/web/src/components/layout/Icon.jsx
+++ b/web/src/components/layout/Icon.jsx
@@ -20,6 +20,9 @@
  */
 
 import React from 'react';
+import format from "format-util";
+
+import { _ } from "~/i18n";
 
 // NOTE: "@icons" is an alias to use a shorter path to real @material-symbols
 // icons location. Check the tsconfig.json file to see its value.
@@ -149,5 +152,5 @@ export default function Icon({ name, className = "", size = 32, ...otherProps })
 
   return (IconComponent)
     ? <IconComponent className={cssClassName} aria-hidden="true" {...otherProps} />
-    : <em>icon {name} not found!</em>;
+    : <em>{format(_("Icon %s not found!"), name)}</em>;
 }

--- a/web/src/components/layout/Icon.test.jsx
+++ b/web/src/components/layout/Icon.test.jsx
@@ -35,6 +35,6 @@ describe("when given a known name", () => {
 describe("when given an unknown name", () => {
   it("renders an informative text", async () => {
     plainRender(<Icon name="apsens" />);
-    await screen.findByText("icon apsens not found!", { name: /options/i });
+    await screen.findByText("Icon apsens not found!", { name: /options/i });
   });
 });

--- a/web/src/components/network/NetworkPage.jsx
+++ b/web/src/components/network/NetworkPage.jsx
@@ -35,7 +35,7 @@ import { _ } from "~/i18n";
 const NoWiredConnections = () => {
   return (
     <div className="stack">
-      <div className="bold">No wired connections found</div>
+      <div className="bold">{_("No wired connections found")}</div>
     </div>
   );
 };

--- a/web/src/components/storage/DeviceSelector.jsx
+++ b/web/src/components/storage/DeviceSelector.jsx
@@ -131,7 +131,8 @@ const ItemContent = ({ device }) => {
 
       const members = device.members.map(m => m.split("/").at(-1));
 
-      return <div>Members: {members.sort().join(", ")}</div>;
+      // TRANSLATORS: RAID details, %s is replaced by list of devices used by the array
+      return <div>{format(_("Members: %s"), members.sort().join(", "))}</div>;
     };
 
     const RAIDInfo = () => {
@@ -139,7 +140,8 @@ const ItemContent = ({ device }) => {
 
       const devices = device.devices.map(m => m.split("/").at(-1));
 
-      return <div>Devices: {devices.sort().join(", ")}</div>;
+      // TRANSLATORS: RAID details, %s is replaced by list of devices used by the array
+      return <div>{format(_("Devices: %s"), devices.sort().join(", "))}</div>;
     };
 
     const MultipathInfo = () => {
@@ -147,7 +149,8 @@ const ItemContent = ({ device }) => {
 
       const wires = device.wires.map(m => m.split("/").at(-1));
 
-      return <div>Wires: {wires.sort().join(", ")}</div>;
+      // TRANSLATORS: multipath details, %s is replaced by list of connections used by the device
+      return <div>{format(_("Wires: %s"), wires.sort().join(", "))}</div>;
     };
 
     return (

--- a/web/src/components/storage/ProposalPageOptions.jsx
+++ b/web/src/components/storage/ProposalPageOptions.jsx
@@ -57,7 +57,7 @@ const ZFCPLink = () => {
       href={href}
       description={_("Activate disks")}
     >
-      zFCP
+      {_("zFCP")}
     </PageOptions.Item>
   );
 };
@@ -75,7 +75,7 @@ const ISCSILink = () => {
       href={href}
       description={_("Connect to iSCSI targets")}
     >
-      iSCSI
+      {_("iSCSI")}
     </PageOptions.Item>
   );
 };


### PR DESCRIPTION
## Problem

- We do not automatically scan the web UI for untranslated texts, we can easily miss some translations

## Solution

- Use the [eslint-plugin-i18next](https://www.npmjs.com/package/eslint-plugin-i18next) plugin to find all text literals in the JSX templates

## Notes

- This is not a perfect solution, it reports only string literals, it cannot find cases like this:
```jsx
// missing translation
const msg = "message";
...
<b>{msg}</b>
```
- However, it still found like a half dozen of missing translations so it still makes sense