### PR TITLE
[web] Make search of selectors case-insensitive

### DIFF
--- a/web/src/components/core/ListSearch.jsx
+++ b/web/src/components/core/ListSearch.jsx
@@ -25,11 +25,13 @@ import { _ } from "~/i18n";
 import { noop, useDebounce } from "~/utils";
 
 const search = (elements, term) => {
+  const value = term.toLowerCase();
+
   const match = (element) => {
     return Object.values(element)
       .join('')
       .toLowerCase()
-      .includes(term);
+      .includes(value);
   };
 
   return elements.filter(match);

--- a/web/src/components/core/ListSearch.test.jsx
+++ b/web/src/components/core/ListSearch.test.jsx
@@ -25,10 +25,10 @@ import { plainRender } from "~/test-utils";
 import { ListSearch } from "~/components/core";
 
 const fruits = [
-  { name: "apple", color: "red", size: "medium" },
-  { name: "banana", color: "yellow", size: "medium" },
-  { name: "grape", color: "green", size: "small" },
-  { name: "pear", color: "green", size: "medium" }
+  { name: "Apple", color: "red", size: "medium" },
+  { name: "Banana", color: "yellow", size: "medium" },
+  { name: "Grape", color: "green", size: "small" },
+  { name: "Pear", color: "green", size: "medium" }
 ];
 
 const FruitList = ({ fruits }) => {
@@ -44,7 +44,7 @@ const FruitList = ({ fruits }) => {
   );
 };
 
-it("searches for elements matching the given text", async () => {
+it("searches for elements matching the given term (case-insensitive)", async () => {
   const { user } = plainRender(<FruitList fruits={fruits} />);
 
   const searchInput = screen.getByRole("search");
@@ -54,47 +54,47 @@ it("searches for elements matching the given text", async () => {
   await waitFor(() => (
     expect(screen.queryByRole("option", { name: /grape/ })).not.toBeInTheDocument())
   );
-  screen.getByRole("option", { name: /apple/ });
-  screen.getByRole("option", { name: /banana/ });
-  screen.getByRole("option", { name: /pear/ });
+  screen.getByRole("option", { name: "Apple" });
+  screen.getByRole("option", { name: "Banana" });
+  screen.getByRole("option", { name: "Pear" });
 
   // Search for "green" fruit
   await user.clear(searchInput);
-  await user.type(searchInput, "green");
+  await user.type(searchInput, "Green");
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /apple/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: "Apple" })).not.toBeInTheDocument())
   );
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /banana/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: "Banana" })).not.toBeInTheDocument())
   );
-  screen.getByRole("option", { name: /grape/ });
-  screen.getByRole("option", { name: /pear/ });
+  screen.getByRole("option", { name: "Grape" });
+  screen.getByRole("option", { name: "Pear" });
 
   // Search for known fruit
   await user.clear(searchInput);
   await user.type(searchInput, "ap");
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /banana/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: "Banana" })).not.toBeInTheDocument())
   );
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /pear/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: "Pear" })).not.toBeInTheDocument())
   );
-  screen.getByRole("option", { name: /apple/ });
-  screen.getByRole("option", { name: /grape/ });
+  screen.getByRole("option", { name: "Apple" });
+  screen.getByRole("option", { name: "Grape" });
 
   // Search for unknown fruit
   await user.clear(searchInput);
   await user.type(searchInput, "tomato");
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /apple/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: "Apple" })).not.toBeInTheDocument())
   );
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /banana/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: "Banana" })).not.toBeInTheDocument())
   );
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /grape/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: "Grape" })).not.toBeInTheDocument())
   );
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /pear/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: "Pear" })).not.toBeInTheDocument())
   );
 });


### PR DESCRIPTION
## Problem

Search introduced in #881 is _pseudo case-sensitve_ by mistake, which results in a not consistent filtering.

| Filtering language by "es_ES" | Filtering languages by "es_es" |
|-|-|
|![Screen Shot 2023-12-01 at 08 23 11](https://github.com/openSUSE/agama/assets/1691872/3561f3f2-851e-47a7-ab88-7de3fd119767) | ![Screen Shot 2023-12-01 at 08 23 16](https://github.com/openSUSE/agama/assets/1691872/de38931a-d847-49a7-a8b9-489c1b757b2b) |


## Solution

Make search _fully_ case-insentitive.


## Testing

- Adapted unit test
- Tested manually

## Screenshots

| Before | After |
|-|-|
|![Screen Shot 2023-12-01 at 08 23 11](https://github.com/openSUSE/agama/assets/1691872/104ea0d9-d742-4c17-8eb8-d07b8171e2d2) |![Screen Shot 2023-12-01 at 08 22 57](https://github.com/openSUSE/agama/assets/1691872/b327bc23-89c8-46e9-8d9d-d642d0558a6b) |


