### PR TITLE
Do not run the integration tests in forks

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -2,8 +2,8 @@ name: "CI - Integration Tests"
 
 on:
   schedule:
-    # at 9:50 UTC every day from Monday to Friday
-    - cron: "50 9 * * 1-5"
+    # at 9:45 UTC every day from Monday to Friday
+    - cron: "45 9 * * 1-5"
 
   # allow running manually
   workflow_dispatch:
@@ -12,6 +12,8 @@ jobs:
   integration-tests:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    # do not run scheduled jobs in forks, in forks only allow manual run ("workflow_dispatch")
+    if: github.repository_owner == 'openSUSE' || github.event_name == 'workflow_dispatch'
 
     steps:
 
@@ -89,7 +91,8 @@ jobs:
     - name: IRC notification
       # see https://github.com/marketplace/actions/irc-message-action
       uses: Gottox/irc-message-action@v2
-      if: failure()
+      # never run in forks
+      if: failure() && github.repository_owner == 'openSUSE'
       with:
         channel: "#yast"
         nickname: github-action


### PR DESCRIPTION
## Problem

- The integration tests use a schedule and are run automatically every day
- If the integration test fails it reports a failure on our IRC channel
- But if it fails in a fork it is just spamming the IRC and we cannot do anything about it anyway

## Solution

- Disable scheduled runs in forks, allow only explicit manual run (if somebody wants to be sure it still works fine)
- Never run the IRC notification in forks, even in manual runs

## Additional Fix

- Run the test 5 minutes earlier to have enough time to check the failure and possibly discuss it on the daily call