### PR TITLE
[web] Agama/Section fixes and improvements

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 29 13:01:04 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- UI: improve the look and feel by fine tunning the sections spacing,
+  alignment, and icon sizes (gh#openSUSE/agama#892).
+
+-------------------------------------------------------------------
 Tue Nov 21 15:21:06 UTC 2023 - David Diaz <dgonzalez@suse.com>
 
 - UI: Do not crash when clicking the install button. It started

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -8,6 +8,7 @@ section:not([class^="pf-c"]) {
     "icon title"
     ".... content";
   gap: var(--spacer-small);
+  padding-inline-end: var(--icon-size-m);
 }
 
 section:not(:last-child, [class^="pf-c"]) {

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -89,9 +89,8 @@ section > .content {
   padding: 0;
   right: 0;
   z-index: 1000;
-  // FIXME: improve how avoid sidebar content be hidden in the left because of
-  // the wrapper padding
-  inline-size: calc(70% + var(--wrapper-padding));
+  inline-size: 70%;
+  min-inline-size: min-content;
   box-shadow: -10px 10px 20px 0 var(--color-primary);
 }
 
@@ -148,6 +147,7 @@ section > .content {
 .sidebar[data-state="hidden"] {
   transition: all 0.04s ease-in-out;
   inline-size: 0;
+  min-inline-size: 0;
   box-shadow: none;
 }
 

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -3,12 +3,15 @@
 // section layouts.
 section:not([class^="pf-c"]) {
   display: grid;
-  grid-template-columns: var(--icon-size-m) 1fr;
+  grid-template-columns: var(--section-icon-size) 1fr;
   grid-template-areas:
     "icon title"
     ".... content";
   gap: var(--spacer-small);
-  padding-inline-end: var(--icon-size-m);
+  padding-inline-start: calc(
+    var(--header-icon-size) - var(--section-icon-size)
+  );
+  padding-inline-end: var(--section-icon-size);
 }
 
 section:not(:last-child, [class^="pf-c"]) {
@@ -17,6 +20,8 @@ section:not(:last-child, [class^="pf-c"]) {
 
 section > svg {
   grid-area: icon;
+  block-size: var(--section-icon-size);
+  inline-size: var(--section-icon-size);
 }
 
 section > h2 {

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -89,7 +89,9 @@ section > .content {
   padding: 0;
   right: 0;
   z-index: 1000;
-  inline-size: 70%;
+  // FIXME: improve how avoid sidebar content be hidden in the left because of
+  // the wrapper padding
+  inline-size: calc(70% + var(--wrapper-padding));
   box-shadow: -10px 10px 20px 0 var(--color-primary);
 }
 

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -3,7 +3,7 @@
 // section layouts.
 section:not([class^="pf-c"]) {
   display: grid;
-  grid-template-columns: min-content 1fr;
+  grid-template-columns: var(--icon-size-m) 1fr;
   grid-template-areas:
     "icon title"
     ".... content";

--- a/web/src/assets/styles/layout.scss
+++ b/web/src/assets/styles/layout.scss
@@ -33,6 +33,8 @@
 
   svg {
     color: white;
+    block-size: var(--header-icon-size);
+    inline-size: var(--header-icon-size);
   }
 }
 

--- a/web/src/assets/styles/layout.scss
+++ b/web/src/assets/styles/layout.scss
@@ -40,7 +40,7 @@
   grid-area: content;
   overflow-y: auto; // Sadly, only Firefox supports overflow-block at this moment (Jan 2023)
   overflow-block: auto;
-  padding: var(--spacer-medium);
+  padding: var(--spacer-medium) var(--spacer-small);
 }
 
 .wrapper > footer {

--- a/web/src/assets/styles/utilities.scss
+++ b/web/src/assets/styles/utilities.scss
@@ -59,6 +59,11 @@
   height: 24px;
 }
 
+.icon-size-28 {
+  width: 28px;
+  height: 28px;
+}
+
 .icon-size-32 {
   width: 32px;
   height: 32px;

--- a/web/src/assets/styles/variables.scss
+++ b/web/src/assets/styles/variables.scss
@@ -60,7 +60,7 @@
   --gradient-border-start-color: var(--color-gray);
   --gradient-border-end-color: transparent;
 
-  --icon-size-m: 32px;
+  --icon-size-m: 28px;
 
   --header-block-size: auto;
   --footer-block-size: auto;

--- a/web/src/assets/styles/variables.scss
+++ b/web/src/assets/styles/variables.scss
@@ -26,7 +26,7 @@
   --stack-gutter: var(--spacer-normal);
   --split-gutter: var(--spacer-small);
 
-  --wrapper-padding: var(--spacer-normal);
+  --wrapper-padding: var(--spacer-small);
   --wrapper-background: white;
 
   --color-primary: #0c322c;
@@ -60,7 +60,8 @@
   --gradient-border-start-color: var(--color-gray);
   --gradient-border-end-color: transparent;
 
-  --icon-size-m: 28px;
+  --header-icon-size: 32px;
+  --section-icon-size: 28px;
 
   --header-block-size: auto;
   --footer-block-size: auto;

--- a/web/src/components/core/Page.jsx
+++ b/web/src/components/core/Page.jsx
@@ -87,7 +87,7 @@ export default function Page({
   return (
     <>
       { title && <Title>{title}</Title> }
-      { icon && <PageIcon><Icon name={icon} /></PageIcon> }
+      { icon && <PageIcon><Icon name={icon} size="32" /></PageIcon> }
       <MainActions>
         { action ||
           <Button size="lg" variant={actionVariant} onClick={pageAction}>

--- a/web/src/components/core/Section.jsx
+++ b/web/src/components/core/Section.jsx
@@ -77,12 +77,14 @@ export default function Section({
   const Header = () => {
     if (!title?.trim()) return;
 
-    const header = !path?.trim() ? <>{title}</> : <Link to={path}>{title}</Link>;
+    const iconName = loading ? "loading" : icon;
+    const headerIcon = iconName ? <Icon name={iconName} /> : null;
+    const headerText = !path?.trim() ? title : <Link to={path}>{title}</Link>;
 
     return (
       <>
-        <Icon name={loading ? "loading" : icon} />
-        <h2 id={headerId}>{header}</h2>
+        {headerIcon}
+        <h2 id={headerId}>{headerText}</h2>
       </>
     );
   };

--- a/web/src/components/core/Section.test.jsx
+++ b/web/src/components/core/Section.test.jsx
@@ -72,12 +72,6 @@ describe("Section", () => {
       const icon = container.querySelector("svg");
       expect(icon).toBeNull();
     });
-
-    it("does not render the loading icon", () => {
-      const { container } = plainRender(<Section loading />);
-      const icon = container.querySelector("svg");
-      expect(icon).toBeNull();
-    });
   });
 
   describe("when aria-label is given", () => {
@@ -168,6 +162,7 @@ describe("Section", () => {
       expect(icon).toBeNull();
     });
   });
+
   describe("when path is given", () => {
     it("renders a link for navigating to it", async () => {
       installerRender(<Section title="Settings" path="/settings" />);

--- a/web/src/components/core/Section.test.jsx
+++ b/web/src/components/core/Section.test.jsx
@@ -49,6 +49,8 @@ describe("Section", () => {
       const { container } = plainRender(<Section title="Settings" />);
       const icon = container.querySelector("svg");
       expect(icon).toBeNull();
+      // Check that <Icon /> component was not mounted with 'undefined'
+      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("does not render an icon if not valid icon name is given", () => {

--- a/web/src/components/layout/Icon.jsx
+++ b/web/src/components/layout/Icon.jsx
@@ -150,7 +150,7 @@ const icons = {
  * @param {object} [props.otherProps] Other props sent to SVG icon.
  *
  */
-export default function Icon({ name, className = "", size = 32, ...otherProps }) {
+export default function Icon({ name, className = "", size = 28, ...otherProps }) {
   if (!name) {
     console.error(`Icon called without name. '${name}' given instead. Rendering nothing.`);
     return null;


### PR DESCRIPTION
## Problem

Lately, we use more and more the `Agama/Section` component, which make us realize about problems it has or improvements we can introduce. This PR is about both things.

## Details

* After https://github.com/openSUSE/agama/pull/839, there are a lot of Icon errors logged in the development console when visiting a page with sections without icons.
 
  Fixed by 59ff592445ba4a8207a74980ddb278bd5d8c8fa5

* There are sections that do not have a representative icon, but they can enter in _loading mode_. When so, the loading icon is used in the section header, moving the section header and content to the right as much as needed and putting it back when leaving the _loading mode_.

  Solution has been to revert change done at https://github.com/openSUSE/agama/pull/549 and reserve the icon space, 1672dbc81702c7c01017364073c858efbde78af1

    <table>
     <tr><th>Before</th><th>After</th></tr>
     <tr><th>
  <p>

  ![Screenshot from 2023-11-29 09-57-05](https://github.com/openSUSE/agama/assets/1691872/b7650bdc-309e-4183-8b81-419e7e6f9016) 

  </p>
    </th><th>

  <p>

  ![Screenshot from 2023-11-29 10-04-25](https://github.com/openSUSE/agama/assets/1691872/89c396c1-0238-471f-930c-d7fdbf72fcf1)

  </p>

  </th></tr>

     <tr><th>
  <p>

    [Screencast from 2023-11-29 09-58-18.webm](https://github.com/openSUSE/agama/assets/1691872/59ac3d22-5cd6-4c82-a8f2-8a013dbf667f)

  </p>
    </th><th>

  <p>

   [Screencast from 2023-11-29 09-59-54.webm](https://github.com/openSUSE/agama/assets/1691872/dd5727ae-735c-420f-9d1f-74403aa9682c)

  </p>

  </th></tr>
    </table>

* Because of the above, better to add padding to the end of the section for a visual balance of space at both sides ac746932c271f3b252e6b77a7016fe984275fae9



  | Before | After |
  |-|-|
  | ![Screenshot from 2023-11-29 10-04-25](https://github.com/openSUSE/agama/assets/1691872/71331c87-c3de-46aa-8e95-e309fa1211dc) |![Screenshot from 2023-11-29 10-17-12](https://github.com/openSUSE/agama/assets/1691872/d5fa42f8-aa45-42d2-9a29-20c7f3464cce) |

* But there is too much wasted space, so the padding added by the `<main>` element was reduced, c62976c4825f5941533e71a29c595368827321e6

  | Before | After |
  |-|-|
  | ![Screenshot from 2023-11-29 12-38-29](https://github.com/openSUSE/agama/assets/1691872/266d2a9e-539f-4c20-8525-14d6276288e2) | ![Screenshot from 2023-11-29 12-38-00](https://github.com/openSUSE/agama/assets/1691872/782be287-4f60-423d-bc53-15f7d00a9bc7) |


* Still too much space when sections do not have icons, so icons size was decreased too, 09961b824b7223438cbe37e2fc6713471e72439a

  | Before | After |
  |-|-|
  | ![Screenshot from 2023-11-29 12-44-41](https://github.com/openSUSE/agama/assets/1691872/a981de82-b90c-44df-a0d2-e10125b6d9dc) | ![Screenshot from 2023-11-29 12-45-39](https://github.com/openSUSE/agama/assets/1691872/22c0e59b-e8da-4ef3-8069-84ab89282d07) |
  | ![Screenshot from 2023-11-29 12-45-09](https://github.com/openSUSE/agama/assets/1691872/fc1dba8d-7025-403f-b9f9-644c254b2fde) | ![Screenshot from 2023-11-29 12-45-29](https://github.com/openSUSE/agama/assets/1691872/fb49ce88-a538-4775-a3bd-7b3aca21ad59) |
 


* Then the header had to be better aligned, 6cb65120d2303a5313865554c3c9b436fd714158
  | Before | After |
  |-|-|
  | ![Screenshot from 2023-11-29 12-48-50](https://github.com/openSUSE/agama/assets/1691872/e5143760-3409-4033-a10f-3792d8a19208) | ![Screenshot from 2023-11-29 12-49-10](https://github.com/openSUSE/agama/assets/1691872/2702a794-8c89-4e72-bb89-7a1ed760f6db) |

* And finally ensuring that sidebar content keep always visible, 0927e87d7bd0880ef0e3b5f61499ace3fab5b976

  | Before | After |
  |-|-|
  |![Screenshot from 2023-11-29 12-56-38](https://github.com/openSUSE/agama/assets/1691872/b25d40d2-2e43-45f3-b8ca-198ed4011dce) |![Screenshot from 2023-11-29 12-56-51](https://github.com/openSUSE/agama/assets/1691872/4f1108e7-e82c-4fb8-879c-9a8a7ae34ae2) |


