### PR TITLE
No progress dispatching during progress

### DIFF
--- a/service/lib/agama/dbus/software_service.rb
+++ b/service/lib/agama/dbus/software_service.rb
@@ -47,7 +47,6 @@ module Agama
         @logger = logger || Logger.new($stdout)
         @bus = Bus.current
         @backend = Agama::Software::Manager.new(config, logger)
-        @backend.on_progress_change { dispatch }
       end
 
       # Starts software service. It does more then just #export method.

--- a/service/lib/agama/dbus/storage_service.rb
+++ b/service/lib/agama/dbus/storage_service.rb
@@ -79,9 +79,7 @@ module Agama
       attr_reader :logger
 
       def manager
-        @manager ||= Agama::Storage::Manager.new(config, logger).tap do |manager|
-          manager.on_progress_change { dispatch }
-        end
+        @manager ||= Agama::Storage::Manager.new(config, logger)
       end
 
       # @return [::DBus::ObjectServer]

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -92,6 +92,7 @@ module Agama
       # TODO: report errors
     ensure
       service_status.idle
+      finish_progress
     end
 
     # Runs the install phase
@@ -126,6 +127,7 @@ module Agama
       logger.error "Installation error: #{e.inspect}. Backtrace: #{e.backtrace}"
     ensure
       service_status.idle
+      finish_progress
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 11 11:28:05 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- The software and the storage services do not dispatch actions
+  during progress reporting anymore (related to bsc#1215197).
+
+-------------------------------------------------------------------
 Wed Sep  6 08:02:35 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - New storage proposal settings (gh#openSUSE/agama#738).


### PR DESCRIPTION
## Problem

Related to [bsc#1215197](https://bugzilla.suse.com/show_bug.cgi?id=1215197).

Agama tries to start the installation while busy in the config phase. We have not reproduced the problem but suspect that dispatching new actions during progress reporting is problematic.

## Solution

Stop dispatching actions during progress in the *progress* and *software* services. The manager still dispatches those actions, as "destructive" actions are protected using the `safe_run` mechanism.