### PR TITLE
Use translated product descriptions in the backend

### DIFF
--- a/service/lib/agama/ui_locale.rb
+++ b/service/lib/agama/ui_locale.rb
@@ -47,7 +47,7 @@ module Agama
     def change_locale(locale)
       # TODO: check if we can use UTF-8 everywhere including strange arch consoles
       Yast::WFM.SetLanguage(locale, "UTF-8")
-      # explicitelly set ENV to get localization also from libraries like libstorage
+      # explicitly set ENV to get localization also from libraries like libstorage
       ENV["LANG"] = locale + ".UTF-8"
       log.info "set yast language to #{locale}"
       # explicit call to textdomain to force fast gettext change of language ASAP

--- a/service/test/agama/dbus/software/manager_test.rb
+++ b/service/test/agama/dbus/software/manager_test.rb
@@ -140,4 +140,68 @@ describe Agama::DBus::Software::Manager do
       expect(installed).to eq(true)
     end
   end
+
+  describe "#available_base_products" do
+    # testing product with translations
+    products = {
+      "Tumbleweed" => {
+        "name"         => "openSUSE Tumbleweed",
+        "description"  => "Original description",
+        "translations" => {
+          "description" => {
+            "cs" => "Czech translation",
+            "es" => "Spanish translation"
+          }
+        }
+      }
+    }
+
+    it "returns product ID and name" do
+      expect(backend).to receive(:products).and_return(products)
+
+      product = subject.available_base_products.first
+      expect(product[0]).to eq("Tumbleweed")
+      expect(product[1]).to eq("openSUSE Tumbleweed")
+    end
+
+    it "returns untranslated description when the language is not set" do
+      allow(ENV).to receive(:[]).with("LANG").and_return(nil)
+      expect(backend).to receive(:products).and_return(products)
+
+      product = subject.available_base_products.first
+      expect(product[2]["description"]).to eq("Original description")
+    end
+
+    it "returns Czech translation if locale is \"cs_CZ.UTF-8\"" do
+      allow(ENV).to receive(:[]).with("LANG").and_return("cs_CZ.UTF-8")
+      expect(backend).to receive(:products).and_return(products)
+
+      product = subject.available_base_products.first
+      expect(product[2]["description"]).to eq("Czech translation")
+    end
+
+    it "returns Czech translation if locale is \"cs\"" do
+      allow(ENV).to receive(:[]).with("LANG").and_return("cs")
+      expect(backend).to receive(:products).and_return(products)
+
+      product = subject.available_base_products.first
+      expect(product[2]["description"]).to eq("Czech translation")
+    end
+
+    it "return untranslated description when translation is not available" do
+      allow(ENV).to receive(:[]).with("LANG").and_return("cs_CZ.UTF-8")
+
+      # testing product without translations
+      untranslated = {
+        "Tumbleweed" => {
+          "name"        => "openSUSE Tumbleweed",
+          "description" => "Original description"
+        }
+      }
+      expect(backend).to receive(:products).and_return(untranslated)
+
+      product = subject.available_base_products.first
+      expect(product[2]["description"]).to eq("Original description")
+    end
+  end
 end


### PR DESCRIPTION
## Problem

- Return the translated product description from the backend
- Related to https://github.com/openSUSE/agama/pull/851

## Solution

- Find the translation matching the current locale
- When the translation is not available it returns the original (untranslated) description

## Notes

- For some reason when changing the language in the web UI it is not propagated to the Software service. But propagating to the Storage and Manager services works fine. :thinking: 
- This need some more debugging :lady_beetle: 

## Testing

- Added a new unit test
- Tested manually (with a manually patched Software service switched explicitly to the Czech language, see the note above)
