### PR TITLE
[web] Update PatternFly packages to version 5.1.x

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,9 +9,9 @@
       "dependencies": {
         "@icons-pack/react-simple-icons": "^9.0.1",
         "@material-symbols/svg-400": "^0.13.0",
-        "@patternfly/patternfly": "^5.0.0",
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-table": "^5.0.0",
+        "@patternfly/patternfly": "^5.1.0",
+        "@patternfly/react-core": "^5.1.0",
+        "@patternfly/react-table": "^5.1.0",
         "core-js": "^3.21.1",
         "fast-sort": "^3.2.1",
         "ipaddr.js": "^2.0.1",
@@ -3595,19 +3595,19 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.0.4.tgz",
-      "integrity": "sha512-8akdWzFpG384Q6Es8lzkfuhAlzVGrNK7TJqXGecHDAg8u1JsYn3+Nw6gLRviI88z8Kjxmg5YKirILjpclGxkIA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.1.0.tgz",
+      "integrity": "sha512-wzVgL/0xPsmuRKWc6lMNEo5gDcTUtyU231eJSBTapOKXiwBOv2flvLEHPYLO6oDYXO+hwUrVgbcZFWMd1UlLwA=="
     },
     "node_modules/@patternfly/react-core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.0.1.tgz",
-      "integrity": "sha512-Eevd+8ACLFV733J+cpo4FRgNtRBObIgmUcrqLjf9H99jZ1hFpBgacFyHiALFi2cuoNVGmdEzskFl+4c7Uo0n+w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.1.1.tgz",
+      "integrity": "sha512-9DbgQMXYmF8A4aCNLKXwIN1H07SIPoPaVLvx+yiDuJfDx4Qi0T+H7j5cx0VfDfxuCpqea3POJWqBQn1HnwS4wQ==",
       "dependencies": {
-        "@patternfly/react-icons": "^5.0.1",
-        "@patternfly/react-styles": "^5.0.1",
-        "@patternfly/react-tokens": "^5.0.1",
-        "focus-trap": "7.4.3",
+        "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-styles": "^5.1.1",
+        "@patternfly/react-tokens": "^5.1.1",
+        "focus-trap": "7.5.2",
         "react-dropzone": "^14.2.3",
         "tslib": "^2.5.0"
       },
@@ -3617,28 +3617,28 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.0.1.tgz",
-      "integrity": "sha512-MduetDRzve3eRlKAioM/UxmVuPyFccdeBWAKhbN4SBn7RaZWS7kO7/xZzNkpeT5pqQIeAACvz3uiV2/3uAf38w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.1.1.tgz",
+      "integrity": "sha512-9gCxkWz2xcdi0rtXu2F0L68w4tLIlsgGTACo1ggr4aVng9jRX++o1PlCOqscOd9o0NiFnFD7BLlZUGvJWaYEZg==",
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.0.1.tgz",
-      "integrity": "sha512-kHP/lbvmhBnNfWiqJJLNwOQZnkcl6wfwAesRp22s4Lj941EWe0oFIqn925/uORIOAOz2du1121t7T4UTfLZg4w=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.1.1.tgz",
+      "integrity": "sha512-swO9X+WixYYDsMVsEJp1V8QUfhEQY91QfFm4phfYP4jc2TQ2opIFYdUIHkc+yrZwBhrgb/pPUUfemyqAoSbZcA=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.0.1.tgz",
-      "integrity": "sha512-2YbM6XvgG9ubJE4caPQKPMFBkcf7zYzLUFbHnkyfInpWeVNBs/+ZDAP2wnIHce7uaPLnJ1t0FVzGwaD/UuPwkg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.1.1.tgz",
+      "integrity": "sha512-9tAtHj16hemJ6YRBWIm2O+QRNoFWYQt8ZLQ1G0KBwpg2t2G2CbGsS2RG+BamO4IVE6IPo3Yoo39p4UCNRiGVpA==",
       "dependencies": {
-        "@patternfly/react-core": "^5.0.1",
-        "@patternfly/react-icons": "^5.0.1",
-        "@patternfly/react-styles": "^5.0.1",
-        "@patternfly/react-tokens": "^5.0.1",
+        "@patternfly/react-core": "^5.1.1",
+        "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-styles": "^5.1.1",
+        "@patternfly/react-tokens": "^5.1.1",
         "lodash": "^4.17.19",
         "tslib": "^2.5.0"
       },
@@ -3648,9 +3648,9 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.0.1.tgz",
-      "integrity": "sha512-YafAGJYvxDP4GaQ0vMybalWmx7MJ+etUf1cGoaMh0wRD2eswltT/RckygtEBKR/M61qXbgG+CxKmMyY8leoiDw=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.1.1.tgz",
+      "integrity": "sha512-cHuNkzNA9IY9aDwfjSEkitQoVEvRhOJRKhH0yIRlRByEkbdoV9jJZ9xj20hNShE+bxmNuom+MCTQSkpkN1bV8A=="
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.11",
@@ -9500,11 +9500,11 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
-      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
+      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
       "dependencies": {
-        "tabbable": "^6.1.2"
+        "tabbable": "^6.2.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -21392,51 +21392,51 @@
       }
     },
     "@patternfly/patternfly": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.0.4.tgz",
-      "integrity": "sha512-8akdWzFpG384Q6Es8lzkfuhAlzVGrNK7TJqXGecHDAg8u1JsYn3+Nw6gLRviI88z8Kjxmg5YKirILjpclGxkIA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.1.0.tgz",
+      "integrity": "sha512-wzVgL/0xPsmuRKWc6lMNEo5gDcTUtyU231eJSBTapOKXiwBOv2flvLEHPYLO6oDYXO+hwUrVgbcZFWMd1UlLwA=="
     },
     "@patternfly/react-core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.0.1.tgz",
-      "integrity": "sha512-Eevd+8ACLFV733J+cpo4FRgNtRBObIgmUcrqLjf9H99jZ1hFpBgacFyHiALFi2cuoNVGmdEzskFl+4c7Uo0n+w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.1.1.tgz",
+      "integrity": "sha512-9DbgQMXYmF8A4aCNLKXwIN1H07SIPoPaVLvx+yiDuJfDx4Qi0T+H7j5cx0VfDfxuCpqea3POJWqBQn1HnwS4wQ==",
       "requires": {
-        "@patternfly/react-icons": "^5.0.1",
-        "@patternfly/react-styles": "^5.0.1",
-        "@patternfly/react-tokens": "^5.0.1",
-        "focus-trap": "7.4.3",
+        "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-styles": "^5.1.1",
+        "@patternfly/react-tokens": "^5.1.1",
+        "focus-trap": "7.5.2",
         "react-dropzone": "^14.2.3",
         "tslib": "^2.5.0"
       }
     },
     "@patternfly/react-icons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.0.1.tgz",
-      "integrity": "sha512-MduetDRzve3eRlKAioM/UxmVuPyFccdeBWAKhbN4SBn7RaZWS7kO7/xZzNkpeT5pqQIeAACvz3uiV2/3uAf38w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.1.1.tgz",
+      "integrity": "sha512-9gCxkWz2xcdi0rtXu2F0L68w4tLIlsgGTACo1ggr4aVng9jRX++o1PlCOqscOd9o0NiFnFD7BLlZUGvJWaYEZg==",
       "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.0.1.tgz",
-      "integrity": "sha512-kHP/lbvmhBnNfWiqJJLNwOQZnkcl6wfwAesRp22s4Lj941EWe0oFIqn925/uORIOAOz2du1121t7T4UTfLZg4w=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.1.1.tgz",
+      "integrity": "sha512-swO9X+WixYYDsMVsEJp1V8QUfhEQY91QfFm4phfYP4jc2TQ2opIFYdUIHkc+yrZwBhrgb/pPUUfemyqAoSbZcA=="
     },
     "@patternfly/react-table": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.0.1.tgz",
-      "integrity": "sha512-2YbM6XvgG9ubJE4caPQKPMFBkcf7zYzLUFbHnkyfInpWeVNBs/+ZDAP2wnIHce7uaPLnJ1t0FVzGwaD/UuPwkg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.1.1.tgz",
+      "integrity": "sha512-9tAtHj16hemJ6YRBWIm2O+QRNoFWYQt8ZLQ1G0KBwpg2t2G2CbGsS2RG+BamO4IVE6IPo3Yoo39p4UCNRiGVpA==",
       "requires": {
-        "@patternfly/react-core": "^5.0.1",
-        "@patternfly/react-icons": "^5.0.1",
-        "@patternfly/react-styles": "^5.0.1",
-        "@patternfly/react-tokens": "^5.0.1",
+        "@patternfly/react-core": "^5.1.1",
+        "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-styles": "^5.1.1",
+        "@patternfly/react-tokens": "^5.1.1",
         "lodash": "^4.17.19",
         "tslib": "^2.5.0"
       }
     },
     "@patternfly/react-tokens": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.0.1.tgz",
-      "integrity": "sha512-YafAGJYvxDP4GaQ0vMybalWmx7MJ+etUf1cGoaMh0wRD2eswltT/RckygtEBKR/M61qXbgG+CxKmMyY8leoiDw=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.1.1.tgz",
+      "integrity": "sha512-cHuNkzNA9IY9aDwfjSEkitQoVEvRhOJRKhH0yIRlRByEkbdoV9jJZ9xj20hNShE+bxmNuom+MCTQSkpkN1bV8A=="
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.11",
@@ -25751,11 +25751,11 @@
       "dev": true
     },
     "focus-trap": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
-      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
+      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
       "requires": {
-        "tabbable": "^6.1.2"
+        "tabbable": "^6.2.0"
       }
     },
     "follow-redirects": {

--- a/web/package.json
+++ b/web/package.json
@@ -97,9 +97,9 @@
   "dependencies": {
     "@icons-pack/react-simple-icons": "^9.0.1",
     "@material-symbols/svg-400": "^0.13.0",
-    "@patternfly/patternfly": "^5.0.0",
-    "@patternfly/react-core": "^5.0.0",
-    "@patternfly/react-table": "^5.0.0",
+    "@patternfly/patternfly": "^5.1.0",
+    "@patternfly/react-core": "^5.1.0",
+    "@patternfly/react-table": "^5.1.0",
     "core-js": "^3.21.1",
     "fast-sort": "^3.2.1",
     "ipaddr.js": "^2.0.1",


### PR DESCRIPTION
## Problem

Two weeks ago, three days after [Agama migrated to PatternFly 5](https://github.com/openSUSE/agama/pull/759#event-10535938866), PatternFly released its version [5.1.0](https://github.com/patternfly/patternfly/releases/tag/v5.1.0) and PatternfFly React the [5.1.1](https://github.com/patternfly/patternfly-react/releases/tag/v5.1.1)

## Solution

Update our PatternFly dependencies to be up-to-date with improvements released in these versions.


## Testing

Unit tests run successfully.
