### PR TITLE
[web] Wait until the logs path is resolved

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Sep 11 11:56:56 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- Fix the download logs action in the web UI (gh#openSUSE#agama#697)
+
+-------------------------------------------------------------------
 Wed Sep  6 08:04:13 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Adapt storage to new proposal settings (gh#openSUSE/agama#738).

--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Mon Sep 11 11:56:56 UTC 2023 - David Diaz <dgonzalez@suse.com>
 
-- Fix the download logs action in the web UI (gh#openSUSE#agama#697)
+- Fix the download logs action in the web UI (gh#openSUSE/agama#697)
 
 -------------------------------------------------------------------
 Wed Sep  6 08:04:13 UTC 2023 - José Iván López González <jlopez@suse.com>

--- a/web/src/client/manager.js
+++ b/web/src/client/manager.js
@@ -86,7 +86,7 @@ class ManagerBaseClient {
    */
   async fetchLogs() {
     const proxy = await this.client.proxy(MANAGER_IFACE);
-    const path = proxy.CollectLogs("root");
+    const path = await proxy.CollectLogs("root");
     const file = cockpit.file(path, { binary: true });
     return file.read();
   }


### PR DESCRIPTION
## Problem

The download logs action on the web UI stop working. Instead of prompt the download, it crashes because of a 
`missing "path" option for fsread channel`. 

## Solution

Wait until the path promise is resolved before continue at https://github.com/openSUSE/agama/blob/00778858434beb54c636d1b1b1921a19bde269ec/web/src/client/manager.js#L89 before continue.

It closes #697.

## Testing

- Tested manually

