### PR TITLE
CI integration test - fixed schedule, the time is UTC

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -2,8 +2,8 @@ name: "CI - Integration Tests"
 
 on:
   schedule:
-    # at 10:50 every day from Monday to Friday
-    - cron: "50 10 * * 1-5"
+    # at 9:50 UTC every day from Monday to Friday
+    - cron: "50 9 * * 1-5"
 
   # allow running manually
   workflow_dispatch:


### PR DESCRIPTION
## Problem

- The scheduled run should happen before the daily call, unfortunately I forgot that the specified time is UTC


## Solution

- Use the correct UTC time :smile: 