### PR TITLE
Autoinstallation for localization (l10n) settings

### DIFF
--- a/rust/agama-cli/src/profile.rs
+++ b/rust/agama-cli/src/profile.rs
@@ -20,7 +20,7 @@ fn validate(path: String) -> anyhow::Result<()> {
     let path = Path::new(&path);
     let result = validator
         .validate_file(path)
-        .context("Could not validate the profile")?;
+        .context(format!("Could not validate the profile {:?}", path))?;
     match result {
         ValidationResult::Valid => {
             println!("The profile is valid")

--- a/rust/agama-dbus-server/src/l10n.rs
+++ b/rust/agama-dbus-server/src/l10n.rs
@@ -106,10 +106,12 @@ impl Locale {
     fn set_keymap(&mut self, keymap_id: &str) -> Result<(), zbus::fdo::Error> {
         let keymap_id: KeymapId = keymap_id
             .parse()
-            .map_err(|_e| zbus::fdo::Error::InvalidArgs("Invalid keymap".to_string()))?;
+            .map_err(|_e| zbus::fdo::Error::InvalidArgs("Cannot parse keymap ID".to_string()))?;
 
         if !self.keymaps_db.exists(&keymap_id) {
-            return Err(zbus::fdo::Error::Failed("Invalid keymap value".to_string()));
+            return Err(zbus::fdo::Error::Failed(
+                "Cannot find this keymap".to_string(),
+            ));
         }
         self.keymap = keymap_id;
         Ok(())

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -243,6 +243,10 @@
         "keyboard": {
           "description": "Keyboard layout ID",
           "type": "string"
+        },
+        "timezone": {
+          "description": "Time zone identifier such as 'Europe/Berlin'",
+          "type": "string"
         }
       }
     },

--- a/rust/agama-lib/src/error.rs
+++ b/rust/agama-lib/src/error.rs
@@ -34,4 +34,6 @@ pub enum ProfileError {
     InputOutputError(#[from] io::Error),
     #[error("The profile is not a valid JSON file")]
     FormatError(#[from] serde_json::Error),
+    #[error("Error: {0}")]
+    Anyhow(#[from] anyhow::Error),
 }

--- a/rust/agama-lib/src/install_settings.rs
+++ b/rust/agama-lib/src/install_settings.rs
@@ -2,8 +2,8 @@
 //!
 //! This module implements the mechanisms to load and store the installation settings.
 use crate::{
-    network::NetworkSettings, product::ProductSettings, software::SoftwareSettings,
-    storage::StorageSettings, users::UserSettings,
+    localization::LocalizationSettings, network::NetworkSettings, product::ProductSettings,
+    software::SoftwareSettings, storage::StorageSettings, users::UserSettings,
 };
 use agama_settings::Settings;
 use serde::{Deserialize, Serialize};
@@ -26,14 +26,17 @@ pub enum Scope {
     Network,
     /// Product settings
     Product,
+    /// Localization settings
+    Localization,
 }
 
 impl Scope {
     /// Returns known scopes
     ///
     // TODO: we can rely on strum so we do not forget to add them
-    pub fn all() -> [Scope; 5] {
+    pub fn all() -> [Scope; 6] {
         [
+            Scope::Localization,
             Scope::Network,
             Scope::Product,
             Scope::Software,
@@ -53,6 +56,7 @@ impl FromStr for Scope {
             "storage" => Ok(Self::Storage),
             "network" => Ok(Self::Network),
             "product" => Ok(Self::Product),
+            "localization" => Ok(Self::Localization),
             _ => Err("Unknown section"),
         }
     }
@@ -80,6 +84,9 @@ pub struct InstallSettings {
     #[serde(default)]
     #[settings(nested)]
     pub network: Option<NetworkSettings>,
+    #[serde(default)]
+    #[settings(nested)]
+    pub localization: Option<LocalizationSettings>,
 }
 
 impl InstallSettings {
@@ -101,6 +108,9 @@ impl InstallSettings {
         }
         if self.product.is_some() {
             scopes.push(Scope::Product);
+        }
+        if self.localization.is_some() {
+            scopes.push(Scope::Localization);
         }
         scopes
     }

--- a/rust/agama-lib/src/lib.rs
+++ b/rust/agama-lib/src/lib.rs
@@ -25,6 +25,7 @@
 
 pub mod error;
 pub mod install_settings;
+pub mod localization;
 pub mod manager;
 pub mod network;
 pub mod product;

--- a/rust/agama-lib/src/localization.rs
+++ b/rust/agama-lib/src/localization.rs
@@ -1,6 +1,7 @@
 //! Implements support for handling the localization settings
 
 mod client;
+mod proxies;
 mod settings;
 mod store;
 

--- a/rust/agama-lib/src/localization.rs
+++ b/rust/agama-lib/src/localization.rs
@@ -1,5 +1,9 @@
 //! Implements support for handling the localization settings
 
+mod client;
 mod settings;
+mod store;
 
+pub use client::LocalizationClient;
 pub use settings::LocalizationSettings;
+pub use store::LocalizationStore;

--- a/rust/agama-lib/src/localization.rs
+++ b/rust/agama-lib/src/localization.rs
@@ -1,0 +1,5 @@
+//! Implements support for handling the localization settings
+
+mod settings;
+
+pub use settings::LocalizationSettings;

--- a/rust/agama-lib/src/localization/client.rs
+++ b/rust/agama-lib/src/localization/client.rs
@@ -1,0 +1,37 @@
+use crate::error::ServiceError;
+use crate::proxies::LocaleProxy;
+use zbus::Connection;
+
+/// D-Bus client for the software service
+pub struct LocalizationClient<'a> {
+    localization_proxy: LocaleProxy<'a>,
+}
+
+impl<'a> LocalizationClient<'a> {
+    pub async fn new(connection: Connection) -> Result<LocalizationClient<'a>, ServiceError> {
+        Ok(Self {
+            localization_proxy: LocaleProxy::new(&connection).await?,
+        })
+    }
+
+    pub async fn language(&self) -> Result<String, ServiceError> {
+        let locales = self.localization_proxy.locales().await?;
+        if locales.is_empty() {
+            // FIXME is this right?
+            Ok("".to_owned())
+        } else {
+            // without clone:
+            // error[E0507]: cannot move out of index of `Vec<std::string::String>`
+            // but why, it's a Vec<String> I should be able to move it?!
+            Ok(locales[0].clone())
+        }
+    }
+
+    pub async fn keyboard(&self) -> Result<String, ServiceError> {
+        Ok(self.localization_proxy.keymap().await?)
+    }
+
+    pub async fn timezone(&self) -> Result<String, ServiceError> {
+        Ok(self.localization_proxy.timezone().await?)
+    }
+}

--- a/rust/agama-lib/src/localization/client.rs
+++ b/rust/agama-lib/src/localization/client.rs
@@ -34,4 +34,17 @@ impl<'a> LocalizationClient<'a> {
     pub async fn timezone(&self) -> Result<String, ServiceError> {
         Ok(self.localization_proxy.timezone().await?)
     }
+
+    pub async fn set_language(&self, language: &str) -> zbus::Result<()> {
+        let locales = [language];
+        self.localization_proxy.set_locales(&locales).await
+    }
+
+    pub async fn set_keyboard(&self, keyboard: &str) -> zbus::Result<()> {
+        self.localization_proxy.set_keymap(keyboard).await
+    }
+
+    pub async fn set_timezone(&self, timezone: &str) -> zbus::Result<()> {
+        self.localization_proxy.set_timezone(timezone).await
+    }
 }

--- a/rust/agama-lib/src/localization/client.rs
+++ b/rust/agama-lib/src/localization/client.rs
@@ -14,17 +14,12 @@ impl<'a> LocalizationClient<'a> {
         })
     }
 
-    pub async fn language(&self) -> Result<String, ServiceError> {
+    pub async fn language(&self) -> Result<Option<String>, ServiceError> {
         let locales = self.localization_proxy.locales().await?;
-        if locales.is_empty() {
-            // FIXME is this right?
-            Ok("".to_owned())
-        } else {
-            // without clone:
-            // error[E0507]: cannot move out of index of `Vec<std::string::String>`
-            // but why, it's a Vec<String> I should be able to move it?!
-            Ok(locales[0].clone())
-        }
+        let mut iter = locales.into_iter();
+        let first = iter.next();
+        // may be None
+        Ok(first)
     }
 
     pub async fn keyboard(&self) -> Result<String, ServiceError> {

--- a/rust/agama-lib/src/localization/client.rs
+++ b/rust/agama-lib/src/localization/client.rs
@@ -1,5 +1,5 @@
+use super::proxies::LocaleProxy;
 use crate::error::ServiceError;
-use crate::proxies::LocaleProxy;
 use zbus::Connection;
 
 /// D-Bus client for the software service

--- a/rust/agama-lib/src/localization/proxies.rs
+++ b/rust/agama-lib/src/localization/proxies.rs
@@ -1,0 +1,44 @@
+use zbus::dbus_proxy;
+
+#[dbus_proxy(
+    interface = "org.opensuse.Agama1.Locale",
+    default_service = "org.opensuse.Agama1",
+    default_path = "/org/opensuse/Agama1/Locale"
+)]
+trait Locale {
+    /// Commit method
+    fn commit(&self) -> zbus::Result<()>;
+
+    /// ListKeymaps method
+    fn list_keymaps(&self) -> zbus::Result<Vec<(String, String)>>;
+
+    /// ListLocales method
+    fn list_locales(&self) -> zbus::Result<Vec<(String, String, String)>>;
+
+    /// ListTimezones method
+    fn list_timezones(&self) -> zbus::Result<Vec<(String, Vec<String>)>>;
+
+    /// Keymap property
+    #[dbus_proxy(property)]
+    fn keymap(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
+    fn set_keymap(&self, value: &str) -> zbus::Result<()>;
+
+    /// Locales property
+    #[dbus_proxy(property)]
+    fn locales(&self) -> zbus::Result<Vec<String>>;
+    #[dbus_proxy(property)]
+    fn set_locales(&self, value: &[&str]) -> zbus::Result<()>;
+
+    /// Timezone property
+    #[dbus_proxy(property)]
+    fn timezone(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
+    fn set_timezone(&self, value: &str) -> zbus::Result<()>;
+
+    /// UILocale property
+    #[dbus_proxy(property, name = "UILocale")]
+    fn uilocale(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
+    fn set_uilocale(&self, value: &str) -> zbus::Result<()>;
+}

--- a/rust/agama-lib/src/localization/settings.rs
+++ b/rust/agama-lib/src/localization/settings.rs
@@ -1,0 +1,16 @@
+//! Representation of the localization settings
+
+use agama_settings::Settings;
+use serde::{Deserialize, Serialize};
+
+/// Localization settings for the system being installed (not the UI)
+#[derive(Debug, Default, Settings, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalizationSettings {
+    /// like "en_US.UTF-8"
+    pub language: Option<String>,
+    /// like "cz(qwerty)"
+    pub keyboard: Option<String>,
+    /// like "Europe/Berlin"
+    pub timezone: Option<String>,
+}

--- a/rust/agama-lib/src/localization/store.rs
+++ b/rust/agama-lib/src/localization/store.rs
@@ -22,12 +22,12 @@ impl<'a> LocalizationStore<'a> {
         // but LocaleProxy does not have it, only get_property for individual methods
         // and properties_proxy is private
 
-        let language = self.localization_client.language().await?;
+        let opt_language = self.localization_client.language().await?;
         let keyboard = self.localization_client.keyboard().await?;
         let timezone = self.localization_client.timezone().await?;
 
         Ok(LocalizationSettings {
-            language: Some(language),
+            language: opt_language,
             keyboard: Some(keyboard),
             timezone: Some(timezone),
         })

--- a/rust/agama-lib/src/localization/store.rs
+++ b/rust/agama-lib/src/localization/store.rs
@@ -33,9 +33,19 @@ impl<'a> LocalizationStore<'a> {
         })
     }
 
-    pub async fn store(&self, _settings: &LocalizationSettings) -> Result<(), ServiceError> {
-        // FIXME: not so trivial to copy from Storage
-        //self.localization_client.calculate(settings).await?;
+    pub async fn store(&self, settings: &LocalizationSettings) -> Result<(), ServiceError> {
+        if let Some(language) = &settings.language {
+            self.localization_client.set_language(language).await?;
+        }
+
+        if let Some(keyboard) = &settings.keyboard {
+            self.localization_client.set_keyboard(keyboard).await?;
+        }
+
+        if let Some(timezone) = &settings.timezone {
+            self.localization_client.set_timezone(timezone).await?;
+        }
+
         Ok(())
     }
 }

--- a/rust/agama-lib/src/localization/store.rs
+++ b/rust/agama-lib/src/localization/store.rs
@@ -1,0 +1,41 @@
+//! Implements the store for the localization settings.
+// TODO: for an overview see crate::store (?)
+
+use super::{LocalizationClient, LocalizationSettings};
+use crate::error::ServiceError;
+use zbus::Connection;
+
+/// Loads and stores the storage settings from/to the D-Bus service.
+pub struct LocalizationStore<'a> {
+    localization_client: LocalizationClient<'a>,
+}
+
+impl<'a> LocalizationStore<'a> {
+    pub async fn new(connection: Connection) -> Result<LocalizationStore<'a>, ServiceError> {
+        Ok(Self {
+            localization_client: LocalizationClient::new(connection).await?,
+        })
+    }
+
+    pub async fn load(&self) -> Result<LocalizationSettings, ServiceError> {
+        // TODO: we should use a single D-Bus call with Properties.GetAll
+        // but LocaleProxy does not have it, only get_property for individual methods
+        // and properties_proxy is private
+
+        let language = self.localization_client.language().await?;
+        let keyboard = self.localization_client.keyboard().await?;
+        let timezone = self.localization_client.timezone().await?;
+
+        Ok(LocalizationSettings {
+            language: Some(language),
+            keyboard: Some(keyboard),
+            timezone: Some(timezone),
+        })
+    }
+
+    pub async fn store(&self, _settings: &LocalizationSettings) -> Result<(), ServiceError> {
+        // FIXME: not so trivial to copy from Storage
+        //self.localization_client.calculate(settings).await?;
+        Ok(())
+    }
+}

--- a/rust/agama-lib/src/profile.rs
+++ b/rust/agama-lib/src/profile.rs
@@ -87,7 +87,7 @@ impl ProfileValidator {
         let contents = serde_json::from_str(profile)?;
         let result = self.schema.validate(&contents);
         if let Err(errors) = result {
-            let messages: Vec<String> = errors.map(|e| format!("{e}")).collect();
+            let messages: Vec<String> = errors.map(|e| format!("{e}. {e:?}")).collect();
             return Ok(ValidationResult::NotValid(messages));
         }
         Ok(ValidationResult::Valid)

--- a/rust/agama-lib/src/profile.rs
+++ b/rust/agama-lib/src/profile.rs
@@ -67,12 +67,13 @@ impl ProfileValidator {
         } else {
             Path::new("/usr/share/agama-cli/profile.schema.json")
         };
-        info!("Validation with path {}", path.to_str().unwrap());
+        info!("Validation with path {:?}", path);
         Self::new(path)
     }
 
     pub fn new(schema_path: &Path) -> Result<Self, ProfileError> {
-        let contents = fs::read_to_string(schema_path)?;
+        let contents = fs::read_to_string(schema_path)
+            .context(format!("Failed to read schema at {:?}", schema_path))?;
         let schema = serde_json::from_str(&contents)?;
         let schema = JSONSchema::compile(&schema).expect("A valid schema");
         Ok(Self { schema })

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -98,21 +98,25 @@ trait Locale {
     /// Keymap property
     #[dbus_proxy(property)]
     fn keymap(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
     fn set_keymap(&self, value: &str) -> zbus::Result<()>;
 
     /// Locales property
     #[dbus_proxy(property)]
     fn locales(&self) -> zbus::Result<Vec<String>>;
+    #[dbus_proxy(property)]
     fn set_locales(&self, value: &[&str]) -> zbus::Result<()>;
 
     /// Timezone property
     #[dbus_proxy(property)]
     fn timezone(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
     fn set_timezone(&self, value: &str) -> zbus::Result<()>;
 
     /// UILocale property
     #[dbus_proxy(property, name = "UILocale")]
     fn uilocale(&self) -> zbus::Result<String>;
+    #[dbus_proxy(property)]
     fn set_uilocale(&self, value: &str) -> zbus::Result<()>;
 }
 

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -75,6 +75,8 @@ trait Manager {
     ) -> zbus::Result<Vec<std::collections::HashMap<String, zbus::zvariant::OwnedValue>>>;
 }
 
+// IT'S HERE (FIXME: remove this)
+
 #[dbus_proxy(
     interface = "org.opensuse.Agama1.Locale",
     default_service = "org.opensuse.Agama1",

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -75,51 +75,6 @@ trait Manager {
     ) -> zbus::Result<Vec<std::collections::HashMap<String, zbus::zvariant::OwnedValue>>>;
 }
 
-// IT'S HERE (FIXME: remove this)
-
-#[dbus_proxy(
-    interface = "org.opensuse.Agama1.Locale",
-    default_service = "org.opensuse.Agama1",
-    default_path = "/org/opensuse/Agama1/Locale"
-)]
-trait Locale {
-    /// Commit method
-    fn commit(&self) -> zbus::Result<()>;
-
-    /// ListKeymaps method
-    fn list_keymaps(&self) -> zbus::Result<Vec<(String, String)>>;
-
-    /// ListLocales method
-    fn list_locales(&self) -> zbus::Result<Vec<(String, String, String)>>;
-
-    /// ListTimezones method
-    fn list_timezones(&self) -> zbus::Result<Vec<(String, Vec<String>)>>;
-
-    /// Keymap property
-    #[dbus_proxy(property)]
-    fn keymap(&self) -> zbus::Result<String>;
-    #[dbus_proxy(property)]
-    fn set_keymap(&self, value: &str) -> zbus::Result<()>;
-
-    /// Locales property
-    #[dbus_proxy(property)]
-    fn locales(&self) -> zbus::Result<Vec<String>>;
-    #[dbus_proxy(property)]
-    fn set_locales(&self, value: &[&str]) -> zbus::Result<()>;
-
-    /// Timezone property
-    #[dbus_proxy(property)]
-    fn timezone(&self) -> zbus::Result<String>;
-    #[dbus_proxy(property)]
-    fn set_timezone(&self, value: &str) -> zbus::Result<()>;
-
-    /// UILocale property
-    #[dbus_proxy(property, name = "UILocale")]
-    fn uilocale(&self) -> zbus::Result<String>;
-    #[dbus_proxy(property)]
-    fn set_uilocale(&self, value: &str) -> zbus::Result<()>;
-}
-
 #[dbus_proxy(
     interface = "org.opensuse.Agama1.Questions",
     default_service = "org.opensuse.Agama1",

--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -73,10 +73,6 @@ impl<'a> Store<'a> {
 
     /// Stores the given installation settings in the D-Bus service
     pub async fn store(&self, settings: &InstallSettings) -> Result<(), ServiceError> {
-        // ordering: localization before product
-        if let Some(localization) = &settings.localization {
-            self.localization.store(localization).await?;
-        }
         if let Some(network) = &settings.network {
             self.network.store(network).await?;
         }
@@ -84,6 +80,10 @@ impl<'a> Store<'a> {
         // to registration server and selecting product is important for rest
         if let Some(product) = &settings.product {
             self.product.store(product).await?;
+        }
+        // ordering: localization after product as some product may miss some locales
+        if let Some(localization) = &settings.localization {
+            self.localization.store(localization).await?;
         }
         if let Some(software) = &settings.software {
             self.software.store(software).await?;

--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -73,6 +73,10 @@ impl<'a> Store<'a> {
 
     /// Stores the given installation settings in the D-Bus service
     pub async fn store(&self, settings: &InstallSettings) -> Result<(), ServiceError> {
+        // ordering: localization before product
+        if let Some(localization) = &settings.localization {
+            self.localization.store(localization).await?;
+        }
         if let Some(network) = &settings.network {
             self.network.store(network).await?;
         }


### PR DESCRIPTION
## Problem

In #881 localization was improved and works in the web UI.
This PR adds CLI and autoinstallation

- https://trello.com/c/AvrY5iBP

## Solution

Mimic the structure of the other configuration scopes.

TODO:

- [x] decide where to use `locale` and/or `localization` in the code: mostly "localization" except the D-Bus proxy which is "locale" 

## Testing

- Tested manually
- More unit tests for `KeymapId`


## Screenshots

`agama config show` now works for `localization`:

```console
7e24bb397c23:/checkout # (cd rust/; cargo run --bin agama -- -f yaml config show)
[... Compiling ...]
     Running `target/debug/agama -f yaml config show`
user:
  fullName: ''
  [... etc ...]
localization:
  language: en_US
  keyboard: us
  timezone: Europe/Berlin
```

