### PR TITLE
[web] Start using `PF/Dropdown#onOpenChange` prop

### DIFF
--- a/web/src/components/core/PageOptions.jsx
+++ b/web/src/components/core/PageOptions.jsx
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState } from 'react';
 import {
   Dropdown, DropdownGroup, DropdownItem, DropdownList,
   MenuToggle
@@ -138,42 +138,24 @@ const Options = ({ children, ...props }) => {
  */
 const PageOptions = ({ children }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef(null);
 
-  const onToggle = () => setIsOpen(!isOpen);
-  const onSelect = () => setIsOpen(false);
-
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-        setIsOpen(false);
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener('click', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  }, [isOpen]);
+  const toggle = () => setIsOpen(!isOpen);
+  const close = () => setIsOpen(false);
 
   return (
     <PageOptionsSlot>
-      <div ref={dropdownRef}>
-        <Dropdown
-          isOpen={isOpen}
-          toggle={(toggleRef) => <Toggler toggleRef={toggleRef} onClick={onToggle} />}
-          onSelect={onSelect}
-          popperProps={{ minWidth: "150px", position: "right" }}
-          className="page-options"
-        >
-          <DropdownList>
-            {Array(children)}
-          </DropdownList>
-        </Dropdown>
-      </div>
+      <Dropdown
+        isOpen={isOpen}
+        toggle={(toggleRef) => <Toggler toggleRef={toggleRef} onClick={toggle} />}
+        onSelect={close}
+        onOpenChange={close}
+        popperProps={{ minWidth: "150px", position: "right" }}
+        className="page-options"
+      >
+        <DropdownList>
+          {Array(children)}
+        </DropdownList>
+      </Dropdown>
     </PageOptionsSlot>
   );
 };

--- a/web/src/components/core/PageOptions.test.jsx
+++ b/web/src/components/core/PageOptions.test.jsx
@@ -20,7 +20,7 @@
  */
 
 import React from "react";
-import { screen, fireEvent } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { plainRender, mockLayout } from "~/test-utils";
 import { PageOptions } from "~/components/core";
 
@@ -36,7 +36,7 @@ it("renders the component initially closed", async () => {
   expect(screen.queryByRole("menuitem", { name: "A dummy action" })).toBeNull();
 });
 
-it("show and hide the component content on user request", async () => {
+it("shows and hides the component content on user request", async () => {
   const { user } = plainRender(
     <PageOptions>
       <PageOptions.Option><>A dummy action</></PageOptions.Option>
@@ -56,7 +56,7 @@ it("show and hide the component content on user request", async () => {
   expect(screen.queryByRole("menuitem", { name: "A dummy action" })).toBeNull();
 });
 
-it("hide the component content when the user clicks on one of its actions", async () => {
+it("hides the component content when user clicks on one of its actions", async () => {
   const { user } = plainRender(
     <PageOptions>
       <PageOptions.Group label="Refresh">
@@ -75,23 +75,28 @@ it("hide the component content when the user clicks on one of its actions", asyn
   expect(screen.queryByRole("menuitem", { name: "A dummy action" })).toBeNull();
 });
 
-it('should close the dropdown on click outside', async () => {
+it('closes the component  when user clicks outside', async () => {
   const { user } = plainRender(
-    <PageOptions>
-      <PageOptions.Option><>Option 1</></PageOptions.Option>
-      <PageOptions.Option><>Option 2</></PageOptions.Option>
-    </PageOptions>
+    <>
+      <div>Sibling</div>
+      <PageOptions>
+        <PageOptions.Option><>Option 1</></PageOptions.Option>
+        <PageOptions.Option><>Option 2</></PageOptions.Option>
+      </PageOptions>
+    </>
   );
 
-  // Open the dropdown
   const toggler = screen.getByRole("button");
+  const sibling = screen.getByText("Sibling");
+
+  // Open the dropdown
   await user.click(toggler);
 
   // Ensure the dropdown is open
   screen.getByRole("menuitem", { name: "Option 2" });
 
   // Click outside the dropdown
-  fireEvent.click(document);
+  await user.click(sibling);
 
   // Ensure the dropdown is closed
   expect(screen.queryByRole("menuitem", { name: "Option 2" })).toBeNull();


### PR DESCRIPTION
## Problem

No problem at all, actually :wink: Just a PR to start using the `#onOpenChange` prop of [PF5/Dropdown](https://www.patternfly.org/components/menus/dropdown#dropdown), which wasn't present in the former PF4/Dropdown as I commented in https://github.com/openSUSE/agama/issues/552.

## Solution

`PF/Dropdown#onOpenChange` prop should be used whenever needed. As a result, this undoes or replaces the [great contribution](https://github.com/openSUSE/agama/pull/671) made by @balsa-asanovic only 3 months ago. However, I feel relying on the library, when possible, is the right path to take. While click handling is nearly identical, they are taking care of the keyboard, and there is a `onOpenChangeKeys` beta prop that might be useful in the future. Have a look to the [source code](https://github.com/patternfly/patternfly-react/blob/7767e6a96195dffbf155c7608d9aad0c14303f03/packages/react-core/src/components/Dropdown/Dropdown.tsx#L96-L137) if you're curious.

## Tests

Adapted the original unit test just for using the user events API instead of the `fireClick` method, but the test passed as it was after made the change.