### PR TITLE
Fix client initialization

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 26 05:31:28 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix client initialization to avoid a useless reconnection
+  (gh#openSUSE/agama#819).
+
+-------------------------------------------------------------------
 Mon Oct 23 11:33:53 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 5

--- a/web/src/context/installer.jsx
+++ b/web/src/context/installer.jsx
@@ -84,6 +84,7 @@ function InstallerClientProvider({
       if (await client.isConnected()) {
         setValue(client);
         setAttempt(0);
+        return;
       }
 
       console.warn(`Failed to connect to D-Bus (attempt ${attempt + 1})`);

--- a/web/src/context/installer.test.jsx
+++ b/web/src/context/installer.test.jsx
@@ -63,7 +63,7 @@ describe("installer context", () => {
         <InstallerClientProvider interval={0.1}>
           <ClientStatus />
         </InstallerClientProvider>);
-      await screen.findByText("attempt: 2");
+      await screen.findByText("attempt: 1");
     });
   });
 


### PR DESCRIPTION
## Problem

The client is reconnected once even if it is not needed.

## Solution

Avoid the reconnection.

## Testing

- Update the unit tests
- Tested manual