### PR TITLE
Sort languages in the language selector by the language code

### DIFF
--- a/web/src/components/l10n/LanguageSwitcher.jsx
+++ b/web/src/components/l10n/LanguageSwitcher.jsx
@@ -36,9 +36,9 @@ export default function LanguageSwitcher() {
     changeLanguage(value);
   }, [setSelected, changeLanguage]);
 
-  const options = Object.entries(languages).map(([id, name]) => {
-    return <FormSelectOption key={id} value={id} label={name} />;
-  });
+  // sort by the language code to maintain consistent order
+  const options = Object.keys(languages).sort()
+    .map(id => <FormSelectOption key={id} value={id} label={languages[id]} />);
 
   return (
     <>


### PR DESCRIPTION
## Problem

- The order of the languages in the language selector was not guaranteed

## Solution

- Explicitly sort the language by the language code

## Testing

- Tested manually
