### PR TITLE
Set more restrictive permissions to archive produced by agama logs store command

### DIFF
--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::fs::File;
 use std::io;
 use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempdir::TempDir;
@@ -295,13 +296,30 @@ fn compress_logs(tmp_dir: &TempDir, result: &String) -> io::Result<()> {
         .status()?;
 
     if res.success() {
-        Ok(())
+        set_archive_permissions(result)
     } else {
         Err(io::Error::new(
             io::ErrorKind::Other,
             "Cannot create tar archive",
         ))
     }
+}
+
+fn set_archive_permissions(archive: &String) -> io::Result<()> {
+    let attr = fs::metadata(archive)?;
+    let mut permissions = attr.permissions();
+
+    // set the archive file permissions to -rw-------
+    permissions.set_mode(0o600);
+    fs::set_permissions(archive, permissions)?;
+
+    // set the archive owner to root:root
+    // note: std::os::unix::fs::chown is unstable for now
+    Command::new("chown")
+        .args(["root:root", archive.as_str()])
+        .status()?;
+
+    Ok(())
 }
 
 // Handler for the "agama logs store" subcommand

--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -305,6 +305,8 @@ fn compress_logs(tmp_dir: &TempDir, result: &String) -> io::Result<()> {
     }
 }
 
+// Sets the archive owner to root:root. Also sets the file permissions to read/write for the
+// owner only.
 fn set_archive_permissions(archive: &String) -> io::Result<()> {
     let attr = fs::metadata(archive)?;
     let mut permissions = attr.permissions();

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Mon Oct 23 14:43:59 UTC 2023 - Michal Filka <mfilka@suse.com>
 
-- Improved "agama logs store"
+- Improved "agama logs store" (gh#openSUSE/agama#812)
   - the archive file owner is root:root
   - the permissions is set to r/w for the owner 
 

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 23 14:43:59 UTC 2023 - Michal Filka <mfilka@suse.com>
+
+- Improved "agama logs store"
+  - the archive file owner is root:root
+  - the permissions is set to r/w for the owner 
+
+-------------------------------------------------------------------
 Mon Oct 23 11:33:40 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 5


### PR DESCRIPTION
## Problem

logs produced by ```agama logs store``` were publicly readable

## Solution

owner is set to root and permissions to r/w for the owner only


## Testing

- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*
![agama-logs-permissions](https://github.com/openSUSE/agama/assets/1579239/b39c8dbb-7303-44c7-93a5-b9aa664f6547)


