### PR TITLE
Replace `async_std` with `tokio`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,7 +24,6 @@ dependencies = [
  "agama-lib",
  "agama-settings",
  "anyhow",
- "async-std",
  "clap",
  "console",
  "convert_case",
@@ -28,6 +36,8 @@ dependencies = [
  "serde_yaml",
  "tempdir",
  "thiserror",
+ "tokio",
+ "zbus",
 ]
 
 [[package]]
@@ -37,7 +47,6 @@ dependencies = [
  "agama-lib",
  "agama-locale-data",
  "anyhow",
- "async-std",
  "cidr",
  "futures",
  "log",
@@ -46,6 +55,7 @@ dependencies = [
  "simplelog",
  "systemd-journal-logger",
  "thiserror",
+ "tokio",
  "uuid",
  "zbus",
  "zbus_macros",
@@ -66,7 +76,6 @@ version = "1.0.0"
 dependencies = [
  "agama-settings",
  "anyhow",
- "async-std",
  "cidr",
  "curl",
  "futures",
@@ -77,6 +86,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tokio",
+ "tokio-stream",
  "zbus",
 ]
 
@@ -178,16 +189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "async-broadcast"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,47 +210,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-executor"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
-dependencies = [
- "async-lock",
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
-dependencies = [
- "async-lock",
- "autocfg",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "async-io"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,7 +225,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
 ]
 
@@ -308,33 +268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-attributes",
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "async-task"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +295,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -421,12 +369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
-
-[[package]]
 name = "bytecount"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +379,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
@@ -629,7 +577,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2",
+ "socket2 0.4.9",
  "winapi",
 ]
 
@@ -916,16 +864,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.6"
+name = "gimli"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "hashbrown"
@@ -1056,15 +998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
-name = "js-sys"
-version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "jsonschema"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,15 +1022,6 @@ dependencies = [
  "time",
  "url",
  "uuid",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -1196,6 +1120,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1315,6 +1250,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1273,15 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -1447,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1650,6 +1604,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1783,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,6 +1947,47 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2 0.5.4",
+ "tokio-macros",
+ "tracing",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "toml_datetime"
@@ -2142,82 +2153,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.26",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.26",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
-
-[[package]]
-name = "web-sys"
-version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "winapi"
@@ -2418,18 +2353,13 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "3.13.1"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3d77c9966c28321f1907f0b6c5a5561189d1f7311eea6d94180c6be9daab29"
+checksum = "31de390a2d872e4cd04edd71b425e29853f786dc99317ed72d73d6fcf5ebb948"
 dependencies = [
  "async-broadcast",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
  "async-process",
  "async-recursion",
- "async-task",
  "async-trait",
  "byteorder",
  "derivative",
@@ -2447,6 +2377,7 @@ dependencies = [
  "serde_repr",
  "sha1",
  "static_assertions",
+ "tokio",
  "tracing",
  "uds_windows",
  "winapi",
@@ -2458,24 +2389,23 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "3.13.1"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e341d12edaff644e539ccbbf7f161601294c9a84ed3d7e015da33155b435af"
+checksum = "41d1794a946878c0e807f55a397187c11fc7a038ba5d868e7db4f3bd7760bc9d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
  "syn 1.0.109",
- "winnow",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "2.5.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82441e6033be0a741157a72951a3e4957d519698f3a824439cc131c5ba77ac2a"
+checksum = "fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9"
 dependencies = [
  "serde",
  "static_assertions",
@@ -2484,23 +2414,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622cc473f10cef1b0d73b7b34a266be30ebdcfaea40ec297dd8cbda088f9f93c"
+checksum = "44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c"
 dependencies = [
  "byteorder",
  "enumflags2",
  "libc",
  "serde",
  "static_assertions",
+ "uuid",
  "zvariant_derive",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d9c1b57352c25b778257c661f3c4744b7cefb7fc09dd46909a153cce7773da2"
+checksum = "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -48,7 +48,6 @@ dependencies = [
  "agama-locale-data",
  "anyhow",
  "cidr",
- "futures",
  "log",
  "serde",
  "serde_yaml",
@@ -80,7 +79,6 @@ dependencies = [
  "cidr",
  "curl",
  "futures",
- "futures-util",
  "jsonschema",
  "log",
  "serde",
@@ -2424,7 +2422,6 @@ dependencies = [
  "libc",
  "serde",
  "static_assertions",
- "uuid",
  "zvariant_derive",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "systemd-journal-logger",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "uuid",
  "zbus",
  "zbus_macros",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "anyhow",
  "cidr",
  "curl",
- "futures",
+ "futures-util",
  "jsonschema",
  "log",
  "serde",
@@ -738,52 +738,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "futures"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-lite"
@@ -802,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -813,29 +777,26 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",

--- a/rust/agama-cli/Cargo.toml
+++ b/rust/agama-cli/Cargo.toml
@@ -22,8 +22,8 @@ log = "0.4"
 tempdir = "0.3"
 fs_extra = "1.3.0"
 nix = { version = "0.27.1", features = ["user"] }
-zbus = { version = "3.14.1", default-features = false, features = ["tokio", "uuid"] }
-tokio = { version = "1.33.0", features = ["tokio-macros", "macros", "rt-multi-thread"] }
+zbus = { version = "3", default-features = false, features = ["tokio"] }
+tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
 
 [[bin]]
 name = "agama"

--- a/rust/agama-cli/Cargo.toml
+++ b/rust/agama-cli/Cargo.toml
@@ -13,7 +13,6 @@ serde = { version = "1.0.152" }
 serde_json = "1.0.91"
 serde_yaml = "0.9.17"
 indicatif= "0.17.3"
-async-std = { version ="1.12.0", features = ["attributes"] }
 thiserror = "1.0.39"
 convert_case = "0.6.0"
 console = "0.15.7"
@@ -23,6 +22,8 @@ log = "0.4"
 tempdir = "0.3"
 fs_extra = "1.3.0"
 nix = { version = "0.27.1", features = ["user"] }
+zbus = { version = "3.14.1", default-features = false, features = ["tokio", "uuid"] }
+tokio = { version = "1.33.0", features = ["tokio-macros", "macros", "rt-multi-thread"] }
 
 [[bin]]
 name = "agama"

--- a/rust/agama-cli/src/main.rs
+++ b/rust/agama-cli/src/main.rs
@@ -13,7 +13,6 @@ use crate::error::CliError;
 use agama_lib::error::ServiceError;
 use agama_lib::manager::ManagerClient;
 use agama_lib::progress::ProgressMonitor;
-use tokio;
 use commands::Commands;
 use config::run as run_config_cmd;
 use logs::run as run_logs_cmd;
@@ -26,6 +25,7 @@ use std::{
     thread::sleep,
     time::Duration,
 };
+use tokio;
 
 #[derive(Parser)]
 #[command(name = "agama", version, about, long_about = None)]
@@ -40,7 +40,9 @@ struct Cli {
 
 async fn probe() -> anyhow::Result<()> {
     let another_manager = build_manager().await?;
-    let probe = tokio::spawn(async move { let _ = another_manager.probe().await; });
+    let probe = tokio::spawn(async move {
+        let _ = another_manager.probe().await;
+    });
     show_progress().await?;
 
     Ok(probe.await?)

--- a/rust/agama-dbus-server/Cargo.toml
+++ b/rust/agama-dbus-server/Cargo.toml
@@ -12,13 +12,12 @@ agama-lib = { path="../agama-lib" }
 log = "0.4"
 simplelog = "0.12.1"
 systemd-journal-logger = "1.0"
-zbus = { version = "3.7.0", default-features = false, features = ["tokio", "uuid"] }
-zbus_macros = "3.7.0"
+zbus = { version = "3", default-features = false, features = ["tokio"] }
+zbus_macros = "3"
 uuid = { version = "1.3.4", features = ["v4"] }
 thiserror = "1.0.40"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_yaml = "0.9.24"
-futures = "0.3.28"
 cidr = { version = "0.2.2", features = ["serde"] }
-tokio = { version = "1.33.0", features = ["tokio-macros", "macros", "rt-multi-thread"] }
+tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.14"

--- a/rust/agama-dbus-server/Cargo.toml
+++ b/rust/agama-dbus-server/Cargo.toml
@@ -21,3 +21,4 @@ serde_yaml = "0.9.24"
 futures = "0.3.28"
 cidr = { version = "0.2.2", features = ["serde"] }
 tokio = { version = "1.33.0", features = ["tokio-macros", "macros", "rt-multi-thread"] }
+tokio-stream = "0.1.14"

--- a/rust/agama-dbus-server/Cargo.toml
+++ b/rust/agama-dbus-server/Cargo.toml
@@ -12,12 +12,12 @@ agama-lib = { path="../agama-lib" }
 log = "0.4"
 simplelog = "0.12.1"
 systemd-journal-logger = "1.0"
-zbus = "3.7.0"
+zbus = { version = "3.7.0", default-features = false, features = ["tokio", "uuid"] }
 zbus_macros = "3.7.0"
-async-std = { version = "1.12.0", features = ["attributes"]}
 uuid = { version = "1.3.4", features = ["v4"] }
 thiserror = "1.0.40"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_yaml = "0.9.24"
 futures = "0.3.28"
 cidr = { version = "0.2.2", features = ["serde"] }
+tokio = { version = "1.33.0", features = ["tokio-macros", "macros", "rt-multi-thread"] }

--- a/rust/agama-dbus-server/src/main.rs
+++ b/rust/agama-dbus-server/src/main.rs
@@ -4,11 +4,12 @@ use agama_lib::connection_to;
 use anyhow::Context;
 use log::LevelFilter;
 use std::future::pending;
+use tokio;
 
 const ADDRESS: &str = "unix:path=/run/agama/bus";
 const SERVICE_NAME: &str = "org.opensuse.Agama1";
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // be smart with logging and log directly to journal if connected to it
     if systemd_journal_logger::connected_to_journal() {

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -185,7 +185,10 @@ impl Connection {
     ///
     /// * `actions`: sending-half of a channel to send actions.
     /// * `connection`: connection to expose over D-Bus.
-    pub fn new(actions: UnboundedSender<Action>, connection: Arc<Mutex<NetworkConnection>>) -> Self {
+    pub fn new(
+        actions: UnboundedSender<Action>,
+        connection: Arc<Mutex<NetworkConnection>>,
+    ) -> Self {
         Self {
             actions: Arc::new(Mutex::new(actions)),
             connection,
@@ -248,7 +251,10 @@ impl Match {
     ///
     /// * `actions`: sending-half of a channel to send actions.
     /// * `connection`: connection to expose over D-Bus.
-    pub fn new(actions: UnboundedSender<Action>, connection: Arc<Mutex<NetworkConnection>>) -> Self {
+    pub fn new(
+        actions: UnboundedSender<Action>,
+        connection: Arc<Mutex<NetworkConnection>>,
+    ) -> Self {
         Self {
             actions: Arc::new(Mutex::new(actions)),
             connection,
@@ -348,7 +354,10 @@ impl Wireless {
     ///
     /// * `actions`: sending-half of a channel to send actions.
     /// * `connection`: connection to expose over D-Bus.
-    pub fn new(actions: UnboundedSender<Action>, connection: Arc<Mutex<NetworkConnection>>) -> Self {
+    pub fn new(
+        actions: UnboundedSender<Action>,
+        connection: Arc<Mutex<NetworkConnection>>,
+    ) -> Self {
         Self {
             actions: Arc::new(Mutex::new(actions)),
             connection,
@@ -374,9 +383,7 @@ impl Wireless {
     ) -> zbus::fdo::Result<()> {
         let actions = self.actions.lock().await;
         let connection = NetworkConnection::Wireless(connection.clone());
-        actions
-            .send(Action::UpdateConnection(connection))
-            .unwrap();
+        actions.send(Action::UpdateConnection(connection)).unwrap();
         Ok(())
     }
 }

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -10,9 +10,9 @@ use crate::network::{
 };
 
 use agama_lib::network::types::SSID;
-use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
 use zbus::{
     dbus_interface,
     zvariant::{ObjectPath, OwnedObjectPath},

--- a/rust/agama-dbus-server/src/network/dbus/interfaces/ip_config.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces/ip_config.rs
@@ -8,10 +8,10 @@ use crate::network::{
     action::Action,
     model::{Connection as NetworkConnection, IpConfig, Ipv4Method, Ipv6Method},
 };
-use async_std::{channel::Sender, sync::Arc};
 use cidr::IpInet;
-use futures::lock::{MappedMutexGuard, Mutex, MutexGuard};
-use std::net::IpAddr;
+use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
+use std::{net::IpAddr, sync::Arc};
+use tokio::sync::mpsc::Sender;
 use zbus::dbus_interface;
 
 /// D-Bus interface for IPv4 and IPv6 settings
@@ -55,7 +55,7 @@ impl Ip {
 
 impl Ip {
     /// Returns the IpConfig struct.
-    async fn get_ip_config(&self) -> MappedMutexGuard<NetworkConnection, IpConfig> {
+    async fn get_ip_config(&self) -> MappedMutexGuard<IpConfig> {
         MutexGuard::map(self.get_connection().await, |c| c.ip_config_mut())
     }
 

--- a/rust/agama-dbus-server/src/network/dbus/interfaces/ip_config.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces/ip_config.rs
@@ -9,9 +9,9 @@ use crate::network::{
     model::{Connection as NetworkConnection, IpConfig, Ipv4Method, Ipv6Method},
 };
 use cidr::IpInet;
-use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
 use std::{net::IpAddr, sync::Arc};
 use tokio::sync::mpsc::Sender;
+use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
 use zbus::dbus_interface;
 
 /// D-Bus interface for IPv4 and IPv6 settings

--- a/rust/agama-dbus-server/src/network/dbus/interfaces/ip_config.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces/ip_config.rs
@@ -10,13 +10,13 @@ use crate::network::{
 };
 use cidr::IpInet;
 use std::{net::IpAddr, sync::Arc};
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
 use zbus::dbus_interface;
 
 /// D-Bus interface for IPv4 and IPv6 settings
 pub struct Ip {
-    actions: Arc<Mutex<Sender<Action>>>,
+    actions: Arc<Mutex<UnboundedSender<Action>>>,
     connection: Arc<Mutex<NetworkConnection>>,
 }
 
@@ -25,7 +25,7 @@ impl Ip {
     ///
     /// * `actions`: sending-half of a channel to send actions.
     /// * `connection`: connection to expose over D-Bus.
-    pub fn new(actions: Sender<Action>, connection: Arc<Mutex<NetworkConnection>>) -> Self {
+    pub fn new(actions: UnboundedSender<Action>, connection: Arc<Mutex<NetworkConnection>>) -> Self {
         Self {
             actions: Arc::new(Mutex::new(actions)),
             connection,
@@ -47,7 +47,6 @@ impl Ip {
         let actions = self.actions.lock().await;
         actions
             .send(Action::UpdateConnection(connection.clone()))
-            .await
             .unwrap();
         Ok(())
     }

--- a/rust/agama-dbus-server/src/network/dbus/interfaces/ip_config.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces/ip_config.rs
@@ -25,7 +25,10 @@ impl Ip {
     ///
     /// * `actions`: sending-half of a channel to send actions.
     /// * `connection`: connection to expose over D-Bus.
-    pub fn new(actions: UnboundedSender<Action>, connection: Arc<Mutex<NetworkConnection>>) -> Self {
+    pub fn new(
+        actions: UnboundedSender<Action>,
+        connection: Arc<Mutex<NetworkConnection>>,
+    ) -> Self {
         Self {
             actions: Arc::new(Mutex::new(actions)),
             connection,

--- a/rust/agama-dbus-server/src/network/dbus/service.rs
+++ b/rust/agama-dbus-server/src/network/dbus/service.rs
@@ -3,6 +3,7 @@
 //! This module defines a D-Bus service which exposes Agama's network configuration.
 use crate::network::{Adapter, NetworkSystem};
 use std::error::Error;
+use tokio;
 use zbus::Connection;
 
 /// Represents the Agama networking D-Bus service.
@@ -19,7 +20,7 @@ impl NetworkService {
         let connection = connection.clone();
         let mut network = NetworkSystem::new(connection.clone(), adapter);
 
-        async_std::task::spawn(async move {
+        tokio::spawn(async move {
             network
                 .setup()
                 .await

--- a/rust/agama-dbus-server/src/network/dbus/tree.rs
+++ b/rust/agama-dbus-server/src/network/dbus/tree.rs
@@ -1,11 +1,11 @@
 use agama_lib::error::ServiceError;
-use futures::lock::Mutex;
+use tokio::sync::Mutex;
 use zbus::zvariant::{ObjectPath, OwnedObjectPath};
 
 use crate::network::{action::Action, dbus::interfaces, model::*};
-use async_std::{channel::Sender, sync::Arc};
 use log;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::mpsc::Sender;
 
 const CONNECTIONS_PATH: &str = "/org/opensuse/Agama1/Network/connections";
 const DEVICES_PATH: &str = "/org/opensuse/Agama1/Network/devices";

--- a/rust/agama-dbus-server/src/network/dbus/tree.rs
+++ b/rust/agama-dbus-server/src/network/dbus/tree.rs
@@ -5,7 +5,7 @@ use zbus::zvariant::{ObjectPath, OwnedObjectPath};
 use crate::network::{action::Action, dbus::interfaces, model::*};
 use log;
 use std::{collections::HashMap, sync::Arc};
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::UnboundedSender;
 
 const CONNECTIONS_PATH: &str = "/org/opensuse/Agama1/Network/connections";
 const DEVICES_PATH: &str = "/org/opensuse/Agama1/Network/devices";
@@ -13,7 +13,7 @@ const DEVICES_PATH: &str = "/org/opensuse/Agama1/Network/devices";
 /// Handle the objects in the D-Bus tree for the network state
 pub struct Tree {
     connection: zbus::Connection,
-    actions: Sender<Action>,
+    actions: UnboundedSender<Action>,
     objects: Arc<Mutex<ObjectsRegistry>>,
 }
 
@@ -22,7 +22,7 @@ impl Tree {
     ///
     /// * `connection`: D-Bus connection to use.
     /// * `actions`: sending-half of a channel to send actions.
-    pub fn new(connection: zbus::Connection, actions: Sender<Action>) -> Self {
+    pub fn new(connection: zbus::Connection, actions: UnboundedSender<Action>) -> Self {
         Self {
             connection,
             actions,

--- a/rust/agama-dbus-server/src/network/nm/adapter.rs
+++ b/rust/agama-dbus-server/src/network/nm/adapter.rs
@@ -5,6 +5,7 @@ use crate::network::{
 };
 use agama_lib::error::ServiceError;
 use log;
+use tokio::{runtime::Handle, task};
 
 /// An adapter for NetworkManager
 pub struct NetworkManagerAdapter<'a> {
@@ -28,30 +29,34 @@ impl<'a> NetworkManagerAdapter<'a> {
 
 impl<'a> Adapter for NetworkManagerAdapter<'a> {
     fn read(&self) -> Result<NetworkState, Box<dyn std::error::Error>> {
-        async_std::task::block_on(async {
-            let devices = self.client.devices().await?;
-            let connections = self.client.connections().await?;
+        task::block_in_place(|| {
+            Handle::current().block_on(async {
+                let devices = self.client.devices().await?;
+                let connections = self.client.connections().await?;
 
-            Ok(NetworkState::new(devices, connections))
+                Ok(NetworkState::new(devices, connections))
+            })
         })
     }
 
     fn write(&self, network: &NetworkState) -> Result<(), Box<dyn std::error::Error>> {
         // By now, traits do not support async functions. Using `task::block_on` allows
         // to use 'await'.
-        async_std::task::block_on(async {
-            for conn in &network.connections {
-                if !Self::is_writable(conn) {
-                    continue;
-                }
-                if conn.is_removed() {
-                    if let Err(e) = self.client.remove_connection(conn.uuid()).await {
-                        log::error!("Could not remove the connection {}: {}", conn.id(), e);
+        task::block_in_place(|| {
+            Handle::current().block_on(async {
+                for conn in &network.connections {
+                    if !Self::is_writable(conn) {
+                        continue;
                     }
-                } else if let Err(e) = self.client.add_or_update_connection(conn).await {
-                    log::error!("Could not add/update the connection {}: {}", conn.id(), e);
+                    if conn.is_removed() {
+                        if let Err(e) = self.client.remove_connection(conn.uuid()).await {
+                            log::error!("Could not remove the connection {}: {}", conn.id(), e);
+                        }
+                    } else if let Err(e) = self.client.add_or_update_connection(conn).await {
+                        log::error!("Could not add/update the connection {}: {}", conn.id(), e);
+                    }
                 }
-            }
+            })
         });
         // FIXME: indicate which connections could not be written.
         Ok(())

--- a/rust/agama-dbus-server/src/network/system.rs
+++ b/rust/agama-dbus-server/src/network/system.rs
@@ -1,14 +1,14 @@
 use crate::network::{dbus::Tree, model::Connection, Action, Adapter, NetworkState};
 use std::error::Error;
-use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 /// Represents the network system using holding the state and setting up the D-Bus tree.
 pub struct NetworkSystem<T: Adapter> {
     /// Network state
     pub state: NetworkState,
     /// Side of the channel to send actions.
-    actions_tx: Sender<Action>,
-    actions_rx: Receiver<Action>,
+    actions_tx: UnboundedSender<Action>,
+    actions_rx: UnboundedReceiver<Action>,
     tree: Tree,
     /// Adapter to read/write the network state.
     adapter: T,
@@ -16,7 +16,7 @@ pub struct NetworkSystem<T: Adapter> {
 
 impl<T: Adapter> NetworkSystem<T> {
     pub fn new(conn: zbus::Connection, adapter: T) -> Self {
-        let (actions_tx, actions_rx) = mpsc::channel(100);
+        let (actions_tx, actions_rx) = mpsc::unbounded_channel();
         let tree = Tree::new(conn, actions_tx.clone());
         Self {
             state: NetworkState::default(),
@@ -34,9 +34,10 @@ impl<T: Adapter> NetworkSystem<T> {
         Ok(())
     }
 
-    /// Returns a clone of the [Sender](https://doc.rust-lang.org/std/sync/mpsc/struct.Sender.html) to execute
-    /// [actions](Action).
-    pub fn actions_tx(&self) -> Sender<Action> {
+    /// Returns a clone of the
+    /// [UnboundedSender](https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.UnboundedSender.html)
+    /// to execute [actions](Action).
+    pub fn actions_tx(&self) -> UnboundedSender<Action> {
         self.actions_tx.clone()
     }
 

--- a/rust/agama-dbus-server/tests/common/mod.rs
+++ b/rust/agama-dbus-server/tests/common/mod.rs
@@ -3,7 +3,7 @@ use std::{
     error::Error,
     future::Future,
     process::{Child, Command},
-    time::Duration
+    time::Duration,
 };
 use tokio;
 use tokio_stream::StreamExt;

--- a/rust/agama-dbus-server/tests/common/mod.rs
+++ b/rust/agama-dbus-server/tests/common/mod.rs
@@ -1,9 +1,12 @@
 use agama_lib::error::ServiceError;
-use futures::stream::StreamExt;
-use futures::Future;
-use std::error::Error;
-use std::process::{Child, Command};
-use std::time::Duration;
+use std::{
+    error::Error,
+    future::Future,
+    process::{Child, Command},
+    time::Duration
+};
+use tokio;
+use tokio_stream::StreamExt;
 use uuid::Uuid;
 use zbus::{MatchRule, MessageStream, MessageType};
 
@@ -76,7 +79,7 @@ impl DBusServer<Started> {
 
         let mut stream = NameOwnerChangedStream::for_connection(&connection).await?;
         let cloned = connection.clone();
-        async_std::task::spawn(async move {
+        tokio::spawn(async move {
             cloned
                 .request_name(DBUS_SERVICE)
                 .await
@@ -136,7 +139,7 @@ where
                 }
                 retry = retry + 1;
                 let wait_time = Duration::from_millis(INTERVAL);
-                async_std::task::sleep(wait_time).await;
+                tokio::time::sleep(wait_time).await;
             }
         }
     }

--- a/rust/agama-dbus-server/tests/network.rs
+++ b/rust/agama-dbus-server/tests/network.rs
@@ -7,9 +7,9 @@ use agama_dbus_server::network::{
     Adapter, NetworkService, NetworkState,
 };
 use agama_lib::network::{settings, types::DeviceType, NetworkClient};
-use async_std::test;
 use cidr::IpInet;
 use std::error::Error;
+use tokio::test;
 
 #[derive(Default)]
 pub struct NetworkTestAdapter(network::NetworkState);

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -11,13 +11,12 @@ anyhow = "1.0"
 cidr = { version = "0.2.2", features = ["serde"] }
 curl = { version = "0.4.44", features = ["protocol-ftp"] }
 futures = "0.3.27"
-futures-util = "0.3.27"
 jsonschema = { version = "0.16.1", default-features = false }
 log = "0.4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.94"
 tempfile = "3.4.0"
 thiserror = "1.0.39"
-tokio = "1.33.0"
+tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.14"
-zbus = { version = "3.7.0", features = ["uuid", "tokio"], default-features = false }
+zbus = { version = "3", default-features = false, features = ["tokio"] }

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 agama-settings = { path="../agama-settings" }
 anyhow = "1.0"
-async-std = "1.12.0"
 cidr = { version = "0.2.2", features = ["serde"] }
 curl = { version = "0.4.44", features = ["protocol-ftp"] }
 futures = "0.3.27"
@@ -19,4 +18,6 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.94"
 tempfile = "3.4.0"
 thiserror = "1.0.39"
-zbus = "3.7.0"
+tokio = "1.33.0"
+tokio-stream = "0.1.14"
+zbus = { version = "3.7.0", features = ["uuid", "tokio"], default-features = false }

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -10,7 +10,7 @@ agama-settings = { path="../agama-settings" }
 anyhow = "1.0"
 cidr = { version = "0.2.2", features = ["serde"] }
 curl = { version = "0.4.44", features = ["protocol-ftp"] }
-futures = "0.3.27"
+futures-util = "0.3.29"
 jsonschema = { version = "0.16.1", default-features = false }
 log = "0.4"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/rust/agama-lib/src/manager.rs
+++ b/rust/agama-lib/src/manager.rs
@@ -4,7 +4,7 @@ use crate::{
     progress::Progress,
     proxies::{ManagerProxy, ProgressProxy},
 };
-use futures_util::StreamExt;
+use tokio_stream::StreamExt;
 use zbus::Connection;
 
 /// D-Bus client for the manager service

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -2,7 +2,7 @@ use super::proxies::{ConnectionProxy, ConnectionsProxy, IPProxy, MatchProxy, Wir
 use super::settings::{MatchSettings, NetworkConnection, WirelessSettings};
 use super::types::SSID;
 use crate::error::ServiceError;
-use async_std::stream::StreamExt;
+use tokio_stream::StreamExt;
 use zbus::zvariant::OwnedObjectPath;
 use zbus::Connection;
 

--- a/rust/agama-lib/src/progress.rs
+++ b/rust/agama-lib/src/progress.rs
@@ -6,7 +6,7 @@
 //!
 //! ```no_run
 //! # use agama_lib::progress::{Progress, ProgressMonitor, ProgressPresenter};
-//! # use async_std::task::block_on;
+//! # use tokio::{runtime::Handle, task};
 //! # use zbus;
 //!
 //! // Custom presenter
@@ -37,9 +37,11 @@
 //!     }
 //! }
 //!
-//! let connection = block_on(zbus::Connection::system()).unwrap();
-//! let mut monitor = block_on(ProgressMonitor::new(connection)).unwrap();
-//! monitor.run(SimplePresenter {});
+//! async fn run_monitor() {
+//!   let connection = zbus::Connection::system().await.unwrap();
+//!   let mut monitor = ProgressMonitor::new(connection).await.unwrap();
+//!   monitor.run(SimplePresenter {});
+//!}
 //! ```
 
 use crate::error::ServiceError;

--- a/rust/agama-lib/src/progress.rs
+++ b/rust/agama-lib/src/progress.rs
@@ -46,7 +46,7 @@
 
 use crate::error::ServiceError;
 use crate::proxies::ProgressProxy;
-use tokio_stream::{StreamMap, StreamExt};
+use tokio_stream::{StreamExt, StreamMap};
 use zbus::Connection;
 
 /// Represents the progress for an Agama service.

--- a/rust/agama-lib/src/storage/client.rs
+++ b/rust/agama-lib/src/storage/client.rs
@@ -3,7 +3,7 @@
 use super::proxies::{BlockDeviceProxy, ProposalCalculatorProxy, ProposalProxy, Storage1Proxy};
 use super::StorageSettings;
 use crate::error::ServiceError;
-use futures::future::join_all;
+use futures_util::future::join_all;
 use serde::Serialize;
 use std::collections::HashMap;
 use zbus::zvariant::OwnedObjectPath;


### PR DESCRIPTION
Regarding async/await, Rust does not endorse a runtime. There are different alternatives, but the most popular are [tokio](https://tokio.rs/), [async-std](https://github.com/async-rs/async-std) and [smol](https://github.com/smol-rs/smol). 

At the beginning of this project, we chose `async-std` because it was the default for [zbus](https://github.com/dbus2/zbus/). However, zbus offers [support for Tokio](https://docs.rs/zbus/latest/zbus/#special-tokio-support).

Taking into account that Tokio is the most used runtime in the Rust ecosystem, I am considering whether we should make the switch.

This pull request adapts the code to replace `async-std` with `tokio`. Sure, it deserves some discussion first, so I am opening it as a draft.

## Testing

In addition to the existing tests (including CI), I am building an  [agama-live](https://build.opensuse.org/package/show/home:IGonzalezSosa:branches:systemsmanagement:Agama:Staging/agama-cli) including the code in this `tokio` branch.