### PR TITLE
Add mac assigning to network base connection

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "cidr",
  "gettext-rs",
  "log",
+ "macaddr",
  "once_cell",
  "regex",
  "serde",
@@ -1142,6 +1143,12 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
  "value-bag",
 ]
+
+[[package]]
+name = "macaddr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
 
 [[package]]
 name = "malloc_buf"

--- a/rust/agama-dbus-server/Cargo.toml
+++ b/rust/agama-dbus-server/Cargo.toml
@@ -24,3 +24,4 @@ tokio-stream = "0.1.14"
 gettext-rs = { version = "0.7.0", features = ["gettext-system"] }
 regex = "1.10.2"
 once_cell = "1.18.0"
+macaddr = "1.0"

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -238,6 +238,19 @@ impl Connection {
         connection.set_interface(name);
         self.update_connection(connection).await
     }
+
+    /// Custom mac-address
+    #[dbus_interface(property)]
+    pub async fn mac_address(&self) -> String {
+        self.get_connection().await.mac_address()
+    }
+
+    #[dbus_interface(property)]
+    pub async fn set_mac_address(&mut self, mac_address: &str) -> zbus::fdo::Result<()> {
+        let mut connection = self.get_connection().await;
+        connection.set_mac_address(mac_address)?;
+        self.update_connection(connection).await
+    }
 }
 
 /// D-Bus interface for Match settings

--- a/rust/agama-dbus-server/src/network/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces.rs
@@ -6,11 +6,13 @@ use super::ObjectsRegistry;
 use crate::network::{
     action::Action,
     error::NetworkStateError,
-    model::{Connection as NetworkConnection, Device as NetworkDevice, WirelessConnection},
+    model::{
+        Connection as NetworkConnection, Device as NetworkDevice, MacAddress, WirelessConnection,
+    },
 };
 
 use agama_lib::network::types::SSID;
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
 use zbus::{
@@ -248,7 +250,7 @@ impl Connection {
     #[dbus_interface(property)]
     pub async fn set_mac_address(&mut self, mac_address: &str) -> zbus::fdo::Result<()> {
         let mut connection = self.get_connection().await;
-        connection.set_mac_address(mac_address)?;
+        connection.set_mac_address(MacAddress::from_str(mac_address)?);
         self.update_connection(connection).await
     }
 }

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -319,9 +319,8 @@ impl Connection {
         self.base().mac_address.to_string()
     }
 
-    pub fn set_mac_address(&mut self, mac_address: &str) -> Result<(), InvalidMacAddress> {
-        self.base_mut().mac_address = MacAddress::from_str(mac_address)?;
-        Ok(())
+    pub fn set_mac_address(&mut self, mac_address: MacAddress) {
+        self.base_mut().mac_address = mac_address;
     }
 }
 

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -354,7 +354,7 @@ pub enum MacAddress {
     Random,
     Stable,
     #[default]
-    None,
+    Unset,
 }
 
 impl FromStr for MacAddress {
@@ -366,7 +366,7 @@ impl FromStr for MacAddress {
             "permanent" => Ok(Self::Permanent),
             "random" => Ok(Self::Random),
             "stable" => Ok(Self::Stable),
-            "" => Ok(Self::None),
+            "" => Ok(Self::Unset),
             _ => Ok(Self::MacAddress(match macaddr::MacAddr6::from_str(s) {
                 Ok(mac) => mac,
                 Err(e) => return Err(InvalidMacAddress(e.to_string())),
@@ -383,7 +383,7 @@ impl fmt::Display for MacAddress {
             Self::Permanent => "permanent".to_string(),
             Self::Random => "random".to_string(),
             Self::Stable => "stable".to_string(),
-            Self::None => "".to_string(),
+            Self::Unset => "".to_string(),
         };
         write!(f, "{}", output)
     }

--- a/rust/agama-dbus-server/src/network/nm/dbus.rs
+++ b/rust/agama-dbus-server/src/network/nm/dbus.rs
@@ -33,8 +33,12 @@ pub fn connection_to_dbus(conn: &Connection) -> NestedHash {
     result.insert("ipv6", ip_config_to_ipv6_dbus(conn.ip_config()));
     result.insert("match", match_config_to_dbus(conn.match_config()));
 
-    if let Connection::Wireless(wireless) = conn {
-        connection_dbus.insert("type", "802-11-wireless".into());
+    if conn.is_ethernet() {
+        let ethernet_config =
+            HashMap::from([("assigned-mac-address", Value::new(conn.mac_address()))]);
+        result.insert(ETHERNET_KEY, ethernet_config);
+    } else if let Connection::Wireless(wireless) = conn {
+        connection_dbus.insert("type", WIRELESS_KEY.into());
         let wireless_dbus = wireless_config_to_dbus(wireless);
         for (k, v) in wireless_dbus {
             result.insert(k, v);
@@ -227,6 +231,10 @@ fn wireless_config_to_dbus(conn: &WirelessConnection) -> NestedHash {
     let wireless: HashMap<&str, zvariant::Value> = HashMap::from([
         ("mode", Value::new(config.mode.to_string())),
         ("ssid", Value::new(config.ssid.to_vec())),
+        (
+            "assigned-mac-address",
+            Value::new(conn.base.mac_address.to_string()),
+        ),
     ]);
 
     let mut security: HashMap<&str, zvariant::Value> =
@@ -298,6 +306,34 @@ fn base_connection_from_dbus(conn: &OwnedNestedHash) -> Option<BaseConnection> {
 
     if let Some(match_config) = conn.get("match") {
         base_connection.match_config = match_config_from_dbus(match_config)?;
+    }
+
+    if let Some(ethernet_config) = conn.get(ETHERNET_KEY) {
+        if let Some(mac_address) = ethernet_config.get("assigned-mac-address") {
+            base_connection.mac_address =
+                match MacAddress::from_str(mac_address.downcast_ref::<str>()?) {
+                    Ok(mac) => mac,
+                    Err(e) => {
+                        log::warn!("Couldn't parse MAC: {}", e);
+                        MacAddress::None
+                    }
+                };
+        } else {
+            base_connection.mac_address = MacAddress::None;
+        }
+    } else if let Some(wireless_config) = conn.get(WIRELESS_KEY) {
+        if let Some(mac_address) = wireless_config.get("assigned-mac-address") {
+            base_connection.mac_address =
+                match MacAddress::from_str(mac_address.downcast_ref::<str>()?) {
+                    Ok(mac) => mac,
+                    Err(e) => {
+                        log::warn!("Couldn't parse MAC: {}", e);
+                        MacAddress::None
+                    }
+                };
+        } else {
+            base_connection.mac_address = MacAddress::None;
+        }
     }
 
     base_connection.ip_config = ip_config_from_dbus(&conn)?;
@@ -594,6 +630,8 @@ mod test {
         let match_config = connection.match_config();
         assert_eq!(match_config.kernel, vec!["pci-0000:00:19.0"]);
 
+        assert_eq!(connection.mac_address(), "12:34:56:78:9A:BC");
+
         assert_eq!(
             ip_config.addresses,
             vec![
@@ -649,6 +687,10 @@ mod test {
                 "ssid".to_string(),
                 Value::new("agama".as_bytes()).to_owned(),
             ),
+            (
+                "assigned-mac-address".to_string(),
+                Value::new("13:45:67:89:AB:CD").to_owned(),
+            ),
         ]);
 
         let security_section =
@@ -661,6 +703,7 @@ mod test {
         ]);
 
         let connection = connection_from_dbus(dbus_conn).unwrap();
+        assert_eq!(connection.mac_address(), "13:45:67:89:AB:CD".to_string());
         assert!(matches!(connection, Connection::Wireless(_)));
         if let Connection::Wireless(connection) = connection {
             assert_eq!(connection.wireless.ssid, SSID(vec![97, 103, 97, 109, 97]));
@@ -688,6 +731,12 @@ mod test {
         let wireless = wireless_dbus.get("802-11-wireless").unwrap();
         let mode: &str = wireless.get("mode").unwrap().downcast_ref().unwrap();
         assert_eq!(mode, "infrastructure");
+        let mac_address: &str = wireless
+            .get("assigned-mac-address")
+            .unwrap()
+            .downcast_ref()
+            .unwrap();
+        assert_eq!(mac_address, "FD:CB:A9:87:65:43");
 
         let ssid: &zvariant::Array = wireless.get("ssid").unwrap().downcast_ref().unwrap();
         let ssid: Vec<u8> = ssid
@@ -813,19 +862,33 @@ mod test {
                 Value::new("eth0".to_string()).to_owned(),
             ),
         ]);
+        let ethernet = HashMap::from([(
+            "assigned-mac-address".to_string(),
+            Value::new("12:34:56:78:9A:BC".to_string()).to_owned(),
+        )]);
         original.insert("connection".to_string(), connection);
+        original.insert(ETHERNET_KEY.to_string(), ethernet);
 
         let mut updated = Connection::Ethernet(EthernetConnection::default());
         updated.set_interface("");
+        assert!(updated.set_mac_address("").is_ok());
         let updated = connection_to_dbus(&updated);
 
         let merged = merge_dbus_connections(&original, &updated);
         let connection = merged.get("connection").unwrap();
         assert_eq!(connection.get("interface-name"), None);
+        let ethernet = merged.get(ETHERNET_KEY).unwrap();
+        assert_eq!(ethernet.get("assigned-mac-address"), Some(&Value::from("")));
     }
 
     fn build_ethernet_section_from_dbus() -> HashMap<String, OwnedValue> {
-        HashMap::from([("auto-negotiate".to_string(), true.into())])
+        HashMap::from([
+            ("auto-negotiate".to_string(), true.into()),
+            (
+                "assigned-mac-address".to_string(),
+                Value::new("12:34:56:78:9A:BC").to_owned(),
+            ),
+        ])
     }
 
     fn build_base_connection() -> BaseConnection {
@@ -849,9 +912,11 @@ mod test {
             }]),
             ..Default::default()
         };
+        let mac_address = MacAddress::from_str("FD:CB:A9:87:65:43").unwrap();
         BaseConnection {
             id: "agama".to_string(),
             ip_config,
+            mac_address,
             ..Default::default()
         }
     }
@@ -867,6 +932,14 @@ mod test {
         let connection_dbus = conn_dbus.get("connection").unwrap();
         let id: &str = connection_dbus.get("id").unwrap().downcast_ref().unwrap();
         assert_eq!(id, "agama");
+
+        let ethernet_connection = conn_dbus.get(ETHERNET_KEY).unwrap();
+        let mac_address: &str = ethernet_connection
+            .get("assigned-mac-address")
+            .unwrap()
+            .downcast_ref()
+            .unwrap();
+        assert_eq!(mac_address, "FD:CB:A9:87:65:43");
 
         let ipv4_dbus = conn_dbus.get("ipv4").unwrap();
         let gateway4: &str = ipv4_dbus.get("gateway").unwrap().downcast_ref().unwrap();

--- a/rust/agama-dbus-server/src/network/nm/dbus.rs
+++ b/rust/agama-dbus-server/src/network/nm/dbus.rs
@@ -315,11 +315,11 @@ fn base_connection_from_dbus(conn: &OwnedNestedHash) -> Option<BaseConnection> {
                     Ok(mac) => mac,
                     Err(e) => {
                         log::warn!("Couldn't parse MAC: {}", e);
-                        MacAddress::None
+                        MacAddress::Unset
                     }
                 };
         } else {
-            base_connection.mac_address = MacAddress::None;
+            base_connection.mac_address = MacAddress::Unset;
         }
     } else if let Some(wireless_config) = conn.get(WIRELESS_KEY) {
         if let Some(mac_address) = wireless_config.get("assigned-mac-address") {
@@ -328,11 +328,11 @@ fn base_connection_from_dbus(conn: &OwnedNestedHash) -> Option<BaseConnection> {
                     Ok(mac) => mac,
                     Err(e) => {
                         log::warn!("Couldn't parse MAC: {}", e);
-                        MacAddress::None
+                        MacAddress::Unset
                     }
                 };
         } else {
-            base_connection.mac_address = MacAddress::None;
+            base_connection.mac_address = MacAddress::Unset;
         }
     }
 

--- a/rust/agama-dbus-server/src/network/nm/dbus.rs
+++ b/rust/agama-dbus-server/src/network/nm/dbus.rs
@@ -863,7 +863,7 @@ mod test {
 
         let mut updated = Connection::Ethernet(EthernetConnection::default());
         updated.set_interface("");
-        assert!(updated.set_mac_address("").is_ok());
+        updated.set_mac_address(MacAddress::Unset);
         let updated = connection_to_dbus(&updated);
 
         let merged = merge_dbus_connections(&original, &updated);

--- a/rust/agama-dbus-server/tests/network.rs
+++ b/rust/agama-dbus-server/tests/network.rs
@@ -62,6 +62,7 @@ async fn test_add_connection() -> Result<(), Box<dyn Error>> {
     let addresses: Vec<IpInet> = vec!["192.168.0.2/24".parse()?, "::ffff:c0a8:7ac7/64".parse()?];
     let wlan0 = settings::NetworkConnection {
         id: "wlan0".to_string(),
+        mac_address: Some("FD:CB:A9:87:65:43".to_string()),
         method4: Some("auto".to_string()),
         method6: Some("disabled".to_string()),
         addresses: addresses.clone(),
@@ -80,6 +81,7 @@ async fn test_add_connection() -> Result<(), Box<dyn Error>> {
 
     let conn = conns.first().unwrap();
     assert_eq!(conn.id, "wlan0");
+    assert_eq!(conn.mac_address, Some("FD:CB:A9:87:65:43".to_string()));
     assert_eq!(conn.device_type(), DeviceType::Wireless);
     assert_eq!(&conn.addresses, &addresses);
     let method4 = conn.method4.as_ref().unwrap();

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -36,6 +36,10 @@
                 "description": "The name of the network interface bound to this connection",
                 "type": "string"
               },
+              "mac-address": {
+                "description": "Custom mac-address (can also be 'preserve', 'permanent', 'random' or 'stable')",
+                "type": "string"
+              },
               "method4": {
                 "description": "IPv4 configuration method (e.g., 'auto')",
                 "type": "string",

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -194,11 +194,7 @@ impl<'a> NetworkClient<'a> {
         let interface = conn.interface.as_deref().unwrap_or("");
         proxy.set_interface(interface).await?;
 
-        let mac_address = if let Some(mac_address) = &conn.mac_address {
-            mac_address
-        } else {
-            ""
-        };
+        let mac_address = conn.mac_address.as_deref().unwrap_or("");
         proxy.set_mac_address(mac_address).await?;
 
         self.update_ip_settings(path, conn).await?;

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -67,6 +67,10 @@ impl<'a> NetworkClient<'a> {
             "" => None,
             value => Some(value.to_string()),
         };
+        let mac_address = match connection_proxy.mac_address().await?.as_str() {
+            "" => None,
+            value => Some(value.to_string()),
+        };
 
         let ip_proxy = IPProxy::builder(&self.connection)
             .path(path)?
@@ -91,6 +95,7 @@ impl<'a> NetworkClient<'a> {
             addresses,
             nameservers,
             interface,
+            mac_address,
             ..Default::default()
         })
     }
@@ -188,6 +193,13 @@ impl<'a> NetworkClient<'a> {
 
         let interface = conn.interface.as_deref().unwrap_or("");
         proxy.set_interface(interface).await?;
+
+        let mac_address = if let Some(mac_address) = &conn.mac_address {
+            mac_address
+        } else {
+            ""
+        };
+        proxy.set_mac_address(mac_address).await?;
 
         self.update_ip_settings(path, conn).await?;
 

--- a/rust/agama-lib/src/network/proxies.rs
+++ b/rust/agama-lib/src/network/proxies.rs
@@ -83,6 +83,10 @@ trait Connection {
     fn interface(&self) -> zbus::Result<String>;
     #[dbus_proxy(property)]
     fn set_interface(&self, interface: &str) -> zbus::Result<()>;
+    #[dbus_proxy(property)]
+    fn mac_address(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
+    fn set_mac_address(&self, mac_address: &str) -> zbus::Result<()>;
 }
 
 #[dbus_proxy(

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -69,6 +69,8 @@ pub struct NetworkConnection {
     pub interface: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub match_settings: Option<MatchSettings>,
+    #[serde(rename = "mac-address", skip_serializing_if = "Option::is_none")]
+    pub mac_address: Option<String>,
 }
 
 impl NetworkConnection {

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Dec  5 11:18:41 UTC 2023 - Jorik Cronenberg <jorik.cronenberg@suse.com>
+
+- Add ability to assign a custom MAC address for network
+  connections (gh#openSUSE/agama#893)
+
+-------------------------------------------------------------------
 Tue Dec  5 09:46:48 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Explicitly add dependencies instead of relying on the live ISO


### PR DESCRIPTION
## Problem

It's not possible to assign a mac address to network connections

## Solution

Add a property `mac_address` to base connection and also to `NetworkConnection` inside settings to allow setting of custom mac addresses.

**Note**: Currently for simplicity sake it just stores it as `String` all around, but with this draft I also wanted to start a discussion on what agama should use to store the mac address inside `BaseConnection`. `String` is of course the simplest, but doesn't perform any validation before sending it to NetworkManager, so the result is a pretty non explanatory error that the connection couldn't be added, because NetworkManager rejects any invalid macs of course. Let me know what you would prefer :slightly_smiling_face: (adjustments to the type shouldn't be to much work so no worries if I should change it)


## Testing

- *Modified existing unit tests*
- *Tested manually*
