### PR TITLE
Force writing the timezone

### DIFF
--- a/rust/agama-dbus-server/src/locale.rs
+++ b/rust/agama-dbus-server/src/locale.rs
@@ -166,7 +166,13 @@ impl Locale {
             .status()
             .context("Failed to execute systemd-firstboot")?;
         Command::new("/usr/bin/systemd-firstboot")
-            .args(["--root", ROOT, "--timezone", self.timezone.as_str()])
+            .args([
+                "--root",
+                ROOT,
+                "--force",
+                "--timezone",
+                self.timezone.as_str(),
+            ])
             .status()
             .context("Failed to execute systemd-firstboot")?;
 

--- a/rust/agama-dbus-server/src/locale.rs
+++ b/rust/agama-dbus-server/src/locale.rs
@@ -156,22 +156,13 @@ impl Locale {
             .args([
                 "--root",
                 ROOT,
+                "--force",
                 "--locale",
                 self.locales.first().context("missing locale")?.as_str(),
-            ])
-            .status()
-            .context("Failed to execute systemd-firstboot")?;
-        Command::new("/usr/bin/systemd-firstboot")
-            .args(["--root", ROOT, "--keymap", &self.keymap.to_string()])
-            .status()
-            .context("Failed to execute systemd-firstboot")?;
-        Command::new("/usr/bin/systemd-firstboot")
-            .args([
-                "--root",
-                ROOT,
-                "--force",
+                "--keymap",
+                &self.keymap.to_string(),
                 "--timezone",
-                self.timezone.as_str(),
+                &self.timezone,
             ])
             .status()
             .context("Failed to execute systemd-firstboot")?;

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Sun Dec  3 15:53:34 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Use a single call to systemd-firstboot to write the localization
+  settings (gh#openSUSE/agama#903).
+
+-------------------------------------------------------------------
 Sat Dec  2 18:05:54 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 6

--- a/service/lib/agama/dbus/y2dir/modules/InstFunctions.rb
+++ b/service/lib/agama/dbus/y2dir/modules/InstFunctions.rb
@@ -1,0 +1,58 @@
+# Copyright (c) [2022-2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+# :nodoc:
+module Yast
+  # Replacement for the Yast::Package module
+  #
+  # @see https://github.com/yast/yast-installation/blob/279b7d108eab24082237cf5e3f02a31f58fef8da/src/modules/InstFunctions.rb
+  class InstFunctionsClass < Module
+    def main
+      puts "Loading mocked module #{__FILE__}"
+    end
+
+    # @see https://github.com/yast/yast-installation/blob/279b7d108eab24082237cf5e3f02a31f58fef8da/src/modules/InstFunctions.rb#L56
+    def ignored_features
+      []
+    end
+
+    # @see https://github.com/yast/yast-installation/blob/279b7d108eab24082237cf5e3f02a31f58fef8da/src/modules/InstFunctions.rb#L83
+    def reset_ignored_features; end
+
+    # @see https://github.com/yast/yast-installation/blob/279b7d108eab24082237cf5e3f02a31f58fef8da/src/modules/InstFunctions.rb#L91
+    def feature_ignored?(_feature_name)
+      false
+    end
+
+    # @see https://github.com/yast/yast-installation/blob/279b7d108eab24082237cf5e3f02a31f58fef8da/src/modules/InstFunctions.rb#L107
+    def second_stage_required?
+      false
+    end
+
+    # @see https://github.com/yast/yast-installation/blob/279b7d108eab24082237cf5e3f02a31f58fef8da/src/modules/InstFunctions.rb#L137
+    def self_update_explicitly_enabled?
+      false
+    end
+  end
+
+  InstFunctions = InstFunctionsClass.new
+  InstFunctions.main
+end

--- a/service/lib/agama/dbus/y2dir/storage/modules/InstFunctions.rb
+++ b/service/lib/agama/dbus/y2dir/storage/modules/InstFunctions.rb
@@ -1,0 +1,1 @@
+../../modules/InstFunctions.rb

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sun Dec  3 15:45:22 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Redefine the InstFunctions module to avoid calling code that
+  causes unwanted side effects, like resetting the timezone
+  (gh#openSUSE/agama#903).
+
+-------------------------------------------------------------------
 Sat Dec  2 18:05:37 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 6


### PR DESCRIPTION
## Problem

YaST is rewriting the timezone settings. See #903.

## Solution

* Write the locale settings on a single call.
* Mock the `InstFunctions` module to avoid loading some code when asking whether the second stage will be executed (no second stage in Agama). This code ended up writing the timezone with the wrong value.

## Testing

- Tested manually