### PR TITLE
[web] Do not delete source map from production build

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep 29 08:04:01 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- Do not drop source maps from production build
+  (gh/openSUSE/agama#779)
+
+-------------------------------------------------------------------
 Wed Sep 27 12:15:13 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Allow to select the devices for the system volume group

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -76,7 +76,7 @@ if (stylelint) {
 if (production) {
   plugins.unshift(new CompressionPlugin({
     test: /\.(js|html|css)$/,
-    deleteOriginalAssets: true
+    deleteOriginalAssets: "keep-source-map"
   }));
 }
 


### PR DESCRIPTION
## Problem

In the context of https://trello.com/c/hInThumV (internal link), we realized that source maps are missing in the production build.

```
Source map error: Error: request failed with status 404
Resource URL: http://127.0.0.90/cockpit/@localhost/agama/index.js
Source Map URL: index.js.map
Source map error: Error: request failed with status 404
Resource URL: http://127.0.0.90/cockpit/@localhost/agama/index.css
Source Map URL: index.css.map
```

They would have been useful for debugging the error we were facing. In fact, there is a Webpack recommendation about serving source maps in production too

> We encourage you to have source maps enabled in production, as they are useful for debugging as well as running benchmark tests — https://webpack.js.org/guides/production/#source-mapping

The weird thing is that we already had the [`devtool`](https://webpack.js.org/configuration/devtool/) webpack option set to `"source-map"`, the value recommended for production builds. But, surprisingly, files were not there.

After closely checking the webpack configuration file, the culprit came to scene: the [`deleteOriginalAssets`](https://webpack.js.org/plugins/compression-webpack-plugin/#deleteoriginalassets) option of the `CompressionWebpackPlugin`. It was set as `true` and it **does not honor** the pattern given in `test` option.

## Solution

Fortunately, it's something that was [fixed long time ago](https://github.com/webpack-contrib/compression-webpack-plugin/pull/216). For us is just about switching from `true` to `"keep-source-map"` value.

## Tests

Tested manually by checking the _dist/_ content after running the `NODE_ENV=production npm run build` command.

<details>
  <summary>Click to show/hide <em>ls -l dist/</em> output BEFORE the change</summary>

  ```
Sep 28 17:28 favicon.svg
Sep 28 17:28 fonts
Sep 28 17:28 index.css.gz
Sep 28 17:28 index.html.gz
Sep 28 17:28 index.js.gz
Sep 28 17:28 index.js.LICENSE.txt.gz
Sep 28 17:28 manifest.json
Sep 28 17:28 po.cs.js.gz
Sep 28 17:28 po.ja.js.gz
Sep 28 17:28 po.nl.js.gz
Sep 28 17:28 po.ru.js.gz
Sep 28 17:28 po.sv.js.gz
Sep 28 17:28 po.uk.js.gz
  ```
</details>
<details>
  <summary>Click to show/hide <em>ls -l dist/</em> output AFTER the change</summary>

  ```
Sep 28 17:31 favicon.svg
Sep 28 17:31 fonts
Sep 28 17:31 index.css.gz
Sep 28 17:31 index.css.map
Sep 28 17:31 index.html.gz
Sep 28 17:31 index.js.gz
Sep 28 17:31 index.js.LICENSE.txt.gz
Sep 28 17:31 index.js.map
Sep 28 17:31 manifest.json
Sep 28 17:31 po.cs.js.gz
Sep 28 17:31 po.ja.js.gz
Sep 28 17:31 po.nl.js.gz
Sep 28 17:31 po.ru.js.gz
Sep 28 17:31 po.sv.js.gz
Sep 28 17:31 po.uk.js.gz
  ```
</details>