### PR TITLE
WIP: Add Ipv6 support to BaseConnection

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "agama-locale-data",
  "anyhow",
  "async-std",
+ "duplicate",
  "futures",
  "log",
  "serde",
@@ -648,6 +649,16 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "duplicate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de78e66ac9061e030587b2a2e75cc88f22304913c907b11307bca737141230cb"
+dependencies = [
+ "heck",
+ "proc-macro-error",
 ]
 
 [[package]]
@@ -1465,6 +1476,30 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]

--- a/rust/agama-dbus-server/Cargo.toml
+++ b/rust/agama-dbus-server/Cargo.toml
@@ -20,3 +20,4 @@ thiserror = "1.0.40"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_yaml = "0.9.24"
 futures = "0.3.28"
+duplicate = "1.0.0"

--- a/rust/agama-dbus-server/src/network/nm/dbus.rs
+++ b/rust/agama-dbus-server/src/network/nm/dbus.rs
@@ -416,7 +416,10 @@ mod test {
                 "address-data".to_string(),
                 Value::new(v6_address_data).to_owned(),
             ),
-            ("gateway".to_string(), Value::new("2001:db8:1::1").to_owned()),
+            (
+                "gateway".to_string(),
+                Value::new("2001:db8:1::1").to_owned(),
+            ),
             (
                 "dns-data".to_string(),
                 Value::new(vec!["2001:db8:1::2"]).to_owned(),
@@ -447,7 +450,10 @@ mod test {
         assert_eq!(ipv4.nameservers, vec![Ipv4Addr::new(192, 168, 0, 2)]);
         assert_eq!(ipv4.method, IpMethod::Auto);
         assert_eq!(ipv6.addresses, vec!["2001:db8:1::10/64".parse().unwrap()]);
-        assert_eq!(ipv6.nameservers, vec![Ipv6Addr::new(0x2001, 0xdb8, 0x1, 0, 0, 0, 0, 2)]);
+        assert_eq!(
+            ipv6.nameservers,
+            vec![Ipv6Addr::new(0x2001, 0xdb8, 0x1, 0, 0, 0, 0, 2)]
+        );
         assert_eq!(ipv6.method, IpMethod::Manual);
     }
 


### PR DESCRIPTION
## Problem

Ipv6 is missing from Agama BaseConnection


## Solution

This PR aims to implement what is already there for ipv4 in BaseConnection also for ipv6.


## Testing

- *Extended existing unit test*
- *Tested manually*

## Notes

To not duplicate all the code I used the duplicate crate which makes the process of creating macros easier. The macros could also of course be written into the code directly but like I said this makes it more convenient and also has a cleaner syntax IMO. However it of course introduces a new dependency, let me know if this is a problem.
I also tried my hand at using generics to solve the code duplication problem but ran into some issues where honestly my rust knowledge wasn't enough, so if this path is desired I would need some help.
Let me know what you think :slightly_smiling_face: 