### PR TITLE
Merge back the product translations

### DIFF
--- a/.github/workflows/product_translations/merge_po
+++ b/.github/workflows/product_translations/merge_po
@@ -1,0 +1,166 @@
+#! /usr/bin/node
+
+/*
+This script merges the product translations back to the product YAML files.
+
+Requirements: NodeJS, run "npm ci" to install the needed NPM packages
+
+Usage:
+
+  merge_po <translations_dir> <products_dir>
+*/
+
+const fs = require("fs");
+const process = require("process");
+const path = require("path");
+
+const { parseDocument } = require("yaml");
+const { globSync } = require("glob");
+const gettextParser = require("gettext-parser");
+
+/**
+ * Translation object with original text, its translations and the locale name.
+ */
+class Translation {
+  msgid;
+  msgstr;
+  locale;
+
+  /**
+   * Constructor
+   * @param {string} msgid - the original text
+   * @param {string} msgstr - the translation
+   * @param {string} locale - the locale
+   */
+  constructor(msgid, msgstr, locale) {
+    this.msgid = msgid;
+    this.msgstr = msgstr;
+    this.locale = locale;
+  }
+
+  /**
+   * Read all translations (PO files) in the specified directory
+   * @param {string} dir - input directory for reading the the PO files
+   * @returns {Translation[]} list of found translations
+   */
+  static read(dir) {
+    const ret = [];
+    // sort the files so the translations in the YAML files are also sorted
+    const files = globSync(dir + "/*.po").sort();
+
+    files.forEach(f => {
+      console.log(`Reading ${path.basename(f)}`);
+
+      const locale = path.basename(f, ".po");
+      const input = fs.readFileSync(f, "utf-8");
+      const po = gettextParser.po.parse(input);
+
+      // translations for the default (empty) context
+      const translations = po.translations[""];
+
+      Object.values(translations).forEach(t => {
+        if (t.msgid !== "") {
+          ret.push(new Translation(t.msgid, t.msgstr[0], locale));
+        }
+      });
+    });
+
+    return ret;
+  }
+}
+
+/**
+ * YAML product file
+ */
+class YamlProduct {
+  file;
+  document;
+
+  /**
+   * Constructor
+   * @param {string} file - the path to the YAML file
+   */
+  constructor(file) {
+    this.file = file;
+    // parse the file
+    const data = fs.readFileSync(this.file, "utf-8");
+    this.document = parseDocument(data);
+  }
+
+  /**
+   * Read all product definitions (YAML files) in the specified directory
+   * @param {string} dir - input directory for reading the the PO files
+   * @returns {YamlProduct[]} all found products
+   */
+  static read(dir) {
+    const ret = [];
+    const files = globSync(dir + "/*.y{a,}ml");
+    return files.map(f => {
+      console.log(`Reading ${path.basename(f)}`);
+      return new YamlProduct(f);
+    });
+  }
+
+  /**
+   * Find the matching translations in the list and add them to the YAML document
+   * @param {Translation[]} translations
+   */
+  addTranslations(translations) {
+    const description = this.document.get("description");
+    const newTranslations = {};
+
+    translations.forEach(t => {
+      if (t.msgid === description) {
+        newTranslations[t.locale] = t.msgstr;
+      }
+    });
+
+    // add or update the translations depending on whether they already exist
+    if (!this.document.has("translations")) {
+       this.document.add({key: "translations", value: { description: newTranslations}});
+    } else {
+      const trans = this.document.get("translations");
+      if (!trans) {
+        this.document.set("translations", { description: newTranslations});
+      } else {
+        trans.set("description", newTranslations);
+      }
+    }
+  }
+
+  /**
+   * Convert back the parsed YAML to String
+   * @returns {string} new update YAML data
+   */
+  dump() {
+    return this.document.toString();
+  }
+
+  /**
+   * Save the current YAML data back to the file, the original content is
+   * overwritten.
+   */
+  save() {
+    console.log(`Writing ${path.basename(this.file)}`);
+    fs.writeFileSync(this.file, this.dump(), "utf-8");
+  }
+}
+
+// script arguments (the first arg is executor path ("/usr/bin/node"),
+// the second is name of this script)
+const [, , translations_dir, products_dir] = process.argv;
+
+if (!translations_dir || !products_dir) {
+  console.log("ERROR: missing argument");
+  process.exit(1);
+}
+
+// read all YAML products and all translations
+const translations = Translation.read(translations_dir);
+const products = YamlProduct.read(products_dir);
+
+// inject the translations to the products and save the changes
+products.forEach(p => {
+  p.addTranslations(translations);
+  p.save();
+});

--- a/.github/workflows/product_translations/package-lock.json
+++ b/.github/workflows/product_translations/package-lock.json
@@ -6,7 +6,35 @@
     "": {
       "devDependencies": {
         "gettext-parser": "^7.0.1",
+        "glob": "^10.3.10",
         "yaml": "^2.3.4"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/abort-controller": {
@@ -20,6 +48,36 @@
       "engines": {
         "node": ">=6.5"
       }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -40,6 +98,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
     },
     "node_modules/buffer": {
       "version": "6.0.3",
@@ -65,6 +132,24 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -73,6 +158,32 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/encoding": {
       "version": "0.1.13",
@@ -101,6 +212,22 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gettext-parser": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-7.0.1.tgz",
@@ -111,6 +238,28 @@
         "encoding": "^0.1.13",
         "readable-stream": "^4.3.0",
         "safe-buffer": "^5.2.1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/iconv-lite": {
@@ -144,6 +293,97 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -196,6 +436,39 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -203,6 +476,208 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yaml": {

--- a/.github/workflows/product_translations/package.json
+++ b/.github/workflows/product_translations/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "gettext-parser": "^7.0.1",
+    "glob": "^10.3.10",
     "yaml": "^2.3.4"
   }
 }

--- a/.github/workflows/product_translations/products_pot
+++ b/.github/workflows/product_translations/products_pot
@@ -51,7 +51,7 @@ class POFile {
    */
   timestamp() {
     const date = new Date();
-    return date.getUTCFullYear() + "-" + date.getUTCMonth() + "-" +
+    return date.getUTCFullYear() + "-" + (date.getUTCMonth() + 1) + "-" +
       date.getUTCDate() + " " + date.getUTCHours() + ":" + date.getUTCMinutes() +
       "+0000";
   }

--- a/.github/workflows/weblate-merge-products-po.yml
+++ b/.github/workflows/weblate-merge-products-po.yml
@@ -1,9 +1,9 @@
-name: Weblate Merge PO
+name: Weblate Merge Product PO
 
 on:
   schedule:
-    # run every Monday at 2:42AM UTC
-    - cron: "42 2 * * 0"
+    # run every Monday at 2:45AM UTC
+    - cron: "45 2 * * 0"
 
   # allow running manually
   workflow_dispatch:
@@ -33,7 +33,7 @@ jobs:
             zypper --non-interactive --gpg-auto-import-keys ref
 
       - name: Install tools
-        run: zypper --non-interactive install --no-recommends gh git gettext-tools python3-langtable
+        run: zypper --non-interactive install --no-recommends gh git gettext-tools npm-default
 
       - name: Configure Git
         run: |
@@ -50,62 +50,57 @@ jobs:
         with:
           path: agama-weblate
           repository: openSUSE/agama-weblate
-
-      - name: Update PO files
-        working-directory: ./agama
+  
+      - name: Validate the product PO files
+        working-directory: ./agama-weblate
+        run:  ls products/*.po | xargs -n1 msgfmt --check-format -o /dev/null
+  
+      - name: Install NPM packages
+        working-directory: ./agama/.github/workflows/product_translations
+        run:  npm ci
+  
+      - name: Update product files with translations
+        env:
+          NODE_PATH: ./agama/.github/workflows/product_translations
         run: |
-          mkdir -p web/po
-          # delete the current translations
-          find web/po -name '*.po' -exec git rm '{}' ';'
+          ${NODE_PATH}/merge_po agama-weblate/products agama/products.d
 
-          # copy the new ones
-          mkdir -p web/po
-          cp -a ../agama-weblate/web/*.po web/po
-          git add web/po/*.po
-
-      - name: Validate the PO files
-        working-directory: ./agama
-        run:  ls web/po/*.po | xargs -n1 msgfmt --check-format -o /dev/null
-
-      # any changes besides the timestamps in the PO files?
       - name: Check changes
         id: check_changes
         working-directory: ./agama
         run: |
-          git diff --staged --ignore-matching-lines="POT-Creation-Date:" \
-            --ignore-matching-lines="PO-Revision-Date:" web/po > po.diff
+          git diff products.d > po.diff
 
           if [ -s po.diff ]; then
-            echo "PO files updated"
+            echo "Product files updated"
             # this is an Output Parameter
             # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
-            echo "po_updated=true" >> $GITHUB_OUTPUT
+            echo "products_updated=true" >> $GITHUB_OUTPUT
           else
-            echo "PO files unchanged"
-            echo "po_updated=false" >> $GITHUB_OUTPUT
+            echo "Product files unchanged"
+            echo "products_updated=false" >> $GITHUB_OUTPUT
           fi
 
           rm po.diff
 
-      - name: Push updated PO files
+      - name: Push updated product files
         # run only when a PO file has been updated
-        if: steps.check_changes.outputs.po_updated == 'true'
+        if: steps.check_changes.outputs.products_updated == 'true'
         working-directory: ./agama
         run: |
-          web/share/update-manifest.py web/src/manifest.json
           # use a unique branch to avoid possible conflicts with already existing branches
-          git checkout -b "po_merge_${GITHUB_RUN_ID}"
-          git commit -a -m "Update web PO files"$'\n\n'"Agama-weblate commit: `git -C ../agama-weblate rev-parse HEAD`"
-          git push origin "po_merge_${GITHUB_RUN_ID}"
+          git checkout -b "products_po_merge_${GITHUB_RUN_ID}"
+          git commit -a -m "Update translations in the product files"$'\n\n'"Agama-weblate commit: `git -C ../agama-weblate rev-parse HEAD`"
+          git push origin "products_po_merge_${GITHUB_RUN_ID}"
 
       - name: Create pull request
         # run only when a PO file has been updated
-        if: steps.check_changes.outputs.po_updated == 'true'
+        if: steps.check_changes.outputs.products_updated == 'true'
         working-directory: ./agama
         run: |
-          gh pr create -B master -H "po_merge_${GITHUB_RUN_ID}" \
+          gh pr create -B master -H "products_po_merge_${GITHUB_RUN_ID}" \
             --label translations --label bot \
-            --title "Update web PO files" \
-            --body "Updating the web translation files from the agama-weblate repository"
+            --title "Update translations in the product files" \
+            --body "Updating the product translations from the agama-weblate repository"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/products.d/ALP-Dolomite.yaml
+++ b/products.d/ALP-Dolomite.yaml
@@ -1,8 +1,14 @@
 id: ALP-Dolomite
 name: SUSE ALP Dolomite
+# ------------------------------------------------------------------------------
+# WARNING: When changing the product description delete the translations located
+# at the at translations/description key below to avoid using obsolete
+# translations!!
+# ------------------------------------------------------------------------------
 description: 'SUSE ALP Dolomite is a minimum immutable OS core, focused on
   security to provide the bare minimum to run workloads and services as
   containers or virtual machines.'
+translations:
 software:
   installation_repositories:
     - url: https://updates.suse.com/SUSE/Products/ALP-Dolomite/1.0/x86_64/product/

--- a/products.d/leap16.yaml
+++ b/products.d/leap16.yaml
@@ -1,7 +1,14 @@
 id: Leap16
 name: openSUSE Leap 16.0
 archs: x86_64,aarch64
-description: '[Experimental project] openSUSE Leap 16 is built on top of the next generation Adaptable Linux Platform (ALP) from SUSE.'
+# ------------------------------------------------------------------------------
+# WARNING: When changing the product description delete the translations located
+# at the at translations/description key below to avoid using obsolete
+# translations!!
+# ------------------------------------------------------------------------------
+description: '[Experimental project] openSUSE Leap 16 is built on top of the
+  next generation Adaptable Linux Platform (ALP) from SUSE.'
+translations:
 software:
   installation_repositories:
     - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/images/repo/Leap-16.0-x86_64-Media1/

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -1,9 +1,15 @@
 id: Tumbleweed
 name: openSUSE Tumbleweed
-description: 'The Tumbleweed distribution is a pure rolling release version
-  of openSUSE containing the latest "stable" versions of all software
-  instead of relying on rigid periodic release cycles. The project does
-  this for users that want the newest stable software.'
+# ------------------------------------------------------------------------------
+# WARNING: When changing the product description delete the translations located
+# at the at translations/description key below to avoid using obsolete
+# translations!!
+# ------------------------------------------------------------------------------
+description: 'The Tumbleweed distribution is a pure rolling release version of
+  openSUSE containing the latest "stable" versions of all software instead of
+  relying on rigid periodic release cycles. The project does this for users that
+  want the newest stable software.'
+translations:
 software:
   installation_repositories:
     - url: https://download.opensuse.org/tumbleweed/repo/oss/


### PR DESCRIPTION
## Problem

- The product translations need to be merged back to the original YAML files
- We cannot store the translations in Agama because in theory there might be external (3rd party) product definitions so the translations needs to be included in the product YAML file
- Related to https://github.com/openSUSE/agama/pull/851

## Solution

- Read the translations from the PO files and and merge them back to the original YAML product files
- Implement a GitHub Action which regularly opens a pull request with updated translations (similar to the current solution with the web frontend translations)

## Notes

- Originally I wanted to use keys like `description-cs`, `description-de`,...  for the translations, but then the translations could be scattered over the whole file (the order is not guaranteed or forced)
- So use a new `translations` key with a reference to the original key:
  ```yaml
  description: "Original description ...."
  translations:
    description:
      cs: "Czech translation..."
      de: "German translation ..."
      es: "Spanish translation ..."
  ```
  This also allows translating some other keys if needed in the future.
- When changing the original description the translations need to be manually deleted because they would not match the original text anymore. If we forget that the next run of this GitHub Action will remove them anyway (or update with the new translations if they are already available) . So accidental invalid translations should not stay here for too long.

## Testing

- Tested manually with provided [Czech product translations](https://github.com/openSUSE/agama-weblate/blob/e8e766a746f8e16d30be97bd90dd4acce04e8a31/products/cs.po)
- See a testing [GitHub Action run](https://github.com/lslezak/agama/actions/runs/6795729562/job/18474362818)
- And the [PR created](https://github.com/lslezak/agama/pull/3/files) with the new translations 