### PR TITLE
Wait before probing

### DIFF
--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 26 12:05:52 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Wait until the manager is ready before probing
+  (gh#openSUSE/agama#771).
+
+-------------------------------------------------------------------
 Mon Sep 25 11:32:53 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for IPv6 network settings (gh#openSUSE/agama#761).


### PR DESCRIPTION
## Problem

Recent changes in #748 included the need to start the probing "manually" after selecting a product. However, if the Manager is already "probing", it causes the CLI to crash (and the auto-installation does not start).

## Solution

Make sure that the Manager is available for probing. This PR includes just a fix for the "probe" function, but we expect to extend this behavior to other actions.

## Testing

- Tested manually