### PR TITLE
Fixed merging product translations

### DIFF
--- a/.github/workflows/product_translations/merge_po
+++ b/.github/workflows/product_translations/merge_po
@@ -110,7 +110,7 @@ class YamlProduct {
     const newTranslations = {};
 
     translations.forEach(t => {
-      if (t.msgid === description) {
+      if (t.msgid === description && t.msgstr?.length > 0) {
         newTranslations[t.locale] = t.msgstr;
       }
     });


### PR DESCRIPTION
## Problem

- The code adds empty translations, see https://github.com/openSUSE/agama/pull/894/files

## Solution

- Check that the translation is not empty
- The code also handles `undefined` or `null` if for whatever reason the PO parser returns them

## Testing

- Tested manually
