### PR TITLE
[web] Remove layout slot no longer needed

### DIFF
--- a/web/src/components/layout/Layout.jsx
+++ b/web/src/components/layout/Layout.jsx
@@ -30,7 +30,6 @@ const HeaderActions = createTeleporter();
 const HeaderIcon = createTeleporter();
 const FooterActions = createTeleporter();
 const FooterInfoArea = createTeleporter();
-const Sidebar = createTeleporter();
 
 /**
  *
@@ -65,35 +64,32 @@ const Sidebar = createTeleporter();
  */
 function Layout({ children }) {
   return (
-    <>
-      <Sidebar.Target as="div" />
-      <div id="agama-main-wrapper" className="wrapper shadow">
-        <header className="split justify-between bottom-shadow">
-          <h1 className="split">
-            <HeaderIcon.Target as="span" />
-            <PageTitle.Target as="span" />
-          </h1>
+    <div id="agama-main-wrapper" className="wrapper shadow">
+      <header className="split justify-between bottom-shadow">
+        <h1 className="split">
+          <HeaderIcon.Target as="span" />
+          <PageTitle.Target as="span" />
+        </h1>
 
-          <div className="split">
-            <PageActions.Target as="div" />
-            <HeaderActions.Target as="div" />
-          </div>
+        <div className="split">
+          <PageActions.Target as="div" />
+          <HeaderActions.Target as="div" />
+        </div>
 
-        </header>
+      </header>
 
-        <main className="stack">
-          {children}
-        </main>
+      <main className="stack">
+        {children}
+      </main>
 
-        <footer className="split justify-between top-shadow" data-state="reversed">
-          <FooterActions.Target
-            role="navigation"
-            aria-label="Installer Actions"
-          />
-          <img src={logoUrl} alt="Logo of SUSE" />
-        </footer>
-      </div>
-    </>
+      <footer className="split justify-between top-shadow" data-state="reversed">
+        <FooterActions.Target
+          role="navigation"
+          aria-label="Installer Actions"
+        />
+        <img src={logoUrl} alt="Logo of SUSE" />
+      </footer>
+    </div>
   );
 }
 
@@ -171,8 +167,6 @@ const MainActions = FooterActions.Source;
  */
 const AdditionalInfo = FooterInfoArea.Source;
 
-const SidebarArea = Sidebar.Source;
-
 export {
   Layout as default,
   Title,
@@ -181,5 +175,4 @@ export {
   PageOptions,
   MainActions,
   AdditionalInfo,
-  SidebarArea
 };


### PR DESCRIPTION
## Problem

There is an empty `div` node as a result of a `Sidebar` slot no longer needed.

From the commit description

> At https://github.com/openSUSE/agama/pull/781, the `Sidebar` was created directly from the `Layout` by using a slot for teleporting its content from outside. That was needed because the `Layout` was moved to a provider. Later, https://github.com/openSUSE/agama/pull/796 restored the previous behavior of mounting both, the `Sidebar` and the `Layout`, from _src/App.jsx_ instead of having "content components" in the providers, which was weird if not wrong.
> 
> However, the slot created for the `Sidebar` content was not removed and it was creating an empty div node between the sidebar and the main content.

## Solution

>  Although it wasn't producing any visible side effect in the UI, it has been removed since it is actually no longer needed.

## Testing

Tested manualy

## Screenshots

| Before | After |
|-|-|
| ![Screenshot from 2023-10-19 23-33-18](https://github.com/openSUSE/agama/assets/1691872/f340ceae-4246-46a5-8b3f-d073807ea522) | ![Screenshot from 2023-10-19 23-33-06](https://github.com/openSUSE/agama/assets/1691872/625159dd-7c40-4c43-9ce8-8a808d126fb0) |
