### PR TITLE
DevServerWrapper translations

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -62,7 +62,7 @@
     "overrides": [
       {
         // do not check translations in the testing or development files
-        "files": ["*.test.*", "test-utils.js", "DevServerWrapper.jsx"],
+        "files": ["*.test.*", "test-utils.js"],
         "rules": {
           "i18next/no-literal-string": "off"
         }

--- a/web/src/DevServerWrapper.jsx
+++ b/web/src/DevServerWrapper.jsx
@@ -26,6 +26,7 @@ import {
   EmptyState, EmptyStateBody, EmptyStateFooter, EmptyStateHeader, EmptyStateIcon
 } from "@patternfly/react-core";
 import { Center, Icon, Loading } from "~/components/layout";
+import { _ } from "~/i18n";
 
 // path to any internal Cockpit component to force displaying the login dialog
 const loginPath = "/cockpit/@localhost/system/terminal.html";
@@ -77,26 +78,30 @@ export default function DevServerWrapper({ children }) {
   if (isLoading) return <Loading />;
 
   if (isError) {
+    // TRANSLATORS: error message, %s is replaced by the server URL
+    const [msg1, msg2] = _("The server at %s is not reachable.").split("%s");
     return (
       <Center>
         <EmptyState variant="xl">
           <EmptyStateHeader
-            titleText="Cannot connect to the Cockpit server"
+            // TRANSLATORS: error message
+            titleText={_("Cannot connect to the Cockpit server")}
             headingLevel="h2"
             icon={<EmptyStateIcon icon={ErrorIcon} />}
           />
           <EmptyStateBody>
             <Text>
-              The server at { " " }
-              <Button isInline variant="link" component="a" href={ COCKPIT_TARGET_URL } target="_blank">
-                { COCKPIT_TARGET_URL }
+              {msg1} {" "}
+              <Button isInline variant="link" component="a" href={COCKPIT_TARGET_URL} target="_blank">
+                {COCKPIT_TARGET_URL}
               </Button>
-              { " " } is not reachable.
+              {" "} {msg2}
             </Text>
           </EmptyStateBody>
           <EmptyStateFooter>
             <Button variant="primary" onClick={() => { setIsLoading(true); setIsError(false) }}>
-              Try Again
+              {/* TRANSLATORS: button label */}
+              {_("Try Again")}
             </Button>
           </EmptyStateFooter>
         </EmptyState>

--- a/web/src/components/core/InstallButton.jsx
+++ b/web/src/components/core/InstallButton.jsx
@@ -63,8 +63,8 @@ before proceeding with the installation.").split(/[[\]]/);
       <div className="stack">
         <If condition={hasIssues} then={<IssuesWarning />} />
         <p>
-          { _(`If you continue, partitions on your hard disk will be modified
-according to the provided installation settings.`) }
+          { _("If you continue, partitions on your hard disk will be modified \
+according to the provided installation settings.") }
         </p>
         <p>
           {_("Please, cancel and check the settings if you are unsure.")}
@@ -87,8 +87,8 @@ const CannotInstallPopup = ({ onClose }) => (
     isOpen
   >
     <p>
-      {_(`Some problems were found when trying to start the installation.
-Please, have a look to the reported errors and try again.`)}
+      {_("Some problems were found when trying to start the installation. \
+Please, have a look to the reported errors and try again.")}
     </p>
 
     <Popup.Actions>


### PR DESCRIPTION
## Problem

- Already discussed with @dgdavid, the `DevServerWrapper` component should be translated as well
- The original reason for skipping was that it is used only by developers. But then it looks strange if some texts are not translated esp. when you are showing a demo to someone else.


## Solution

- Just mark the texts for translation

## Additional Fixes

- I noticed that some code uses string template in `_()` function. It works from the JS code POV, but the problem is that `xgettext` cannot extract the text to the POT file, so the text is in the end not translated. 
