### PR TITLE
Update the PO files as well when updating the POT file

### DIFF
--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -69,6 +69,8 @@ jobs:
           else
             echo "POT file unchanged"
             echo "pot_updated=false" >> $GITHUB_OUTPUT
+            # reset any possible changes so they are not accidentally committed later
+            git -C agama-weblate reset --hard
           fi
 
       - name: Push updated web POT file
@@ -78,6 +80,15 @@ jobs:
           cd agama-weblate
           git add web/agama.pot
           git commit -m "Update web POT file"$'\n\n'"Agama commit: $GITHUB_SHA"
+          git push
+
+      - name: Merge new POT to web translations
+        # run only when the POT file has been updated
+        if: steps.check_changes.outputs.pot_updated == 'true'
+        run: |
+          cd agama-weblate/web
+          find . -name "*.po" -exec msgmerge -U "{}" agama.pot \;
+          git commit -a -m "Merge new POT file to web translations"$'\n\n'"Agama commit: $GITHUB_SHA"
           git push
 
       - name: Install NPM packages
@@ -120,4 +131,13 @@ jobs:
           cd agama-weblate
           git add products/products.pot
           git commit -m "Update products POT file"$'\n\n'"Agama commit: $GITHUB_SHA"
+          git push
+
+      - name: Merge new POT to product translations
+        # run only when the POT file has been updated
+        if: steps.check_changes_products.outputs.pot_updated == 'true'
+        run: |
+          cd agama-weblate/products
+          find . -name "*.po" -exec msgmerge -U '{}' products.pot \;
+          git commit -a -m "Merge new POT file to product translations"$'\n\n'"Agama commit: $GITHUB_SHA"
           git push


### PR DESCRIPTION
## Problem

- Currently the [openSUSE Weblate](https://l10n.opensuse.org/) instance is disabled and does not process the repositories
- So the translations can now only be updated manually directly in the [agama-weblate](https://github.com/openSUSE/agama-weblate) repository
- However, the new texts do not appear in the PO files, only in the `agama.pot` file. Merging the POT to the translation files is also done by Weblate. (It is optional, I enabled a Weblate plugin for that.) But because it is disabled that does not happen anymore.

## Solution

- Do the POT merge directly in the GitHub action, do not rely on Weblate doing that later

