### PR TITLE
New subcommand for agama logs, refactoring

### DIFF
--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -327,9 +327,11 @@ fn store(options: LogOptions) -> Result<(), io::Error> {
 
 // Handler for the "agama logs list" subcommand
 fn list(options: LogOptions) {
-    for list in [options.paths, options.commands] {
-        for item in list.iter() {
-            println!("{}", item);
+    for list in [ ("Log paths: ", options.paths), ("Log commands: ", options.commands)] {
+        println!("{}", list.0);
+
+        for item in list.1.iter() {
+            println!("\t{}", item);
         }
 
         println!();

--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -29,16 +29,12 @@ pub async fn run(subcommand: LogsCommands) -> anyhow::Result<()> {
         LogsCommands::Store { verbose } => {
             // feed internal options structure by what was received from user
             // for now we always use / add defaults if any
-            let mut options = LogOptions::new();
-
-            options.verbose = verbose;
+            let options = LogOptions { verbose: verbose, ..Default::default() };
 
             Ok(store(options)?)
         }
         LogsCommands::List => {
-            let options = LogOptions::new();
-
-            list(options);
+            list(LogOptions::default());
 
             Ok(())
         }
@@ -100,8 +96,8 @@ struct LogOptions {
     verbose: bool,
 }
 
-impl LogOptions {
-    fn new() -> Self {
+impl Default for LogOptions {
+    fn default() -> Self {
         Self {
             paths: DEFAULT_PATHS.iter().map(|p| p.to_string()).collect(),
             commands: DEFAULT_COMMANDS.iter().map(|p| p.to_string()).collect(),

--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -255,17 +255,19 @@ fn compress_logs(tmp_dir: &TempDir, result: &String) -> io::Result<()> {
         dir,
     );
     let cmd_parts = compress_cmd.split_whitespace().collect::<Vec<&str>>();
-
-    Command::new(cmd_parts[0])
+    let res = Command::new(cmd_parts[0])
         .args(cmd_parts[1..].iter())
-        .status()
-        .ok_or(
-            Ok(_o) => Ok(()),
-            Err(_e) => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Cannot create tar archive",
-            )
+        .status()?;
+
+    if res.success() {
+        Ok(())
+    }
+    else {
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "Cannot create tar archive",
         ))
+    }
 }
 
 // Handler for the "agama logs store" subcommand

--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -44,7 +44,7 @@ pub async fn run(subcommand: LogsCommands) -> anyhow::Result<()> {
     }
 }
 
-const DEFAULT_COMMANDS: [(&str,&str); 3] = [
+const DEFAULT_COMMANDS: [(&str, &str); 3] = [
     ("journalctl -u agama", "agama"),
     ("journalctl -u agama-auto", "agama-auto"),
     ("journalctl --dmesg", "dmesg"),
@@ -103,7 +103,10 @@ impl Default for LogOptions {
     fn default() -> Self {
         Self {
             paths: DEFAULT_PATHS.iter().map(|p| p.to_string()).collect(),
-            commands: DEFAULT_COMMANDS.iter().map(|p| (p.0.to_string(), p.1.to_string())).collect(),
+            commands: DEFAULT_COMMANDS
+                .iter()
+                .map(|p| (p.0.to_string(), p.1.to_string()))
+                .collect(),
             verbose: false,
         }
     }
@@ -243,11 +246,18 @@ fn paths_to_log_sources(paths: &Vec<String>, tmp_dir: &TempDir) -> Vec<Box<dyn L
 }
 
 // Some info can be collected via particular commands only, turn it into log sources
-fn cmds_to_log_sources(commands: &Vec<(String, String)>, tmp_dir: &TempDir) -> Vec<Box<dyn LogItem>> {
+fn cmds_to_log_sources(
+    commands: &Vec<(String, String)>,
+    tmp_dir: &TempDir,
+) -> Vec<Box<dyn LogItem>> {
     let mut log_sources: Vec<Box<dyn LogItem>> = Vec::new();
 
     for cmd in commands.iter() {
-        log_sources.push(Box::new(LogCmd::new(cmd.0.as_str(), cmd.1.as_str(), tmp_dir.path())));
+        log_sources.push(Box::new(LogCmd::new(
+            cmd.0.as_str(),
+            cmd.1.as_str(),
+            tmp_dir.path(),
+        )));
     }
 
     log_sources
@@ -354,7 +364,10 @@ fn store(options: LogOptions) -> Result<(), io::Error> {
 fn list(options: LogOptions) {
     for list in [
         ("Log paths: ", options.paths),
-        ("Log commands: ", options.commands.iter().map(|c| c.0.clone()).collect()),
+        (
+            "Log commands: ",
+            options.commands.iter().map(|c| c.0.clone()).collect(),
+        ),
     ] {
         println!("{}", list.0);
 

--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -34,14 +34,14 @@ pub async fn run(subcommand: LogsCommands) -> anyhow::Result<()> {
             options.verbose = verbose;
 
             Ok(store(options)?)
-        },
+        }
         LogsCommands::List => {
             let options = LogOptions::new();
 
             list(options);
 
             Ok(())
-        },
+        }
     }
 }
 
@@ -315,8 +315,7 @@ fn store(options: LogOptions) -> Result<(), io::Error> {
 }
 
 // Handler for the "agama logs list" subcommand
-fn list(options: LogOptions)
-{
+fn list(options: LogOptions) {
     for list in [options.paths, options.commands] {
         for item in list.iter() {
             println!("{}", item);

--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -30,7 +30,7 @@ pub async fn run(subcommand: LogsCommands) -> anyhow::Result<()> {
             // feed internal options structure by what was received from user
             // for now we always use / add defaults if any
             let options = LogOptions {
-                verbose: verbose,
+                verbose,
                 ..Default::default()
             };
 
@@ -45,6 +45,7 @@ pub async fn run(subcommand: LogsCommands) -> anyhow::Result<()> {
 }
 
 const DEFAULT_COMMANDS: [(&str, &str); 3] = [
+    // (<command to be executed>, <file name used for storing result of the command>)
     ("journalctl -u agama", "agama"),
     ("journalctl -u agama-auto", "agama-auto"),
     ("journalctl --dmesg", "dmesg"),
@@ -70,6 +71,8 @@ const DEFAULT_PATHS: [&str; 14] = [
 ];
 
 const DEFAULT_RESULT: &str = "/tmp/agama_logs";
+// what compression is used by default:
+// (<compression as distinguished by tar>, <an extension for resulting archive>)
 const DEFAULT_COMPRESSION: (&str, &str) = ("bzip2", "tar.bz2");
 const DEFAULT_TMP_DIR: &str = "agama-logs";
 
@@ -105,7 +108,7 @@ impl Default for LogOptions {
             paths: DEFAULT_PATHS.iter().map(|p| p.to_string()).collect(),
             commands: DEFAULT_COMMANDS
                 .iter()
-                .map(|p| (p.0.to_string(), p.1.to_string()))
+                .map(|(cmd, name)| (cmd.to_string(), name.to_string()))
                 .collect(),
             verbose: false,
         }

--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -272,12 +272,7 @@ fn compress_logs(tmp_dir: &TempDir, result: &String) -> io::Result<()> {
     let tmp_path = tmp_dir
         .path()
         .parent()
-        .ok_or(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "Malformed path to temporary directory",
-        ))?
-        .as_os_str()
-        .to_str()
+        .and_then(|p| p.as_os_str().to_str())
         .ok_or(io::Error::new(
             io::ErrorKind::InvalidInput,
             "Malformed path to temporary directory",
@@ -285,11 +280,7 @@ fn compress_logs(tmp_dir: &TempDir, result: &String) -> io::Result<()> {
     let dir = tmp_dir
         .path()
         .file_name()
-        .ok_or(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "Malformed path to temporary directory",
-        ))?
-        .to_str()
+        .and_then(|f| f.to_str())
         .ok_or(io::Error::new(
             io::ErrorKind::InvalidInput,
             "Malformed path to temporary director",

--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -29,23 +29,18 @@ pub async fn run(subcommand: LogsCommands) -> anyhow::Result<()> {
         LogsCommands::Store { verbose } => {
             // feed internal options structure by what was received from user
             // for now we always use / add defaults if any
-            let options = LogOptions {
-                paths: DEFAULT_PATHS.iter().map(|p| p.to_string()).collect(),
-                commands: DEFAULT_COMMANDS.iter().map(|p| p.to_string()).collect(),
-                verbose: verbose,
-            };
+            let mut options = LogOptions::new();
+
+            options.verbose = verbose;
 
             Ok(store(options)?)
         },
         LogsCommands::List => {
-            let options = LogOptions {
-                paths: Vec::new(),
-                commands: Vec::new(),
-                verbose: false,
-            };
+            let options = LogOptions::new();
 
             list(options);
-            Err(anyhow::anyhow!("Not implemented"))
+
+            Ok(())
         },
     }
 }
@@ -103,6 +98,16 @@ struct LogOptions {
     paths: Vec<String>,
     commands: Vec<String>,
     verbose: bool,
+}
+
+impl LogOptions {
+    fn new() -> Self {
+        Self {
+            paths: DEFAULT_PATHS.iter().map(|p| p.to_string()).collect(),
+            commands: DEFAULT_COMMANDS.iter().map(|p| p.to_string()).collect(),
+            verbose: false,
+        }
+    }
 }
 
 // Struct for log represented by a file
@@ -310,6 +315,13 @@ fn store(options: LogOptions) -> Result<(), io::Error> {
 }
 
 // Handler for the "agama logs list" subcommand
-fn list(_options: LogOptions)
+fn list(options: LogOptions)
 {
+    for list in [options.paths, options.commands] {
+        for item in list.iter() {
+            println!("{}", item);
+        }
+
+        println!();
+    }
 }

--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -244,15 +244,22 @@ fn cmds_to_log_sources(commands: &Vec<String>, tmp_dir: &TempDir) -> Vec<Box<dyn
 // Compress given directory into a tar archive
 fn compress_logs(tmp_dir: &TempDir, result: &String) -> io::Result<()> {
     let compression = DEFAULT_COMPRESSION.0;
-    let tmp_path = tmp_dir.path();
-    let path = tmp_path.parent().unwrap().as_os_str().to_str().ok_or(io::Error::new(io::ErrorKind::InvalidInput, "Wrong path"))?;
-    let dir = tmp_path.file_name().unwrap().to_str().ok_or(io::Error::new(io::ErrorKind::InvalidInput, "Wrong path"))?;
+    let tmp_path = tmp_dir
+        .path()
+        .parent()
+        .unwrap()
+        .as_os_str()
+        .to_str()
+        .ok_or(io::Error::new(io::ErrorKind::InvalidInput, "Wrong path"))?;
+    let dir = tmp_dir
+        .path()
+        .file_name()
+        .unwrap()
+        .to_str()
+        .ok_or(io::Error::new(io::ErrorKind::InvalidInput, "Wrong path"))?;
     let compress_cmd = format!(
         "tar -c -f {} --warning=no-file-changed --{} --dereference -C {} {}",
-        result,
-        compression,
-        path,
-        dir,
+        result, compression, tmp_path, dir,
     );
     let cmd_parts = compress_cmd.split_whitespace().collect::<Vec<&str>>();
     let res = Command::new(cmd_parts[0])
@@ -261,8 +268,7 @@ fn compress_logs(tmp_dir: &TempDir, result: &String) -> io::Result<()> {
 
     if res.success() {
         Ok(())
-    }
-    else {
+    } else {
         Err(io::Error::new(
             io::ErrorKind::Other,
             "Cannot create tar archive",

--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -29,7 +29,10 @@ pub async fn run(subcommand: LogsCommands) -> anyhow::Result<()> {
         LogsCommands::Store { verbose } => {
             // feed internal options structure by what was received from user
             // for now we always use / add defaults if any
-            let options = LogOptions { verbose: verbose, ..Default::default() };
+            let options = LogOptions {
+                verbose: verbose,
+                ..Default::default()
+            };
 
             Ok(store(options)?)
         }
@@ -246,16 +249,28 @@ fn compress_logs(tmp_dir: &TempDir, result: &String) -> io::Result<()> {
     let tmp_path = tmp_dir
         .path()
         .parent()
-        .unwrap()
+        .ok_or(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Malformed path to temporary directory",
+        ))?
         .as_os_str()
         .to_str()
-        .ok_or(io::Error::new(io::ErrorKind::InvalidInput, "Wrong path"))?;
+        .ok_or(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Malformed path to temporary directory",
+        ))?;
     let dir = tmp_dir
         .path()
         .file_name()
-        .unwrap()
+        .ok_or(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Malformed path to temporary directory",
+        ))?
         .to_str()
-        .ok_or(io::Error::new(io::ErrorKind::InvalidInput, "Wrong path"))?;
+        .ok_or(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Malformed path to temporary director",
+        ))?;
     let compress_cmd = format!(
         "tar -c -f {} --warning=no-file-changed --{} --dereference -C {} {}",
         result, compression, tmp_path, dir,
@@ -327,7 +342,10 @@ fn store(options: LogOptions) -> Result<(), io::Error> {
 
 // Handler for the "agama logs list" subcommand
 fn list(options: LogOptions) {
-    for list in [ ("Log paths: ", options.paths), ("Log commands: ", options.commands)] {
+    for list in [
+        ("Log paths: ", options.paths),
+        ("Log commands: ", options.commands),
+    ] {
         println!("{}", list.0);
 
         for item in list.1.iter() {

--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -196,7 +196,10 @@ impl LogItem for LogCmd {
     }
 
     fn to(&self) -> PathBuf {
-        self.dst_path.as_path().join(format!("{}", self.cmd))
+        let mut file_name = self.cmd.clone();
+
+        file_name.retain(|c| c != ' ');
+        self.dst_path.as_path().join(format!("{}", file_name))
     }
 
     fn store(&self) -> Result<(), io::Error> {


### PR DESCRIPTION
## Problem

Trying to grow agama logs from baby age to teenage.

## Solution

- Implemented agama logs list subcommand
- Internal refactoring
- Changes in target tarball - related to: https://github.com/openSUSE/agama/issues/774
- Commands are not stored in files with names containing spaces anymore. 
- Command generated logs can be stored in files with user defined names

## Testing

- *Tested manually*
