### PR TITLE
Webpack-dev-server - watch translation relates files

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -101,6 +101,8 @@ module.exports = {
   externals: { cockpit: "cockpit" },
   devServer: {
     hot: true,
+    // additionally watch these files for changes
+    watchFiles: ["./src/manifest.json", "./po/*.po"],
     proxy: {
       // forward all cockpit connections to a real Cockpit instance
       "/cockpit": {


### PR DESCRIPTION
The web browser page is automatically reloaded when translations or the language index file (manifest.json) is updated.