### PR TITLE
[Service] Delegate TPM-based encryption to YaST

### DIFF
--- a/products.d/ALP-Dolomite.yaml
+++ b/products.d/ALP-Dolomite.yaml
@@ -20,17 +20,12 @@ software:
     - alp_hardware
   optional_patterns: null # no optional pattern shared
   mandatory_packages:
-    - package: device-mapper # Apparently needed if devices at /dev/mapper are used at boot (eg. FDE)
-    - package: fde-tools # Needed for FDE with TPM, hardcoded here temporarily
-      archs: aarch64, x86_64
-    - package: libtss2-tcti-device0
     - package: ppc64-diag # Needed for hardware-based installations
       archs: ppc64
   optional_packages: null
   base_product: ALP-Dolomite
 
 security:
-  tpm_luks_open: true
   lsm: selinux
   available_lsms:
     # apparmor:
@@ -48,6 +43,7 @@ storage:
   encryption:
     method: luks2
     pbkd_function: pbkdf2
+    tpm_luks_open: true
   volumes:
     - "/"
   volume_templates:

--- a/products.d/leap16.yaml
+++ b/products.d/leap16.yaml
@@ -15,16 +15,11 @@ software:
     - alp-container_runtime
     - alp_defaults
   optional_patterns: null # no optional pattern shared
-  mandatory_packages:
-    - package: device-mapper # Apparently needed if devices at /dev/mapper are used at boot (eg. FDE)
-    - package: fde-tools # Needed for FDE with TPM, hardcoded here temporarily
-      archs: aarch64, x86_64
-    - package: libtss2-tcti-device0
+  mandatory_packages: null
   optional_packages: null
   base_product: Leap16
 
 security:
-  tpm_luks_open: true
   lsm: selinux
   available_lsms:
     # apparmor:
@@ -42,6 +37,7 @@ storage:
   encryption:
     method: luks2
     pbkd_function: pbkdf2
+    tpm_luks_open: true
   volumes:
     - "/"
   volume_templates:

--- a/service/lib/agama/dbus/y2dir/manager/modules/Package.rb
+++ b/service/lib/agama/dbus/y2dir/manager/modules/Package.rb
@@ -41,6 +41,13 @@ module Yast
 
     # Determines whether the package is available
     #
+    # @todo Perform a real D-Bus call.
+    def AvailableAll(_package_names)
+      true
+    end
+
+    # Determines whether the package is available
+    #
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/packages/src/modules/Package.rb#L121
     # @todo Perform a real D-Bus call.
     def Installed(package_name, target: nil)

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Nov  2 14:00:01 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Delegate TPM-based encryption to YaST (gh#openSUSE/agama#826)
+
+-------------------------------------------------------------------
 Mon Oct 23 11:33:26 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 5

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -319,6 +319,7 @@ describe Agama::Storage::Manager do
       expect(security).to receive(:write)
       expect(copy_files).to receive(:run)
       expect(bootloader_finish).to receive(:write)
+      expect(Yast::WFM).to receive(:CallFunction).with("storage_finish", ["Write"])
       expect(Yast::WFM).to receive(:CallFunction).with("snapshots_finish", ["Write"])
       expect(Yast::WFM).to receive(:CallFunction).with("copy_logs_finish", ["Write"])
       expect(Yast::WFM).to receive(:CallFunction).with("umount_finish", ["Write"])


### PR DESCRIPTION
## Problem

Encryption with TPM-unlocking was implemented (in a pretty hacky way) directly at Agama.


## Solution

This PR goes together with https://github.com/yast/yast-storage-ng/pull/1363

Now `Y2Storage` takes care of most things.

As a bonus, the storage finisher is now called. We overlooked that in the past and it takes care of some relevant things like copying the multipath configuration to the target system.