### PR TITLE
Require tar and bzip2

### DIFF
--- a/rust/package/agama-cli.spec
+++ b/rust/package/agama-cli.spec
@@ -37,6 +37,9 @@ BuildRequires:  dbus-1-common
 BuildRequires:  dbus-1-daemon
 Requires:       jsonnet
 Requires:       lshw
+# required by "agama logs store"
+Requires:       bzip2
+Requires:       tar
 
 %description
 Command line program to interact with the agama service.


### PR DESCRIPTION
## Problem

`agama logs store` depends on `tar` and `bzip2`.

## Solution

Add both packages to the requires section.
