### PR TITLE
Drop the unused "disableL10n" feature

### DIFF
--- a/web/src/context/agama.jsx
+++ b/web/src/context/agama.jsx
@@ -27,37 +27,21 @@ import { L10nProvider } from "./l10n";
 import { SoftwareProvider } from "./software";
 import { NotificationProvider } from "./notification";
 
-const InternalProviders = ({ children }) => {
-  return (
-    <SoftwareProvider>
-      <NotificationProvider>
-        {children}
-      </NotificationProvider>
-    </SoftwareProvider>
-  );
-};
-
 /**
  * Combines all application providers.
  *
  * @param {object} props
  * @param {React.ReactNode} [props.children] - content to display within the provider.
- * @param {boolean} [props.disableL10n] - Disable l10n handling (to be used
- *   during tests). FIXME: this argument might not be needed anymore.
  */
-function AgamaProviders({ disableL10n, children }) {
-  if (disableL10n) {
-    return (
-      <InstallerClientProvider>
-        <InternalProviders>{children}</InternalProviders>
-      </InstallerClientProvider>
-    );
-  }
-
+function AgamaProviders({ children }) {
   return (
     <InstallerClientProvider>
       <L10nProvider>
-        <InternalProviders>{children}</InternalProviders>
+        <SoftwareProvider>
+          <NotificationProvider>
+            {children}
+          </NotificationProvider>
+        </SoftwareProvider>
       </L10nProvider>
     </InstallerClientProvider>
   );


### PR DESCRIPTION
-------

## Problem

The `disableL10n` argument was introduced to make the unit-tests work before refactoring our providers. With the latest changes, it should not be needed anymore.

## Solution

Drop the parameter.


## Testing

- [ ] Unit tests are still passing
- [ ] Tested manually