### PR TITLE
Dev-server - display fullscreen Cockpit login form

### DIFF
--- a/web/src/DevServerWrapper.jsx
+++ b/web/src/DevServerWrapper.jsx
@@ -115,6 +115,9 @@ export default function DevServerWrapper({ children }) {
   } else {
     // handle updating the iframe with the login form
     const onFrameLoad = () => {
+      // have a full screen login form
+      document.getElementById("root").style.maxInlineSize = "none";
+
       const passwordInput = iframeRef.current.contentWindow.document.getElementById(loginId);
       // reload the window so the manifests.js file referenced from the
       // index.html file is also loaded again


### PR DESCRIPTION
## Problem

- When running the local development server the login form is not displayed in full screen, it is limited to the usual Agama main area.
- The problem is that in production the Cockpit server returns the login page instead of the Agama page when user is not authenticated.
- But in the development server we display the login page *inside* Agama (in an `iframe`), with the main page styling applied

![devserver_login_orig](https://github.com/openSUSE/agama/assets/907998/f8c727e5-c733-458a-b86c-d76a48f59545)


## Solution

- Remove the offending CSS property from the root node

![devserver_login_fixed](https://github.com/openSUSE/agama/assets/907998/a59cc5c3-a7c8-4ec9-91cf-dfdde693fa07)

## Notes

It is a bit hack, but as this is applied only in the development server (not in production) I think it is acceptable. Otherwise we would need to change the HTML structure and CSS quite a lot...