### PR TITLE
Refine definition of storage volumes for ALP Dolomite

### DIFF
--- a/service/etc/agama.yaml
+++ b/service/etc/agama.yaml
@@ -82,6 +82,9 @@ ALP-Dolomite:
             - path: srv
             - path: boot/writable
             - path: usr/local
+            - path: var
+              copy_on_write: false
+            # Architecture specific subvolume
             - path: boot/grub2/arm64-efi
               archs: aarch64
             - path: boot/grub2/i386-pc
@@ -92,16 +95,30 @@ ALP-Dolomite:
               archs: s390
             - path: boot/grub2/x86_64-efi
               archs: x86_64
-            - path: var
-              copy_on_write: false
         size:
-          auto: false
-          min: 5 GiB
+          auto: true
         outline:
           required: true
           filesystems:
             - btrfs
           snapshots_configurable: false
+          auto_size:
+            base_min: 5 GiB
+            base_max: 25 GiB
+            max_fallback_for:
+              - "/var"
+      - mount_path: "/var"
+        filesystem: btrfs
+        mount_options:
+          - "x-initrd.mount"
+          - "nodatacow"
+        size:
+          auto: false
+          min: 5 GiB
+        outline:
+          required: false
+          filesystems:
+            - btrfs
 
 Tumbleweed:
   software:


### PR DESCRIPTION
## Problem

The storage configuration for ALP Dolomite was directly inferred from the corresponding image, just because it was the only source of information.

## Solution

Now we have a better knowledge of the storage needs of ALP Dolomite, so the configuration has been updated according to that.

- The root volume is still a mandatory Btrfs file system with read-only root subvolume and snapshots. That's a requirement for the immutable nature of Dolomite.
- Now it's possible to configure a separate `/var` file system. That's useful (even recommended) for hosting all the containers in a way in which they cannot lead to filling the main file-system[1].
- If a separate `/var` is used, the root volume will not grow beyond the 25 GiB, to leave the rest of the space to `/var`.
- No matter if `/var` is a subvolume or a separate file system, it's always configured to NOT do copy-on-write.
- Creating a separate swap is NOT offered as an option. Having a swap partition can lead to problems with Kubernetes.

[1] Having `/var` as a subvolume and using Btrfs quotas to limit the grow of containers is not an option because Btrfs quotas can be problematic when used alongside other Dolomite technologies.

## Testing

Manually tested. The file systems and subvolumes are created as expected and the UI behaves as seen in the following screenshots.

![dolomite-var1](https://github.com/openSUSE/agama/assets/3638289/e8dcb75d-646b-4062-b24b-145ba91ad8ee)

![dolomite-var2](https://github.com/openSUSE/agama/assets/3638289/47ac2521-7ffb-462e-bf7f-f5f2432e1fe9)

![dolomite-var3](https://github.com/openSUSE/agama/assets/3638289/59f46a03-cc9c-42a4-9462-74e389e3a009)
