### PR TITLE
fix the latest change when /etc/agama.yaml can be missing

### DIFF
--- a/service/lib/agama/config_reader.rb
+++ b/service/lib/agama/config_reader.rb
@@ -148,7 +148,7 @@ module Agama
       paths.uniq! { |f| File.basename(f) }
       # Sort files lexicographic
       paths.sort_by! { |f| File.basename(f) }
-      paths.prepend(default_path)
+      paths.prepend(default_path) if File.exist?(default_path)
 
       paths
     end


### PR DESCRIPTION
## Problem

The latest change cause crash in staging when there is no user defined /etc/agama.yaml


## Solution

Fix it.