### PR TITLE
[web] Fix font families

### DIFF
--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -3,17 +3,12 @@
   // from brand.suse.com
 
   // Font families
-  --pf-v5-global--FontFamily--sans-serif: var(--ff);
-  --pf-v5-global--FontFamily--heading--sans-serif: var(--ff-headings);
+  --pf-v5-global--FontFamily--text: var(--ff);
+  --pf-v5-global--FontFamily--text--vf: var(--ff);
+  --pf-v5-global--FontFamily--heading: var(--ff-headings);
+  --pf-v5-global--FontFamily--heading--vf: var(--ff-headings);
   --pf-v5-global--FontFamily--monospace: var(--ff-code);
-  --pf-v5-global--FontFamily--redhat-updated--sans-serif: var(--ff);
-  --pf-v5-global--FontFamily--redhat-updated--heading--sans-serif: var(--ff-headings);
-  --pf-v5-global--FontFamily--redhat--monospace: var(--ff-code);
-  --pf-v5-global--FontFamily--redhatVF--sans-serif: var(--ff);
-  --pf-v5-global--FontFamily--redhatVF--heading--sans-serif: var(--ff-headings);
-  --pf-v5-global--FontFamily--redhatVF--monospace: var(--ff-code);
-  --pf-v5-global--FontFamily--overpass--sans-serif: var(--ff);
-  --pf-v5-global--FontFamily--overpass--monospace: var(--ff-code);
+  --pf-v5-global--FontFamily--monospace--vf: var(--ff-code);
 
   // Font sizes
   --pf-v5-global--FontSize--4xl: 2em;


### PR DESCRIPTION
## Problem

Font families overwrites/definitions weren't properly updated in the migration to PatternFly 5.

## Solution

Update the _web/src/assets/styles/patternfly-overrides.scss_ file to be _in sync_ with https://github.com/patternfly/patternfly/blob/5233e05c41cae220cf062998839f8881dfd8a080/src/patternfly/base/_variables.scss#L246C1-L252

## Testing

- Tested manually

## Screenshots


| Before | After |
|-|-|
| ![Fonts before updating overrides file](https://github.com/openSUSE/agama/assets/1691872/1cb9b558-cced-4aa8-a94a-1b146dd9b7e2) | ![Fonts after updating overrides file](https://github.com/openSUSE/agama/assets/1691872/67ae7c34-00fa-4d16-8adc-01d5141acaa5) |


*If the fix affects the UI attach some screenshots here.*

## Acknowledgements

Thanks @lslezak for catching and reporting it :smiley: 

