### PR TITLE
Add package dependencies

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -68,7 +68,7 @@ jobs:
       run: zypper --non-interactive install rustup
 
     - name: Install required packages
-      run: zypper --non-interactive install  python-langtable-data openssl-3 libopenssl-3-devel jq
+      run: zypper --non-interactive install python-langtable-data openssl-3 libopenssl-3-devel jq
 
     - name: Install Rust toolchains
       run: rustup toolchain install stable

--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -64,10 +64,28 @@ jobs:
       run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && zypper ref
 
     - name: Install Ruby development files
-      run: zypper --non-interactive install gcc gcc-c++ make openssl-devel ruby-devel npm augeas-devel
+      run: zypper --non-interactive install
+        gcc
+        gcc-c++
+        make
+        openssl-devel
+        ruby-devel
+        augeas-devel
 
     - name: Install required packages
-      run: zypper --non-interactive install yast2-iscsi-client
+      run: zypper --non-interactive install
+        suseconnect-ruby-bindings
+        autoyast2-installation
+        yast2
+        yast2-bootloader
+        yast2-country
+        yast2-hardware-detection
+        yast2-installation
+        yast2-iscsi-client
+        yast2-network
+        yast2-proxy
+        yast2-storage-ng
+        yast2-users
 
     - name: Install RubyGems dependencies
       run: bundle config set --local with 'development' && bundle install

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Dec  5 09:46:48 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Explicitly add dependencies instead of relying on the live ISO
+  to provide the required packages (gh#openSUSE/agama/911).
+
+-------------------------------------------------------------------
 Sun Dec  3 15:53:34 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use a single call to systemd-firstboot to write the localization

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -18,28 +18,52 @@
     %global rb_build_versions %{rb_default_ruby}
     BuildRequires:  dbus-1-common
     Requires:       dbus-1-common
+    Requires:       suseconnect-ruby-bindings
+    # YaST dependencies
+    Requires:       autoyast2-installation
+    # ArchFilter
+    Requires:       yast2 >= 4.5.20
     Requires:       yast2-bootloader
     Requires:       yast2-country
     Requires:       yast2-hardware-detection
     Requires:       yast2-installation
+    Requires:       yast2-iscsi-client >= 4.5.7
     Requires:       yast2-network
     Requires:       yast2-proxy
     # ProposalSettings#swap_reuse
     Requires:       yast2-storage-ng >= 5.0.3
-    Requires:       open-iscsi
-    Requires:       yast2-iscsi-client >= 4.5.7
     Requires:       yast2-users
-    # required for registration
-    Requires:       suseconnect-ruby-bindings
-    # yast2 with ArchFilter
-    Requires:       yast2 >= 4.5.20
-    # storage dependencies
-    Requires:       ntfs-3g
-    Requires:       ntfsprogs
-    Requires:       snapper
     %ifarch s390 s390x
     Requires:       yast2-s390 >= 4.6.4
+    Requires:       yast2-reipl
+    Requires:       yast2-cio
     %endif
+    # Storage dependencies
+    Requires:       bcache-tools
+    Requires:       btrfsprogs
+    Requires:       cryptsetup
+    Requires:       dmraid
+    Requires:       dosfstools
+    Requires:       e2fsprogs
+    Requires:       exfat-utils
+    Requires:       f2fs-tools
+    Requires:       fcoe-utils
+    Requires:       fde-tools
+    Requires:       jfsutils
+    Requires:       libstorage-ng-lang
+    Requires:       lvm2
+    Requires:       mdadm
+    Requires:       multipath-tools
+    Requires:       nilfs-utils
+    Requires:       nfs-client
+    Requires:       ntfs-3g
+    Requires:       ntfsprogs
+    Requires:       nvme-cli
+    Requires:       open-iscsi
+    Requires:       quota
+    Requires:       snapper
+    Requires:       udftools
+    Requires:       xfsprogs
   :filelist: "%{_datadir}/dbus-1/agama.conf\n
     %dir %{_datadir}/dbus-1/agama-services\n
     %{_datadir}/dbus-1/agama-services/org.opensuse.Agama*.service\n

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Dec  5 09:49:10 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Explicitly add dependencies instead of relying on the live ISO
+  to provide the required packages (gh#openSUSE/agama/911).
+
+-------------------------------------------------------------------
 Sun Dec  3 15:45:22 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Redefine the InstFunctions module to avoid calling code that

--- a/setup-service.sh
+++ b/setup-service.sh
@@ -88,8 +88,7 @@ snapper \
 udftools \
 xfsprogs || exit 1
 
-# - Install service rubygem dependencies
-# Install s390 pakcages (do not exit on failure).
+# Install s390 packages (do not exit on failure).
 $SUDO zypper --non-interactive --gpg-auto-import-keys install \
 yast2-s390 \
 yast2-reipl \
@@ -102,15 +101,24 @@ yast2-cio
   bundle install
 )
 
-# Rust service
+# Rust service, CLI and auto-installation.
+
+# Only install cargo if it is not available (avoid conflicts with rustup)
+which cargo || $SUDO zypper --non-interactive install cargo
 
 # This repo can be removed once python-language-data reaches Factory.
 test -f /etc/zypp/repos.d/d_l_python.repo || \
   $SUDO zypper --non-interactive \
     addrepo https://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Tumbleweed/ d_l_python
 
-# Only install cargo if it is not available (avoid conflicts with rustup)
-which cargo || $SUDO zypper --non-interactive install cargo
+# Packages required by Rust code (see ./rust/package/agama-cli.spec)
+$SUDO zypper --non-interactive install \
+bzip2 \
+jsonnet \
+lshw \
+python-langtable-data \
+tar \
+xkeyboard-config-lang || exit 1
 
 (
   cd $MYDIR/rust

--- a/setup-service.sh
+++ b/setup-service.sh
@@ -32,29 +32,86 @@ sudosed() {
   sed -e "$1" "$2" | $SUDO tee "$3" > /dev/null
 }
 
-# - Install RPM dependencies
-
-# this repo can be removed once python-language-data reaches Factory
-test -f /etc/zypp/repos.d/d_l_python.repo || \
-  $SUDO zypper --non-interactive \
-    addrepo https://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Tumbleweed/ d_l_python
-$SUDO zypper --non-interactive --gpg-auto-import-keys install gcc gcc-c++ make openssl-devel ruby-devel \
-  python-langtable-data git augeas-devel jemalloc-devel awk suseconnect-ruby-bindings || exit 1
-
-# only install cargo if it is not available (avoid conflicts with rustup)
-which cargo || $SUDO zypper --non-interactive install cargo
-
 # if agama is already running -> stop it
 $SUDO systemctl list-unit-files agama.service &>/dev/null && $SUDO systemctl stop agama.service
 
+# Ruby services
+
+# Packages required for Ruby development (i.e., bundle install).
+$SUDO zypper --non-interactive --gpg-auto-import-keys install \
+gcc \
+gcc-c++ \
+make \
+openssl-devel \
+ruby-devel \
+augeas-devel || exit 1
+
+# Packages required by Agama Ruby services (see ./service/package/gem2rpm.yml).
+# TODO extract list from gem2rpm.yml
+$SUDO zypper --non-interactive --gpg-auto-import-keys install \
+dbus-1-common \
+suseconnect-ruby-bindings \
+autoyast2-installation \
+yast2 \
+yast2-bootloader \
+yast2-country \
+yast2-hardware-detection \
+yast2-installation \
+yast2-iscsi-client \
+yast2-network \
+yast2-proxy \
+yast2-storage-ng \
+yast2-users \
+bcache-tools \
+btrfsprogs \
+cryptsetup \
+dmraid \
+dosfstools \
+e2fsprogs \
+exfat-utils \
+f2fs-tools \
+fcoe-utils \
+fde-tools \
+jfsutils \
+libstorage-ng-lang \
+lvm2 \
+mdadm \
+multipath-tools \
+nilfs-utils \
+nfs-client \
+ntfs-3g \
+ntfsprogs \
+nvme-cli \
+open-iscsi \
+quota \
+snapper \
+udftools \
+xfsprogs || exit 1
+
 # - Install service rubygem dependencies
+# Install s390 pakcages (do not exit on failure).
+$SUDO zypper --non-interactive --gpg-auto-import-keys install \
+yast2-s390 \
+yast2-reipl \
+yast2-cio
+
+# Rubygem dependencies
 (
   cd $MYDIR/service
   bundle config set --local path 'vendor/bundle'
   bundle install
 )
 
-# - build also rust service
+# Rust service
+
+# This repo can be removed once python-language-data reaches Factory.
+test -f /etc/zypp/repos.d/d_l_python.repo || \
+  $SUDO zypper --non-interactive \
+    addrepo https://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Tumbleweed/ d_l_python
+
+# Only install cargo if it is not available (avoid conflicts with rustup)
+which cargo || $SUDO zypper --non-interactive install cargo
+
 (
   cd $MYDIR/rust
   cargo build

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -1,13 +1,11 @@
 #!/bin/sh -x
 
-# Using a git checkout in the current directory,
-# set up the service (backend) part of agama
-# so that it can be used by
-# - the web frontend (as set up by setup.sh)
+# Using a git checkout in the current directory and set up the services, so that it can be used by:
+# - the web frontend (as set up by setup-web.sh)
 # - the CLI
 # or both
 
-# Exit on error; unset variables are an error
+# Exit on error; unset variables are an error.
 set -eu
 
 MYDIR=$(realpath $(dirname $0))

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -104,11 +104,6 @@ $SUDO zypper --non-interactive --gpg-auto-import-keys install \
 # Only install cargo if it is not available (avoid conflicts with rustup)
 which cargo || $SUDO zypper --non-interactive install cargo
 
-# This repo can be removed once python-language-data reaches Factory.
-test -f /etc/zypp/repos.d/d_l_python.repo || \
-  $SUDO zypper --non-interactive \
-    addrepo https://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Tumbleweed/ d_l_python
-
 # Packages required by Rust code (see ./rust/package/agama-cli.spec)
 $SUDO zypper --non-interactive install \
   bzip2 \

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -37,60 +37,60 @@ $SUDO systemctl list-unit-files agama.service &>/dev/null && $SUDO systemctl sto
 
 # Packages required for Ruby development (i.e., bundle install).
 $SUDO zypper --non-interactive --gpg-auto-import-keys install \
-gcc \
-gcc-c++ \
-make \
-openssl-devel \
-ruby-devel \
-augeas-devel || exit 1
+  gcc \
+  gcc-c++ \
+  make \
+  openssl-devel \
+  ruby-devel \
+  augeas-devel || exit 1
 
 # Packages required by Agama Ruby services (see ./service/package/gem2rpm.yml).
 # TODO extract list from gem2rpm.yml
 $SUDO zypper --non-interactive --gpg-auto-import-keys install \
-dbus-1-common \
-suseconnect-ruby-bindings \
-autoyast2-installation \
-yast2 \
-yast2-bootloader \
-yast2-country \
-yast2-hardware-detection \
-yast2-installation \
-yast2-iscsi-client \
-yast2-network \
-yast2-proxy \
-yast2-storage-ng \
-yast2-users \
-bcache-tools \
-btrfsprogs \
-cryptsetup \
-dmraid \
-dosfstools \
-e2fsprogs \
-exfat-utils \
-f2fs-tools \
-fcoe-utils \
-fde-tools \
-jfsutils \
-libstorage-ng-lang \
-lvm2 \
-mdadm \
-multipath-tools \
-nilfs-utils \
-nfs-client \
-ntfs-3g \
-ntfsprogs \
-nvme-cli \
-open-iscsi \
-quota \
-snapper \
-udftools \
-xfsprogs || exit 1
+  dbus-1-common \
+  suseconnect-ruby-bindings \
+  autoyast2-installation \
+  yast2 \
+  yast2-bootloader \
+  yast2-country \
+  yast2-hardware-detection \
+  yast2-installation \
+  yast2-iscsi-client \
+  yast2-network \
+  yast2-proxy \
+  yast2-storage-ng \
+  yast2-users \
+  bcache-tools \
+  btrfsprogs \
+  cryptsetup \
+  dmraid \
+  dosfstools \
+  e2fsprogs \
+  exfat-utils \
+  f2fs-tools \
+  fcoe-utils \
+  fde-tools \
+  jfsutils \
+  libstorage-ng-lang \
+  lvm2 \
+  mdadm \
+  multipath-tools \
+  nilfs-utils \
+  nfs-client \
+  ntfs-3g \
+  ntfsprogs \
+  nvme-cli \
+  open-iscsi \
+  quota \
+  snapper \
+  udftools \
+  xfsprogs || exit 1
 
 # Install s390 packages (do not exit on failure).
 $SUDO zypper --non-interactive --gpg-auto-import-keys install \
-yast2-s390 \
-yast2-reipl \
-yast2-cio
+  yast2-s390 \
+  yast2-reipl \
+  yast2-cio
 
 # Rubygem dependencies
 (
@@ -111,12 +111,12 @@ test -f /etc/zypp/repos.d/d_l_python.repo || \
 
 # Packages required by Rust code (see ./rust/package/agama-cli.spec)
 $SUDO zypper --non-interactive install \
-bzip2 \
-jsonnet \
-lshw \
-python-langtable-data \
-tar \
-xkeyboard-config-lang || exit 1
+  bzip2 \
+  jsonnet \
+  lshw \
+  python-langtable-data \
+  tar \
+  xkeyboard-config-lang || exit 1
 
 (
   cd $MYDIR/rust

--- a/setup-web.sh
+++ b/setup-web.sh
@@ -1,0 +1,29 @@
+#!/bin/sh -x
+
+# Exit on error; unset variables are an error.
+set -eu
+
+MYDIR=$(realpath $(dirname $0))
+
+# Helper:
+# Ensure root privileges for the installation.
+# In a testing container, we are root but there is no sudo.
+if [ $(id --user) != 0 ]; then
+  SUDO=sudo
+  if [ $($SUDO id --user) != 0 ]; then
+    echo "We are not root and cannot sudo, cannot continue."
+    exit 1
+  fi
+else
+  SUDO=""
+fi
+
+$SUDO zypper --non-interactive --gpg-auto-import-keys install \
+  make \
+  'npm>=18' \
+  cockpit || exit 1
+
+$SUDO systemctl start cockpit
+
+cd web; make devel-install; cd -
+$SUDO ln -snf `pwd`/web/dist /usr/share/cockpit/agama

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-# This script sets up the development environment without installing any
-# package. This script is supposed to run within a repository clone.
+# This script sets up the development environment without installing Agama packages. This script is
+# supposed to run within a repository clone.
 
-# Exit on error; unset variables are an error
+# Exit on error; unset variables are an error.
 set -eu
 
 MYDIR=$(realpath $(dirname $0))
@@ -21,29 +21,23 @@ else
   SUDO=""
 fi
 
-# Backend setup
-
-if ! $MYDIR/setup-service.sh; then
-  echo "Backend setup failed."
-  echo "Agama service is NOT running."
+# Services setup
+if ! $MYDIR/setup-services.sh; then
+  echo "Services setup failed."
+  echo "Agama services are NOT running."
 
   exit 2
 fi;
 
-# Install Frontend dependencies
+# Web setup
+if ! $MYDIR/setup-web.sh; then
+  echo "Web client setup failed."
+  echo "Agama web client is NOT running."
 
-$SUDO zypper --non-interactive --gpg-auto-import-keys install \
-  make git 'npm>=18' cockpit
+  exit 3
+fi;
 
-# Web Frontend
-
-$SUDO systemctl start cockpit
-
-# set up the web UI
-cd web; make devel-install; cd -
-$SUDO ln -snf `pwd`/web/dist /usr/share/cockpit/agama
-
-# Start the installer
+# Start the installer.
 echo
 echo "D-Bus will start the services, see journalctl for their logs."
 echo "To start the services manually, logging to the terminal:"


### PR DESCRIPTION
## Problem

From time to time an issue is reported because some missing dependency in the Agama live image (many times related to missing storage packages). Moreover, Agama depencencies are directly added to the ISO kiwi file, forcing to  all our live images to include that list of packages. Agama should requires its own dependencies instead on relying on the live iso to provide them.  

## Solution

* Collect a list of Agama dependencies by inspecting the packages included by YaST installation images, the kiwi files and the storage features used by *yast2-storage-ng*:
  * https://github.com/openSUSE/installation-images/blob/master/obs/installation-images.spec
  * https://github.com/openSUSE/installation-images/blob/master/data/root/root.file_list
  * https://build.opensuse.org/package/show/systemsmanagement:Agama:Staging/agama-live 
  * https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2storage/storage_feature.rb
* Add dependencies directly to the Agama spec files.
* Remove Agama dependencies from kiwi files: 
  * https://build.opensuse.org/package/rdiff/systemsmanagement:Agama:Staging/agama-live?linkrev=base&rev=26
  * https://build.opensuse.org/package/rdiff/systemsmanagement:Agama:Devel/agama-live?linkrev=base&rev=9
* Add dependencies to `setup` scripts.
* Install required depedencies for CI tasks.

Notes:

* Right now both the `setup` scripts and the spec files contain almost the same list of packages. They should be unified.
* For CI tasks not all dependencies are installed, but only the required dependencies for running the tasks (e.g., unit tests).
* [Agama live imagein IBS](https://build.suse.de/package/show/SUSE:ALP:Products:Installer:1.0/agama-live) was not updated (YaST team does not maintain that image). Agama packages with the new dependencies will be submitted to IBS with the next Agama release. 
