### PR TITLE
Use the eslint-plugin-agama-i18n plugin from npmjs

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -53,7 +53,7 @@
         "eslint-config-standard": "^17.0.0",
         "eslint-config-standard-jsx": "^11.0.0",
         "eslint-config-standard-react": "^13.0.0",
-        "eslint-plugin-agama-i18n": "https://github.com/openSUSE/eslint-plugin-agama-i18n/tarball/v0.1.0",
+        "eslint-plugin-agama-i18n": "^0.1.0",
         "eslint-plugin-flowtype": "^8.0.3",
         "eslint-plugin-i18next": "^6.0.3",
         "eslint-plugin-import": "^2.22.1",
@@ -8461,8 +8461,8 @@
     },
     "node_modules/eslint-plugin-agama-i18n": {
       "version": "0.1.0",
-      "resolved": "https://github.com/openSUSE/eslint-plugin-agama-i18n/tarball/v0.1.0",
-      "integrity": "sha512-YB3FxvM3KStcEGwnkZ2fqAcMlvSYv6xMbhuMPNMpZ5Muw1StOlpIW84MLzPbYQKPG84b9i1JEq+AZWYCPOfBDQ==",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-agama-i18n/-/eslint-plugin-agama-i18n-0.1.0.tgz",
+      "integrity": "sha512-FT/5bgtA80hM7dBd8Q23/ZseEOBFQ2KydIOSJ2MRJdazlmcmHbOgJSp+2+5CCLtmLwQxEV23kVPcC8k1DG3aVQ==",
       "dev": true
     },
     "node_modules/eslint-plugin-es": {

--- a/web/package.json
+++ b/web/package.json
@@ -54,7 +54,7 @@
     "eslint-config-standard": "^17.0.0",
     "eslint-config-standard-jsx": "^11.0.0",
     "eslint-config-standard-react": "^13.0.0",
-    "eslint-plugin-agama-i18n": "https://github.com/openSUSE/eslint-plugin-agama-i18n/tarball/v0.1.0",
+    "eslint-plugin-agama-i18n": "^0.1.0",
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-i18next": "^6.0.3",
     "eslint-plugin-import": "^2.22.1",


### PR DESCRIPTION
## Problem

- OBS cannot build the package properly if some NPM package is not from the official NPM registry

## Solution

- Publish the plugin at https://www.npmjs.com/package/eslint-plugin-agama-i18n
- Use it as a standard NPM package, that works fine in OBS

## Testing

- Tested manually
