### PR TITLE
Update Agama service dependencies

### DIFF
--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    agama (3)
+    agama (5)
       cfa (~> 1.0.2)
       cfa_grub2 (~> 2.0.0)
       cheetah (~> 1.0.0)
       eventmachine (~> 1.2.7)
-      fast_gettext (~> 2.2.0)
-      nokogiri (~> 1.13.1)
+      fast_gettext (~> 2.3.0)
+      nokogiri (~> 1.15.4)
       rexml (~> 3.2.5)
       ruby-dbus (>= 0.23.1, < 1.0)
 
@@ -25,14 +25,12 @@ GEM
     diff-lcs (1.5.0)
     docile (1.4.0)
     eventmachine (1.2.7)
-    fast_gettext (2.2.0)
-    mini_portile2 (2.8.4)
-    nokogiri (1.13.10)
-      mini_portile2 (~> 2.8.0)
+    fast_gettext (2.3.0)
+    nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
-    packaging_rake_tasks (1.5.1)
+    packaging_rake_tasks (1.5.4)
       rake
-    racc (1.7.1)
+    racc (1.7.3)
     rake (13.0.6)
     rexml (3.2.6)
     rspec (3.11.0)
@@ -41,13 +39,13 @@ GEM
       rspec-mocks (~> 3.11.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
-    rspec-expectations (3.11.0)
+    rspec-expectations (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-mocks (3.11.1)
+    rspec-mocks (3.11.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-support (3.11.0)
+    rspec-support (3.11.1)
     ruby-augeas (0.5.0)
     ruby-dbus (0.23.1)
       rexml
@@ -58,9 +56,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
+    yard (0.9.34)
 
 PLATFORMS
   x86_64-linux

--- a/service/agama.gemspec
+++ b/service/agama.gemspec
@@ -55,8 +55,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cfa_grub2", "~> 2.0.0"
   spec.add_dependency "cheetah", "~> 1.0.0"
   spec.add_dependency "eventmachine", "~> 1.2.7"
-  spec.add_dependency "fast_gettext", "~> 2.2.0"
-  spec.add_dependency "nokogiri", "~> 1.13.1"
+  spec.add_dependency "fast_gettext", "~> 2.3.0"
+  spec.add_dependency "nokogiri", "~> 1.15.4"
   spec.add_dependency "rexml", "~> 3.2.5"
   spec.add_dependency "ruby-dbus", ">= 0.23.1", "< 1.0"
 end


### PR DESCRIPTION
Update Ruby service dependencies to adapt to the versions of nokogiri and fast_getext which are available in `openSUSE:Factory`.
