### PR TITLE
[Service] Do not reuse swap partitions in the storage proposal

### DIFF
--- a/service/lib/agama/storage/proposal_settings_conversion/to_y2storage.rb
+++ b/service/lib/agama/storage/proposal_settings_conversion/to_y2storage.rb
@@ -115,6 +115,8 @@ module Agama
 
         # @param target [Y2Storage::ProposalSettings]
         def volumes_conversion(target)
+          target.swap_reuse = :none
+
           volumes = settings.volumes.map { |v| VolumeConversion.to_y2storage(v) }
           disabled_volumes = missing_volumes.map do |volume|
             VolumeConversion.to_y2storage(volume).tap { |v| v.proposed = false }

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -24,7 +24,8 @@
     Requires:       yast2-installation
     Requires:       yast2-network
     Requires:       yast2-proxy
-    Requires:       yast2-storage-ng >= 4.6.10
+    # ProposalSettings#swap_reuse
+    Requires:       yast2-storage-ng >= 5.0.3
     Requires:       open-iscsi
     Requires:       yast2-iscsi-client >= 4.5.7
     Requires:       yast2-users

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Oct 20 08:37:22 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Do not reuse pre-existing swap partitions in the storage proposal
+  (gh#openSUSE/agama#806)
+
+-------------------------------------------------------------------
 Tue Oct 10 08:51:45 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Extended Software service to allow configuring selected patterns

--- a/service/test/agama/storage/proposal_settings_conversion/to_y2storage_test.rb
+++ b/service/test/agama/storage/proposal_settings_conversion/to_y2storage_test.rb
@@ -56,6 +56,7 @@ describe Agama::Storage::ProposalSettingsConversion::ToY2Storage do
       expect(y2storage_settings).to have_attributes(
         candidate_devices:   contain_exactly("/dev/sda", "/dev/sdb"),
         root_device:         "/dev/sda",
+        swap_reuse:          :none,
         lvm:                 true,
         separate_vgs:        true,
         lvm_vg_reuse:        false,


### PR DESCRIPTION
## Problem

It’s still not decided which possibilities we want to use regarding re-use of partitions at Agama.

As a consequence, nothing indicates in the UI if a given volume is going to be allocated in an already existing partition. It's just displayed with a minimum of 0B. There is also no way to control the circumstance in the UI or in unattended mode.

![reuse](https://github.com/openSUSE/agama/assets/3638289/49b23839-425b-491d-806f-4fe74b8afb8d)


## Solution

Simply prevent YaST storage proposal from reusing swaps. Anyways, it's a confusing behavior that was introduced just for backwards compatibility with old versions of YaST and we have no need to keep that legacy behavior in Agama.

Now Agama does not reuse devices in the same scenario.

![dontreuse](https://github.com/openSUSE/agama/assets/3638289/193a8107-066e-452b-8f15-c1731b2f739b)

## Testing

Tested manually (as proven by the screenshots)

## Dependencies

It introduce a dependency on a newer version of yast-storage-ng developed here https://github.com/yast/yast-storage-ng/pull/1362