### PR TITLE
Ensure the software context is ready

### DIFF
--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -19,7 +19,7 @@ const config: PlaywrightTestConfig = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000
+    timeout: 15000
   },
   /* Do not run tests in files in parallel by default */
   fullyParallel: false,

--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 26 05:58:15 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Make sure that the software context is ready before trying to
+  load any route (gh#openSUSE/agama#820).
+
+-------------------------------------------------------------------
 Thu Oct 26 05:31:28 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix client initialization to avoid a useless reconnection

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -24,6 +24,7 @@ import { Outlet } from "react-router-dom";
 
 import { _ } from "~/i18n";
 import { useInstallerClient, useInstallerClientStatus } from "~/context/installer";
+import { useSoftware } from "./context/software";
 import { STARTUP, INSTALL } from "~/client/phase";
 import { BUSY } from "~/client/status";
 
@@ -57,6 +58,7 @@ const ATTEMPTS = 3;
 function App() {
   const client = useInstallerClient();
   const { attempt } = useInstallerClientStatus();
+  const { products } = useSoftware();
   const { language } = useL10n();
   const [status, setStatus] = useState(undefined);
   const [phase, setPhase] = useState(undefined);
@@ -79,7 +81,7 @@ function App() {
   }, [client, setPhase]);
 
   const Content = () => {
-    if (!client) {
+    if (!client || !products) {
       return (attempt > ATTEMPTS) ? <DBusError /> : <Loading />;
     }
 

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -29,6 +29,18 @@ import { IDLE, BUSY } from "~/client/status";
 
 jest.mock("~/client");
 
+// list of available products
+let mockProducts;
+jest.mock("~/context/software", () => ({
+  ...jest.requireActual("~/context/software"),
+  useSoftware: () => {
+    return {
+      products: mockProducts,
+      selectedProduct: null
+    };
+  }
+}));
+
 // Mock some components,
 // See https://www.chakshunyu.com/blog/how-to-mock-a-react-component-in-jest/#default-export
 jest.mock("~/components/core/DBusError", () => <div>D-BusError Mock</div>);
@@ -63,11 +75,27 @@ describe("App", () => {
         }
       };
     });
+
+    mockProducts = [
+      { id: "openSUSE", name: "openSUSE Tumbleweed" },
+      { id: "Leap Micro", name: "openSUSE Micro" }
+    ];
   });
 
   afterEach(() => {
     // setting a cookie with already expired date removes it
     document.cookie = "CockpitLang=; path=/; expires=" + new Date(0).toUTCString();
+  });
+
+  describe("when the software context is not initialized", () => {
+    beforeEach(() => {
+      mockProducts = undefined;
+    });
+
+    it("renders the LoadingEnvironment screen", async () => {
+      installerRender(<App />, { withL10n: true });
+      await screen.findByText(/Loading installation environment/);
+    });
   });
 
   describe("on the startup phase", () => {
@@ -76,7 +104,7 @@ describe("App", () => {
       getStatusFn.mockResolvedValue(BUSY);
     });
 
-    it("renders the LoadingEnvironment theme", async () => {
+    it("renders the LoadingEnvironment screen", async () => {
       installerRender(<App />, { withL10n: true });
       await screen.findByText("LoadingEnvironment Mock");
     });

--- a/web/src/context/software.jsx
+++ b/web/src/context/software.jsx
@@ -64,8 +64,8 @@ function useSoftware() {
   const [products, selectedId] = context;
 
   let selectedProduct = selectedId;
-  if (selectedId) {
-    selectedProduct = products.find(p => p.id === selectedId);
+  if (selectedId && products) {
+    selectedProduct = products.find(p => p.id === selectedId) || null;
   }
 
   return {


### PR DESCRIPTION
## Problem

For a short time (a fraction of a second), the overview page is shown even if you have not selected a product. It's not a problem at all for a human, but something nasty for automated testing.

## Solution

Do not load the application until the software context is ready.

## Testing

- Adapted a new unit test
- Tested manually