### PR TITLE
Optimize loading pattern list

### DIFF
--- a/service/lib/agama/dbus/software/manager.rb
+++ b/service/lib/agama/dbus/software/manager.rb
@@ -79,6 +79,8 @@ module Agama
           dbus_method :ListPatterns, "in Filtered:b, out Result:a{s(ssssi)}" do |filtered|
             [
               backend.patterns(filtered).each_with_object({}) do |pattern, result|
+                # make sure all attributes are already preloaded, adjust the "patterns" method
+                # in service/lib/agama/software/manager.rb when changing this list
                 value = [
                   pattern.category,
                   pattern.description,

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -184,7 +184,10 @@ module Agama
       #                           Filtering criteria can change.
       # @return [Array<Y2Packager::Resolvable>]
       def patterns(filtered)
-        patterns = Y2Packager::Resolvable.find(kind: :pattern)
+        # huge speed up, preload the used attributes to avoid querying libzypp again,
+        # see "ListPatterns" method in service/lib/agama/dbus/software/manager.rb
+        preload = [:category, :description, :icon, :summary, :order, :user_visible]
+        patterns = Y2Packager::Resolvable.find({ kind: :pattern }, preload)
         patterns = patterns.select(&:user_visible) if filtered
 
         patterns


### PR DESCRIPTION
## Problem

- Loading the list of available patterns takes too long time, about 10 seconds
- It turned out that for loading the patterns libzypp is called almost 700x in a Tumbleweed installation!

## Solution

- Use the attribute preloading in to reduce the number of needed libzypp calls to just a single call

## Testing

- Tested manually, now the list of patterns is obtained in a fraction of a second, there is just a single libzypp call
