### PR TITLE
add warning if there are no repos for given product

### DIFF
--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -138,7 +138,9 @@ module Agama
         end
         # no errors and also no repos
         if errors.empty? && repositories.enabled.empty?
-          errors << ValidationError.new("System has to be registered to get access to repositories.")
+          errors << ValidationError.new(
+            "System has to be registered to get access to repositories."
+          )
         end
         return errors if repositories.enabled.empty?
 

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -136,6 +136,10 @@ module Agama
         errors = repositories.disabled.map do |repo|
           ValidationError.new("Could not read the repository #{repo.name}")
         end
+        # no errors and also no repos
+        if errors.empty? && repositories.enabled.empty?
+          errors << ValidationError.new("System has to be registered to get access to repositories.")
+        end
         return errors if repositories.enabled.empty?
 
         errors + proposal.errors


### PR DESCRIPTION
## Problem

Some product will no longer provide public repos and has mandatory registration.


## Solution

Inform user that for such products registration is mandatory.

## Screenshots

note: I manually modify agama.yml and remove all repos for ALP Dolomite product.
before:
![agama-software-old-no-repos](https://github.com/openSUSE/agama/assets/478871/68cf9833-9b13-43af-a6e8-08b9a854b253)
after:
![agama-software-new-no-repos](https://github.com/openSUSE/agama/assets/478871/3d3c4d24-ef09-4f1d-9c2b-16e0614881a4)

