### PR TITLE
Add dummy device type to network model

### DIFF
--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -221,6 +221,7 @@ pub enum Connection {
     Ethernet(EthernetConnection),
     Wireless(WirelessConnection),
     Loopback(LoopbackConnection),
+    Dummy(DummyConnection),
 }
 
 impl Connection {
@@ -236,6 +237,7 @@ impl Connection {
             }),
             DeviceType::Loopback => Connection::Loopback(LoopbackConnection { base }),
             DeviceType::Ethernet => Connection::Ethernet(EthernetConnection { base }),
+            DeviceType::Dummy => Connection::Dummy(DummyConnection { base }),
         }
     }
 
@@ -246,6 +248,7 @@ impl Connection {
             Connection::Ethernet(conn) => &conn.base,
             Connection::Wireless(conn) => &conn.base,
             Connection::Loopback(conn) => &conn.base,
+            Connection::Dummy(conn) => &conn.base,
         }
     }
 
@@ -254,6 +257,7 @@ impl Connection {
             Connection::Ethernet(conn) => &mut conn.base,
             Connection::Wireless(conn) => &mut conn.base,
             Connection::Loopback(conn) => &mut conn.base,
+            Connection::Dummy(conn) => &mut conn.base,
         }
     }
 
@@ -476,6 +480,11 @@ pub struct WirelessConnection {
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct LoopbackConnection {
+    pub base: BaseConnection,
+}
+
+#[derive(Debug, Default, PartialEq, Clone)]
+pub struct DummyConnection {
     pub base: BaseConnection,
 }
 

--- a/rust/agama-dbus-server/src/network/nm/dbus.rs
+++ b/rust/agama-dbus-server/src/network/nm/dbus.rs
@@ -17,6 +17,7 @@ const ETHERNET_KEY: &str = "802-3-ethernet";
 const WIRELESS_KEY: &str = "802-11-wireless";
 const WIRELESS_SECURITY_KEY: &str = "802-11-wireless-security";
 const LOOPBACK_KEY: &str = "loopback";
+const DUMMY_KEY: &str = "dummy";
 
 /// Converts a connection struct into a HashMap that can be sent over D-Bus.
 ///
@@ -40,6 +41,10 @@ pub fn connection_to_dbus(conn: &Connection) -> NestedHash {
         }
     }
 
+    if let Connection::Dummy(_) = conn {
+        connection_dbus.insert("type", DUMMY_KEY.into());
+    }
+
     result.insert("connection", connection_dbus);
     result
 }
@@ -56,6 +61,10 @@ pub fn connection_from_dbus(conn: OwnedNestedHash) -> Option<Connection> {
             wireless: wireless_config,
         }));
     }
+
+    if conn.get(DUMMY_KEY).is_some() {
+        return Some(Connection::Dummy(DummyConnection { base }));
+    };
 
     if conn.get(LOOPBACK_KEY).is_some() {
         return Some(Connection::Loopback(LoopbackConnection { base }));

--- a/rust/agama-dbus-server/src/network/nm/model.rs
+++ b/rust/agama-dbus-server/src/network/nm/model.rs
@@ -83,6 +83,7 @@ impl TryFrom<NmDeviceType> for DeviceType {
             NmDeviceType(0) => Ok(DeviceType::Loopback),
             NmDeviceType(1) => Ok(DeviceType::Ethernet),
             NmDeviceType(2) => Ok(DeviceType::Wireless),
+            NmDeviceType(3) => Ok(DeviceType::Dummy),
             NmDeviceType(_) => Err(NmError::UnsupportedDeviceType(value.into())),
         }
     }

--- a/rust/agama-lib/src/network/types.rs
+++ b/rust/agama-lib/src/network/types.rs
@@ -29,6 +29,7 @@ pub enum DeviceType {
     Loopback = 0,
     Ethernet = 1,
     Wireless = 2,
+    Dummy = 3,
 }
 
 #[derive(Debug, Error, PartialEq)]
@@ -43,6 +44,7 @@ impl TryFrom<u8> for DeviceType {
             0 => Ok(DeviceType::Loopback),
             1 => Ok(DeviceType::Ethernet),
             2 => Ok(DeviceType::Wireless),
+            3 => Ok(DeviceType::Dummy),
             _ => Err(InvalidDeviceType(value)),
         }
     }


### PR DESCRIPTION
## Problem

No dummy device type in network model.

## Solution

Add dummy device type to network model.

## Testing

- *Tested manually*
- *Tested using wicked migration*