### PR TITLE
Use "c-format" flag instead of "javascript-format" in POT

### DIFF
--- a/web/build_pot
+++ b/web/build_pot
@@ -10,8 +10,7 @@ OUTPUT="${1:-agama.pot}"
 
 find . ! -name cockpit.js ! -name '*.test.js' -name '*.js' -o ! -name '*.test.jsx' -name '*.jsx' |
 grep -vE "node_modules/|dist/|coverage/" | \
-xgettext --default-domain=agama --output=- --language=C --files-from=- \
+xgettext --default-domain=agama --output="$OUTPUT" --language=C --files-from=- \
   --keyword= --keyword=_:1 --keyword=N_:1 --keyword=n_:1,2,3t --keyword=Nn_:1,2,3t \
   --foreign-user --copyright-holder="SuSE Linux Products GmbH, Nuernberg" \
-  --from-code=UTF-8 --add-comments=TRANSLATORS --sort-by-file | \
-  sed '/^#/ s/, c-format/, javascript-format/' > "$OUTPUT"
+  --from-code=UTF-8 --add-comments=TRANSLATORS --sort-by-file


### PR DESCRIPTION
## Problem

-  Originally we used a simple [javascript format](https://www.gnu.org/software/gettext/manual/html_node/javascript_002dformat.html) flag which basically supported only simple `%s` or `%d` formats
- But since we switched to the [sprintf-js](https://github.com/alexei/sprintf.js) library (see #735),  which supports full C-like format strings, we can use the `c-format` flag in the POT file
- So do not change the language flag and keep the original `c-format` used by `xgettext`
- Additionally the translators might be more familiar with the C format than the Javascript format

## Testing

- Tested manually, the generated POT file contains the `c-format` flags
- I manually updated the existing PO files and all translations still validate (via `msgfmt --check-format`)
