### PR TITLE
Install recommended packages

### DIFF
--- a/service/lib/agama/software/proposal.rb
+++ b/service/lib/agama/software/proposal.rb
@@ -130,7 +130,7 @@ module Agama
         Yast::Pkg.TargetInitialize(Yast::Installation.destdir)
         Yast::Pkg.TargetLoad
         Yast::Pkg.SetAdditionalLocales(languages)
-        Yast::Pkg.SetSolverFlags("ignoreAlreadyRecommended" => false, "onlyRequires" => true)
+        Yast::Pkg.SetSolverFlags("ignoreAlreadyRecommended" => false, "onlyRequires" => false)
       end
 
       # Selects the base product

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Nov 24 14:50:22 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Install recommended packages (gh#openSUSE/agama#889).
+
+-------------------------------------------------------------------
 Thu Nov 16 16:27:37 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Software service - correctly change the locale, pass the changed


### PR DESCRIPTION
## Problem

Agama does not install recommended packages. The problem is a lot of software that a user might want is not installed. For instance, you can select a desktop environment in the software section, but Agama will not install a proper display manager. So you are presented with the typical text interface.

Manpages and many other software is missing.

## Solution

Consider recommended packages for installation to have an usable system.

## Testing

- Manually tested.