### PR TITLE
[web] Fix install button

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 21 15:21:06 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- UI: Do not crash when clicking the install button. It started
+  failing after removing core-js dependency (gh#openSUSE/agama#880
+  and related to gh#openSUSE/agama#866).
+
+-------------------------------------------------------------------
 Fri Nov 17 13:27:22 UTC 2023 - David Diaz <dgonzalez@suse.com>
 
 - UI: Fix broken storage links (bsc#1217281).

--- a/web/src/components/core/InstallButton.jsx
+++ b/web/src/components/core/InstallButton.jsx
@@ -131,9 +131,12 @@ const InstallButton = ({ onClick }) => {
   const open = async () => {
     if (onClick) onClick();
     const canInstall = await client.manager.canInstall();
-    if (canInstall) setHasIssues(await client.issues.any());
     setIsOpen(true);
     setError(!canInstall);
+    if (canInstall) {
+      const issues = await client.issues();
+      setHasIssues(Object.values(issues).some(n => n.length > 0));
+    }
   };
   const close = () => setIsOpen(false);
   const install = () => client.manager.startInstallation();

--- a/web/src/components/core/InstallButton.test.jsx
+++ b/web/src/components/core/InstallButton.test.jsx
@@ -31,19 +31,18 @@ jest.mock("~/client", () => ({
   createClient: jest.fn()
 }));
 
-describe("when the button is clicked and there are not errors", () => {
-  let hasIssues = false;
+let issues;
 
+describe("when the button is clicked and there are not errors", () => {
   beforeEach(() => {
+    issues = {};
     createClient.mockImplementation(() => {
       return {
         manager: {
           startInstallation: startInstallationFn,
           canInstall: () => Promise.resolve(true),
         },
-        issues: {
-          any: () => Promise.resolve(hasIssues)
-        }
+        issues: jest.fn().mockResolvedValue({ ...issues })
       };
     });
   });
@@ -74,7 +73,16 @@ describe("when the button is clicked and there are not errors", () => {
 
   describe("if there are issues", () => {
     beforeEach(() => {
-      hasIssues = true;
+      issues = {
+        product: [],
+        storage: [
+          { description: "storage issue 1", details: "Details 1", source: "system", severity: "warn" },
+          { description: "storage issue 2", details: "Details 2", source: "config", severity: "error" }
+        ],
+        software: [
+          { description: "software issue 1", details: "Details 1", source: "system", severity: "warn" }
+        ]
+      };
     });
 
     it("shows a link to go to the issues page", async () => {
@@ -87,10 +95,6 @@ describe("when the button is clicked and there are not errors", () => {
   });
 
   describe("if there are not issues", () => {
-    beforeEach(() => {
-      hasIssues = false;
-    });
-
     it("does not show a link to go to the issues page", async () => {
       const { user } = installerRender(<InstallButton />);
       const button = await screen.findByRole("button", { name: "Install" });


### PR DESCRIPTION
## Problem

At the time of [removing the `core-js`](https://github.com/openSUSE/agama/pull/866) dependency, we didn't realize that _core/InstallButton.jsx_ component was making use of `Promise.any` and it stopped working as expected when asking by `client.issues.any()`.

It's weird since the static `Promise.any` method is actually supported for all major browsers, but it is now working in the similar way as it was being _polyfilled_ (just a rush conclusion from my side, I didn't investigate it deeply but just deliver a quick fix)

## Solution

To use, at least by now, just plain (and a bit ugly) JavaScript code for determining if there are pending issues when the user hits the installation button.


## Testing

- Unit tests adapted to be _less_ mocked.
- Behavior tested locally too.