### PR TITLE
[web] Reintroduce blurring when sidebar is open

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 19 22:07:11 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- UI: fix CSS rule for applying grayscale and blur CSS filters to
+  main wrapper when the sidebar is open (gh#openSUSE/agama#802).
+
+-------------------------------------------------------------------
 Tue Oct 17 10:59:37 UTC 2023 - Imobach González Sosa <igonzalezsosa@suse.com>
 
 - Allow changing the language of the user interface

--- a/web/src/assets/styles/composition.scss
+++ b/web/src/assets/styles/composition.scss
@@ -29,6 +29,8 @@
 }
 
 body > div[inert],
-body > div[aria-hidden="true"] {
+body > div[aria-hidden="true"],
+div#root > div.wrapper[inert],
+div#root > div.wrapper[aria-hidden="true"] {
   filter: grayscale(1) blur(2px);
 }

--- a/web/src/assets/styles/composition.scss
+++ b/web/src/assets/styles/composition.scss
@@ -30,7 +30,7 @@
 
 body > div[inert],
 body > div[aria-hidden="true"],
-div#root > div.wrapper[inert],
-div#root > div.wrapper[aria-hidden="true"] {
+div#agama-main-wrapper[inert],
+div#agama-main-wrapper[aria-hidden="true"] {
   filter: grayscale(1) blur(2px);
 }

--- a/web/src/components/layout/Layout.jsx
+++ b/web/src/components/layout/Layout.jsx
@@ -67,7 +67,7 @@ function Layout({ children }) {
   return (
     <>
       <Sidebar.Target as="div" />
-      <div className="wrapper shadow">
+      <div id="agama-main-wrapper" className="wrapper shadow">
         <header className="split justify-between bottom-shadow">
           <h1 className="split">
             <HeaderIcon.Target as="span" />


### PR DESCRIPTION
## Problem

Few months ago, [a couple of CSS filters were added](https://github.com/openSUSE/agama/pull/564) to help sight users understanding quickly which parts of the UI are _inert_. Later, it was needed to [fine tune the rules](https://github.com/openSUSE/agama/pull/588) for applying these filters in order to not get blurred elements that shouldn't be. As a consequence, Agama stopped applying these filters to the main wrapper when the sidebar is open because the wrapper is not a direct child of `body`, but a direct child of `div#root`

## Solution

To use an `id` for identifying the _Agama main wrapper_ and use it for applying these effects too when it is _inert_ or _aria-hidden_.

## Testing

Tested manually

## Screenshots

| Before | After |
|-|-|
|![Screen Shot 2023-10-19 at 15 02 17](https://github.com/openSUSE/agama/assets/1691872/8f7fd142-48a5-4570-9cbc-c11a73f6fbba) |![Screen Shot 2023-10-19 at 15 02 08](https://github.com/openSUSE/agama/assets/1691872/47bbad5a-ae6c-4cb1-b98a-629f9e8278bb) |

