### PR TITLE
Better product change

### DIFF
--- a/service/lib/agama/dbus/manager.rb
+++ b/service/lib/agama/dbus/manager.rb
@@ -172,9 +172,12 @@ module Agama
         end
 
         backend.software.on_product_selected do |_product|
-          safe_run do
-            busy_while { backend.config_phase }
+          if service_status.busy?
+            logger.warn "Could not process the product change because the service is busy"
+            next
           end
+
+          busy_while { backend.config_phase }
         end
       end
     end

--- a/service/lib/agama/dbus/software/manager.rb
+++ b/service/lib/agama/dbus/software/manager.rb
@@ -62,8 +62,14 @@ module Agama
           dbus_reader :selected_base_product, "s"
 
           dbus_method :SelectProduct, "in ProductID:s" do |product_id|
-            logger.info "SelectProduct #{product_id}"
+            old_product_id = backend.product
 
+            if old_product_id == product_id
+              logger.info "Do not changing the product as it is still the same (#{product_id})"
+              return
+            end
+
+            logger.info "Selecting product #{product_id}"
             select_product(product_id)
             dbus_properties_changed(SOFTWARE_INTERFACE, { "SelectedBaseProduct" => product_id }, [])
             update_validation # as different product means different software selection

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Sep 12 12:27:33 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when it is not possible to handle a product change
+  in the manager service (related to bsc#1215197).
+- When selecting the product, do not perform any change if the
+  product is still the same.
+
+-------------------------------------------------------------------
 Mon Sep 11 11:28:05 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - The software and the storage services do not dispatch actions


### PR DESCRIPTION
## Problem

Follow-up of #747.

When handling a product change, the manager raises an exception and sets the service as idle. 

## Solution

* Do not raise an exception, just check whether it is possible to handle the product change.
* Do not change the product if it is not really changed.