### PR TITLE
split a testing_using_container script out of backend-for-testing.md

### DIFF
--- a/rust/agama-cli/doc/backend-for-testing.md
+++ b/rust/agama-cli/doc/backend-for-testing.md
@@ -33,53 +33,8 @@ of [.github/workflows/ci.yml][ci.yml].
 
 [ci.yml]: https://github.com/openSUSE/agama/blob/25462f57ab695d6910beb59ff0b21a7afaeda47e/.github/workflows/ci.yml
 
+## Resulting Script
 
-```sh
-# https://build.opensuse.org/package/show/systemsmanagement:Agama:Staging/agama-testing
-CIMAGE=registry.opensuse.org/systemsmanagement/agama/staging/containers/opensuse/agama-testing:latest
-# rename this if you test multiple things
-CNAME=agama
-# the '?' here will report a shell error
-# if you accidentally paste a command without setting the variable first
-echo ${CNAME?}
-
-test -f service/agama.gemspec || echo "You should run this from a checkout of agama"
-
-# destroy the previous instance
-podman stop ${CNAME?}
-podman rm ${CNAME?}
-
-mkdir -p ./mnt/log-yast2 # needed?
-mkdir -p ./mnt/run-agama # only needed for D-Bus access from outside, unused now
-
-# Update our image
-podman pull ${CIMAGE?}
-
-podman run --name ${CNAME?} \
-  --privileged --detach --ipc=host \
-  -v .:/checkout -v ./mnt/run-agama:/run/agama -v ./mnt/log-yast2:/var/log/YaST2 \
-  ${CIMAGE?}
-
-# shortcut for the following
-CEXEC="podman exec ${CNAME?} bash -c"
-
-${CEXEC?} "cd /checkout && ./setup-services.sh"
-
-# Optional: explicit service start using a separate log file
-${CEXEC?} "cd /checkout/service && (bundle exec bin/agamactl > service.log 2>&1 &)"
-
-# Now the CLI is in the same repo, just symlink it
-${CEXEC?} "ln -sfv /checkout/./rust/target/debug/agama /usr/bin/agama"
-
-# Optional: Play!
-${CEXEC?} "agama -f yaml config show"
-
-# Optional: show logs of autostarted services
-${CEXEC?} "journalctl --since=-5min"
-
-# Optional: show logs of explicitly started services
-${CEXEC?} "cat /checkout/service/service.log"
-
-# Optional: Interactive shell in the container
-podman exec --tty --interactive ${CNAME?} bash
-```
+The script, which used to be inlined here, is now at
+[`/testing_using_container.sh`](../../../testing_using_container.sh).
+>>>>>>> 8f2f0404 (copied the script part of rust/agama-cli/doc/backend-for-testing.md)

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -102,6 +102,15 @@ fi
 # Rubygem dependencies
 (
   cd $MYDIR/service
+
+  if [ -d /checkout-ruby-dbus ]; then
+      # we are in a container, told to use that one
+      # instead of a released version
+      # edit +Gemfile and -gemspec
+      sed -e '/ruby-dbus/d' -i Gemfile agama.gemspec
+      sed -e '/gemspec/a gem "ruby-dbus", path: "/checkout-ruby-dbus"' -i Gemfile
+  fi
+
   bundle config set --local path 'vendor/bundle'
   bundle install
 )

--- a/testing_using_container.sh
+++ b/testing_using_container.sh
@@ -1,0 +1,47 @@
+# https://build.opensuse.org/package/show/YaST:Head:Containers/agama-testing
+CIMAGE=registry.opensuse.org/yast/head/containers/containers_tumbleweed/opensuse/agama-testing:latest
+# rename this if you test multiple things
+CNAME=agama
+# the '?' here will report a shell error
+# if you accidentally paste a command without setting the variable first
+echo ${CNAME?}
+
+test -f service/agama.gemspec || echo "You should run this from a checkout of agama"
+
+# destroy the previous instance
+podman stop ${CNAME?}
+podman rm ${CNAME?}
+
+mkdir -p ./mnt/log-yast2 # needed?
+mkdir -p ./mnt/run-agama # only needed for D-Bus access from outside, unused now
+
+# Update our image
+podman pull ${CIMAGE?}
+
+podman run --name ${CNAME?} \
+  --privileged --detach --ipc=host \
+  -v .:/checkout -v ./mnt/run-agama:/run/agama -v ./mnt/log-yast2:/var/log/YaST2 \
+  ${CIMAGE?}
+
+# shortcut for the following
+CEXEC="podman exec ${CNAME?} bash -c"
+
+${CEXEC?} "cd /checkout && ./setup-services.sh"
+
+# Optional: explicit service start using a separate log file
+${CEXEC?} "cd /checkout/service && (bundle exec bin/agamactl > service.log 2>&1 &)"
+
+# Now the CLI is in the same repo, just symlink it
+${CEXEC?} "ln -sfv /checkout/./rust/target/debug/agama /usr/bin/agama"
+
+# Optional: Play!
+${CEXEC?} "agama -f yaml config show"
+
+# Optional: show logs of autostarted services
+${CEXEC?} "journalctl --since=-5min"
+
+# Optional: show logs of explicitly started services
+${CEXEC?} "cat /checkout/service/service.log"
+
+# Optional: Interactive shell in the container
+podman exec --tty --interactive ${CNAME?} bash

--- a/testing_using_container.sh
+++ b/testing_using_container.sh
@@ -2,8 +2,8 @@
 set -x
 set -eu
 
-# https://build.opensuse.org/package/show/YaST:Head:Containers/agama-testing
-CIMAGE=registry.opensuse.org/yast/head/containers/containers_tumbleweed/opensuse/agama-testing:latest
+# https://build.opensuse.org/package/show/systemsmanagement:Agama:Staging/agama-testing
+CIMAGE=registry.opensuse.org/systemsmanagement/agama/staging/containers/opensuse/agama-testing:latest
 # rename this if you test multiple things
 CNAME=agama
 

--- a/testing_using_container.sh
+++ b/testing_using_container.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+# Run checked-out Agama in a podman container.
+# This is meant to be run from a working copy of the git repo.
+# It uses the systemsmanagement:Agama:Staging/agama-testing image as
+# a platform and runs /setup.sh
+#
+# Details:
+# - container name: agama
+# - port 9090 is exposed so that web UI works
+# - 'WITH_RUBY_DBUS=1 $0' will prefer ../ruby-dbus to any ruby-dbus.gem
+
 set -x
 set -eu
 
@@ -7,7 +17,7 @@ CIMAGE=registry.opensuse.org/systemsmanagement/agama/staging/containers/opensuse
 # rename this if you test multiple things
 CNAME=agama
 
-test -f service/agama.gemspec || echo "You should run this from a checkout of agama"
+test -f service/agama.gemspec || { echo "You should run this from a checkout of agama"; exit 1; }
 
 # destroy the previous instance, can fail if there is no previous instance
 podman stop ${CNAME?} || : no problem if there was nothing to stop
@@ -42,5 +52,5 @@ ${CEXEC?} "ln -sfv /checkout/./rust/target/debug/agama /usr/bin/agama"
 # Manually start cockpit as socket activation does not work with port forwarding
 ${CEXEC?} "systemctl start cockpit"
 
-# Optional: Interactive shell in the container
+# Interactive shell in the container
 podman exec --tty --interactive ${CNAME?} bash


### PR DESCRIPTION
## Problem

We have some documents

- `rust/agama-cli/doc/backend-for-testing.md`
- `doc/testing_using_container.md` (are they duplicate?)

and a script
- `service/run_tests_in_container.sh ` which is only enough for `rake test:unit`

but they either don't do what I want (below) or require cop-pasting


## Solution

Make a script that I can use for testing the entire Agama frontend and backend, in a container

## Testing

- Run the script
- xdg-open https://localhost:9090/agama
- click around

## Screenshots

N/A