### PR TITLE
[web] Save space when rendering a selector

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Nov 30 22:39:57 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- UI: make selectors more compact (gh#openSUSE/agama#898).
+
+-------------------------------------------------------------------
 Thu Nov 30 15:19:38 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Allow selecting the storage policy to make free space for the

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -275,11 +275,13 @@ span.notification-mark[data-variant="sidebar"] {
 ul[data-type="agama/list"] {
   li {
     border: 2px solid var(--color-gray-dark);
-    border-radius: 5px;
     padding: var(--spacer-normal);
     text-align: start;
     background: var(--color-gray-light);
-    margin-block-end: var(--spacer-small);
+
+    &:nth-child(n+2) {
+      border-top: 0;
+    }
 
     > div {
       margin-block-end: var(--spacer-smaller);
@@ -312,6 +314,14 @@ ul[data-type="agama/list"][role="listbox"] {
   li[role="option"] {
     cursor: pointer;
     transition: all 0.2s ease-in-out;
+
+    &:first-child {
+      border-radius: 5px 5px 0 0;
+    }
+
+    &:last-child {
+      border-radius: 0 0 5px 5px;
+    }
 
     &:hover {
       &:not([aria-selected]) {

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -297,7 +297,7 @@ ul[data-type="agama/list"] {
   // FIXME: see if it's semantically correct to mark an li as aria-selected when
   // not belongs to a listbox or grid list ul.
   li[aria-selected] {
-    border: 2px solid var(--color-primary);
+    border-color: var(--color-primary);
     box-shadow: 0 2px 5px 0 var(--color-gray-dark);
     background: var(--color-primary);
     color: white;
@@ -313,7 +313,6 @@ ul[data-type="agama/list"] {
 ul[data-type="agama/list"][role="listbox"] {
   li[role="option"] {
     cursor: pointer;
-    transition: all 0.2s ease-in-out;
 
     &:first-child {
       border-radius: 5px 5px 0 0;

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -323,6 +323,10 @@ ul[data-type="agama/list"][role="listbox"] {
       border-radius: 0 0 5px 5px;
     }
 
+    &:only-child {
+      border-radius: 5px;
+    }
+
     &:hover {
       &:not([aria-selected]) {
         background: var(--color-gray-dark);


### PR DESCRIPTION
## Problem

Back in May, we introduced a _preliminary version_ of a device selector (see https://github.com/openSUSE/agama/pull/578). Although we like its look and feel, after _extending_ its usage to localization page (https://github.com/openSUSE/agama/pull/881) and space policy selector (https://github.com/openSUSE/agama/pull/883), we've realized that there is too much wasted space between selector options. Even after reducing it _accidentally_ as part of https://github.com/openSUSE/agama/pull/883 (https://github.com/openSUSE/agama/pull/883/commits/00c36b96e02d567d9562e06ccd5aba196b554135, https://github.com/openSUSE/agama/pull/883/commits/15aab266eece2dde57076bfa35febf55fe8d535e)

## Solution

Drop the space between options to make the selector looks like what it is: a single widget.

## Testing

- Tested manually

## Notes

With that change, it's true that a selector supporting multiple selection could look a bit weird at first sight when there are two or more options selected in a row. That's why I've kept the `box-shadow` for the selected options, which creates the impression that there is a slight separation between them.

<details>
<summary>Click to show/hide screenshots</summary>

---

|Before|After|
|-|-|
|![Screen Shot 2023-11-30 at 21 46 06](https://github.com/openSUSE/agama/assets/1691872/b9862e9e-af70-4c76-b0c9-583e9ce27a0c) | ![Screen Shot 2023-11-30 at 21 48 00](https://github.com/openSUSE/agama/assets/1691872/52347097-2861-4480-9c00-e40df9fbf049) |
</details>

In any case, **I'd like to go ahead without adding an exception** for the only multiple selection we have at this time. The reason is that we're going to rework these selectors ASAP due to a few known issues. Most probably, the new version will include an extra widget per option: radio for single selection, checkbox for multiple selection. I'm confident on the fact that these widgets will throw away the _potential issue_ we might introduce by removing the wasted space between options.

So, let's _save time_ now :pray: 

## Screenshots

|Before | After |
|-|-|
|![Screen Shot 2023-11-30 at 21 44 43](https://github.com/openSUSE/agama/assets/1691872/c29b8b1e-a3e0-40dd-9699-3f69c576ec6c) | ![Screen Shot 2023-11-30 at 21 46 51](https://github.com/openSUSE/agama/assets/1691872/e666c96d-1581-47c9-95c5-a1b902c0506a) |

<details>
<summary>Click to show/hide more screenshots</summary>

---

|Before|After|
|-|-|
|![Screen Shot 2023-11-30 at 21 44 49](https://github.com/openSUSE/agama/assets/1691872/c4b49a92-5c18-49d0-a9c0-a1466b9e0c32) |![Screen Shot 2023-11-30 at 21 47 11](https://github.com/openSUSE/agama/assets/1691872/c4cb4136-b352-467d-bfa9-a2cbf709d5c5) |
|![Screen Shot 2023-11-30 at 21 44 54](https://github.com/openSUSE/agama/assets/1691872/55e9f09f-883f-4c22-80ac-5f529df96da7)|![Screen Shot 2023-11-30 at 21 47 21](https://github.com/openSUSE/agama/assets/1691872/0d4e3b64-4966-4038-85b2-b9b0be4a3ccf)|
|![Screen Shot 2023-11-30 at 21 45 08](https://github.com/openSUSE/agama/assets/1691872/dee30ced-43f9-401b-b2e7-f76f0cd56cc1)|![Screen Shot 2023-11-30 at 21 47 46](https://github.com/openSUSE/agama/assets/1691872/21b0a951-0f47-4942-9719-4dcbd171536e)|
|![Screen Shot 2023-11-30 at 21 46 21](https://github.com/openSUSE/agama/assets/1691872/7e910fc0-3bae-4904-bec7-72e8c21b0c99)|![Screen Shot 2023-11-30 at 21 48 12](https://github.com/openSUSE/agama/assets/1691872/28ef5304-0194-4560-8e96-88f34fe5834d)|

</details>

