### PR TITLE
Only stop agama service in setup script if it exists

### DIFF
--- a/setup-service.sh
+++ b/setup-service.sh
@@ -45,7 +45,7 @@ $SUDO zypper --non-interactive --gpg-auto-import-keys install gcc gcc-c++ make o
 which cargo || $SUDO zypper --non-interactive install cargo
 
 # if agama is already running -> stop it
-$SUDO systemctl stop agama.service
+$SUDO systemctl list-unit-files agama.service &>/dev/null && $SUDO systemctl stop agama.service
 
 # - Install service rubygem dependencies
 (


### PR DESCRIPTION
## Problem

Commit f65e6c9 broke my personal way of setting up a testing container, because the service isn't yet registered and the setup script exits with an error.

## Solution

Only stop service if it already exists.

## Testing

- *Tested manually*