### PR TITLE
Pass the changed language to the Software service and to libzypp

### DIFF
--- a/service/lib/agama/dbus/manager_service.rb
+++ b/service/lib/agama/dbus/manager_service.rb
@@ -71,11 +71,11 @@ module Agama
       # @note The service runs its startup phase
       def start
         setup_cockpit
+        export
         # We need locale for data from users
         locale_client = Clients::Locale.new
         # TODO: test if we need to pass block with additional actions
         @ui_locale = UILocale.new(locale_client)
-        export
         manager.on_progress_change { dispatch } # make single thread more responsive
         manager.startup_phase
       end

--- a/service/lib/agama/dbus/software_service.rb
+++ b/service/lib/agama/dbus/software_service.rb
@@ -55,6 +55,8 @@ module Agama
 
       # Starts software service. It does more then just #export method.
       def start
+        # for some reason the the "export" method must be called before
+        # registering the language change callback to work properly
         export
         locale_client = Clients::Locale.new
         @ui_locale = UILocale.new(locale_client) do |locale|

--- a/service/lib/agama/dbus/storage_service.rb
+++ b/service/lib/agama/dbus/storage_service.rb
@@ -52,10 +52,10 @@ module Agama
 
       # Starts storage service. It does more then just #export method.
       def start
+        export
         locale_client = Clients::Locale.new
         # TODO: test if we need to pass block with additional actions
         @ui_locale = UILocale.new(locale_client)
-        export
       end
 
       # Exports the storage proposal object through the D-Bus service

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -2,7 +2,7 @@
 Thu Nov 16 16:27:37 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Software service - correctly change the locale, pass the changed
-  locale to libzypp
+  locale to libzypp (gh#openSUSE/agama#875).
 
 -------------------------------------------------------------------
 Wed Nov 15 12:31:10 UTC 2023 - José Iván López González <jlopez@suse.com>

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 16 16:27:37 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Software service - correctly change the locale, pass the changed
+  locale to libzypp
+
+-------------------------------------------------------------------
 Wed Nov 15 12:31:10 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Add D-Bus API for registering a product (gh#openSUSE/agama#869).


### PR DESCRIPTION
## Problem

When changing the display language in the web frontend the change is not propagated to the Software service. From the `y2log`:
```
2023-11-16 09:36:22 <1> localhost.localdomain(1708) [Ruby] agama/ui_locale.rb(change_locale):52 set yast language to es_ES
2023-11-16 09:36:22 <1> localhost.localdomain(1710) [Ruby] agama/ui_locale.rb(change_locale):52 set yast language to es_ES
```

So the [change_locale callback](https://github.com/openSUSE/agama/blob/e6e6e6bb6f270dfc1315700683df4a5ee00caa3c/service/lib/agama/ui_locale.rb#L52) was called only twice. According to the PID numbers only for the Manager and Storage service, not for the `Software` service.

## Solution

Just calling the `export` function before adding the language change callback in the Software service helped.

But actually I'm not sure whether this is the right fix. The same order is used in the Manager and Storage services where it works fine. Maybe there is some race condition and moving the code earlier/later just accidentally removed that collision and the problem is still there. :thinking:

(I updated the order also in the Storage and Manager service so it is consistent.)

With the "fix" the language change callback is correctly called triple times with all services (including the Software service).
```
2023-11-16 09:46:46 <1> localhost.localdomain(2765) [Ruby] agama/ui_locale.rb(change_locale):52 set yast language to es_ES
2023-11-16 09:46:46 <1> localhost.localdomain(2767) [Ruby] agama/ui_locale.rb(change_locale):52 set yast language to es_ES
...
2023-11-16 09:46:46 <1> localhost.localdomain(2771) [Ruby] agama/ui_locale.rb(change_locale):52 set yast language to es_ES
```

## Additional Fix

In the language change callback I added code which forwards the change also to libzypp. With this fix we can also display localized pattern names and descriptions. See the screenshot below.

But it still needs some improvement, libzypp uses the locale set at the repository refresh time, if the language is changed later then it is not reflected. It only works after manually changing the product to install which reloads the repository again.

But that's a different problem reported in #859. This fix at least proves that we can display also translated patterns, it's rather just a proof of concept.

## Testing

- Tested manually

## Screenshots

I tested the pattern selector with the Spanish language.

*Note: Some texts are not translated, but that is not Agama fault, the translations come from the package repository.*

![patterns-spanish](https://github.com/openSUSE/agama/assets/907998/018d71bc-e5d8-4ada-9842-3e7066703601)

