### PR TITLE
Add an icon to the "transactional" label

### DIFF
--- a/web/src/components/layout/Icon.jsx
+++ b/web/src/components/layout/Icon.jsx
@@ -58,6 +58,7 @@ import SettingsEthernet from "@icons/settings_ethernet.svg?component";
 import SettingsFill from "@icons/settings-fill.svg?component";
 import SignalCellularAlt from "@icons/signal_cellular_alt.svg?component";
 import Storage from "@icons/storage.svg?component";
+import Sync from "@icons/sync.svg?component";
 import TaskAlt from "@icons/task_alt.svg?component";
 import Terminal from "@icons/terminal.svg?component";
 import Translate from "@icons/translate.svg?component";
@@ -112,6 +113,7 @@ const icons = {
   settings_ethernet: SettingsEthernet,
   signal_cellular_alt: SignalCellularAlt,
   storage: Storage,
+  sync: Sync,
   task_alt: TaskAlt,
   terminal: Terminal,
   translate: Translate,

--- a/web/src/components/storage/ProposalVolumes.jsx
+++ b/web/src/components/storage/ProposalVolumes.jsx
@@ -207,6 +207,7 @@ const VolumeRow = ({ columns, volume, options, isLoading, onEdit, onDelete }) =>
     const text = `${volume.fsType} ${options.lvm ? _("logical volume") : _("partition")}`;
     const lockIcon = <Icon name="lock" size={12} />;
     const snapshotsIcon = <Icon name="add_a_photo" size={12} />;
+    const transactionalIcon = <Icon name="sync" size={12} />;
 
     return (
       <div className="split">
@@ -216,7 +217,7 @@ const VolumeRow = ({ columns, volume, options, isLoading, onEdit, onDelete }) =>
         {/* TRANSLATORS: filesystem flag, it allows creating snapshots */}
         <If condition={hasSnapshots} then={<Em icon={snapshotsIcon}>{_("with snapshots")}</Em>} />
         {/* TRANSLATORS: flag for transactional file system  */}
-        <If condition={transactional} then={<Em>{_("transactional")}</Em>} />
+        <If condition={transactional} then={<Em icon={transactionalIcon}>{_("transactional")}</Em>} />
       </div>
     );
   };


### PR DESCRIPTION
## Problem

- Missing icon in the "transactional" label
- When Josef implemented the feature he did not find any suitable icon
- We should use some icon so the UI is unified

## Notes

- Originally I wanted to use the [sync_lock](https://github.com/marella/material-symbols/blob/main/svg/400/outlined/sync_lock.svg) icon, but the lock symbol is too small when resized to 12x12 pixels
- The simpler [sync](https://github.com/marella/material-symbols/blob/main/svg/400/outlined/sync.svg) icon looks OK as well

## Testing

- Tested manually

## Screenshots

![agama-proposal-transactional-icon](https://github.com/openSUSE/agama/assets/907998/7802c2f8-8e4a-4823-b155-cf4741b94204)

