### PR TITLE
Configure installer keymap

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -69,6 +69,18 @@ Where  `COCKPIT_TARGET` is the IP address or hostname of the running Agama
 instance. This is especially useful if you use the Live ISO which does not contain
 any development tools, you can develop the web frontend easily from your workstation.
 
+### Special Environment Variables
+
+`COCKPIT_TARGET` - When running the development server set up a proxy to the
+specified Cockpit server. See the [using a development
+server](#using-a-development-server) section above.
+
+`LOCAL_CONNECTION` - Force behaving as in a local connection, useful for
+development or testing some Agama features. For example the keyboard layout
+switcher is displayed only in local installation because it cannot work in
+remote connection. This option will force displaying it even in a remote
+connection.
+
 ## JSDoc Documentation
 
 This project uses [TypeDoc](https://typedoc.org/) to generate the API documentation. The `jsdoc`

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -42,6 +42,7 @@ import {
 import { InstallerKeymapSwitcher, InstallerLocaleSwitcher } from "./components/l10n";
 import { Layout, Loading, Title } from "./components/layout";
 import { useInstallerL10n } from "./context/installerL10n";
+import { localConnection } from "~/utils";
 
 // D-Bus connection attempts before displaying an error.
 const ATTEMPTS = 3;
@@ -117,7 +118,7 @@ function App() {
         <div className="full-width highlighted">
           <div className="flex-stack">
             <InstallerLocaleSwitcher />
-            <InstallerKeymapSwitcher />
+            {localConnection() ? <InstallerKeymapSwitcher /> : null }
           </div>
         </div>
       </Sidebar>

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -39,7 +39,7 @@ import {
   ShowTerminalButton,
   Sidebar
 } from "~/components/core";
-import { InstallerLocaleSwitcher } from "./components/l10n";
+import { InstallerKeymapSwitcher, InstallerLocaleSwitcher } from "./components/l10n";
 import { Layout, Loading, Title } from "./components/layout";
 import { useInstallerL10n } from "./context/installerL10n";
 
@@ -117,6 +117,7 @@ function App() {
         <div className="full-width highlighted">
           <div className="flex-stack">
             <InstallerLocaleSwitcher />
+            <InstallerKeymapSwitcher />
           </div>
         </div>
       </Sidebar>

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -39,7 +39,7 @@ import {
   ShowTerminalButton,
   Sidebar
 } from "~/components/core";
-import { LanguageSwitcher } from "./components/l10n";
+import { InstallerLocaleSwitcher } from "./components/l10n";
 import { Layout, Loading, Title } from "./components/layout";
 import { useInstallerL10n } from "./context/installerL10n";
 
@@ -116,7 +116,7 @@ function App() {
         </div>
         <div className="full-width highlighted">
           <div className="flex-stack">
-            <LanguageSwitcher />
+            <InstallerLocaleSwitcher />
           </div>
         </div>
       </Sidebar>

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -42,7 +42,6 @@ import {
 import { InstallerKeymapSwitcher, InstallerLocaleSwitcher } from "./components/l10n";
 import { Layout, Loading, Title } from "./components/layout";
 import { useInstallerL10n } from "./context/installerL10n";
-import { localConnection } from "~/utils";
 
 // D-Bus connection attempts before displaying an error.
 const ATTEMPTS = 3;
@@ -117,8 +116,10 @@ function App() {
         </div>
         <div className="full-width highlighted">
           <div className="flex-stack">
-            <InstallerLocaleSwitcher />
-            {localConnection() ? <InstallerKeymapSwitcher /> : null }
+            <div className="locale-container">
+              <div><InstallerLocaleSwitcher /></div>
+              <div><InstallerKeymapSwitcher /></div>
+            </div>
           </div>
         </div>
       </Sidebar>

--- a/web/src/assets/styles/app.scss
+++ b/web/src/assets/styles/app.scss
@@ -165,3 +165,10 @@ button.kebab-toggler {
 .pattern-group-name {
   font-size: 120%;
 }
+
+.locale-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 1em;
+  width: 100%;
+}

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -154,7 +154,7 @@ export default function Sidebar ({ children }) {
         <header className="split justify-between">
           <h2>
             {/* TRANSLATORS: sidebar header */}
-            {_("Options")}
+            {_("Installer Options")}
           </h2>
 
           <button

--- a/web/src/components/l10n/InstallerKeymapSwitcher.jsx
+++ b/web/src/components/l10n/InstallerKeymapSwitcher.jsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Icon } from "../layout";
+import { FormSelect, FormSelectOption } from "@patternfly/react-core";
+import { _ } from "~/i18n";
+import { useInstallerL10n } from "~/context/installerL10n";
+import { useL10n } from "~/context/l10n";
+
+const sort = (keymaps) => keymaps.sort((k1, k2) => k1.name > k2.name ? 1 : -1);
+
+export default function InstallerKeymapSwitcher() {
+  const { keymap, changeKeymap } = useInstallerL10n();
+  const { keymaps } = useL10n();
+
+  const onChange = (_, id) => changeKeymap(id);
+
+  const options = sort(keymaps)
+    .map((keymap, index) => <FormSelectOption key={index} value={keymap.id} label={keymap.name} />);
+
+  return (
+    <>
+      <h3>
+        <Icon name="keyboard" size="24" />{_("Keyboard")}
+      </h3>
+      <FormSelect
+        id="keyboard"
+        aria-label={_("keyboard")}
+        value={keymap}
+        onChange={onChange}
+      >
+        {options}
+      </FormSelect>
+    </>
+  );
+}

--- a/web/src/components/l10n/InstallerKeymapSwitcher.jsx
+++ b/web/src/components/l10n/InstallerKeymapSwitcher.jsx
@@ -20,13 +20,20 @@
  */
 
 import React from "react";
-import { Icon } from "../layout";
 import { FormSelect, FormSelectOption } from "@patternfly/react-core";
+
+import cockpit from "../../lib/cockpit";
+
+import { Icon } from "../layout";
 import { _ } from "~/i18n";
 import { useInstallerL10n } from "~/context/installerL10n";
 import { useL10n } from "~/context/l10n";
 
-const sort = (keymaps) => keymaps.sort((k1, k2) => k1.name > k2.name ? 1 : -1);
+const sort = (keymaps) => {
+  // sort the keymap names using the current locale
+  const lang = cockpit.language || "en";
+  return keymaps.sort((k1, k2) => k1.name.localeCompare(k2.name, lang));
+};
 
 export default function InstallerKeymapSwitcher() {
   const { keymap, changeKeymap } = useInstallerL10n();

--- a/web/src/components/l10n/InstallerKeymapSwitcher.jsx
+++ b/web/src/components/l10n/InstallerKeymapSwitcher.jsx
@@ -24,11 +24,12 @@ import { FormSelect, FormSelectOption } from "@patternfly/react-core";
 
 import cockpit from "../../lib/cockpit";
 
-import { Icon } from "../layout";
+import { Icon } from "~/components/layout";
 import { _ } from "~/i18n";
 import { useInstallerL10n } from "~/context/installerL10n";
 import { useL10n } from "~/context/l10n";
 import { localConnection } from "~/utils";
+import { If } from "~/components/core";
 
 const sort = (keymaps) => {
   // sort the keymap names using the current locale
@@ -51,18 +52,24 @@ export default function InstallerKeymapSwitcher() {
         {/* TRANSLATORS: label for keyboard layout selection */}
         <Icon name="keyboard" size="24" />{_("Keyboard")}
       </h3>
-      {(localConnection() &&
-      <FormSelect
-        id="keyboard"
-        // TRANSLATORS: label for keyboard layout selection
-        aria-label={_("keyboard")}
-        value={keymap}
-        onChange={onChange}
-      >
-        {options}
-      </FormSelect>) ||
-      // TRANSLATORS:
-      _("Keyboard layout cannot be changed in remote installation") }
+      <If
+        condition={localConnection()}
+        then={
+          <FormSelect
+            id="keyboard"
+            // TRANSLATORS: label for keyboard layout selection
+            aria-label={_("keyboard")}
+            value={keymap}
+            onChange={onChange}
+          >
+            {options}
+          </FormSelect>
+        }
+        else={
+          // TRANSLATORS:
+          _("Keyboard layout cannot be changed in remote installation")
+        }
+      />
     </>
   );
 }

--- a/web/src/components/l10n/InstallerKeymapSwitcher.jsx
+++ b/web/src/components/l10n/InstallerKeymapSwitcher.jsx
@@ -28,6 +28,7 @@ import { Icon } from "../layout";
 import { _ } from "~/i18n";
 import { useInstallerL10n } from "~/context/installerL10n";
 import { useL10n } from "~/context/l10n";
+import { localConnection } from "~/utils";
 
 const sort = (keymaps) => {
   // sort the keymap names using the current locale
@@ -47,16 +48,21 @@ export default function InstallerKeymapSwitcher() {
   return (
     <>
       <h3>
+        {/* TRANSLATORS: label for keyboard layout selection */}
         <Icon name="keyboard" size="24" />{_("Keyboard")}
       </h3>
+      {(localConnection() &&
       <FormSelect
         id="keyboard"
+        // TRANSLATORS: label for keyboard layout selection
         aria-label={_("keyboard")}
         value={keymap}
         onChange={onChange}
       >
         {options}
-      </FormSelect>
+      </FormSelect>) ||
+      // TRANSLATORS:
+      _("Local keyboard cannot be set in remote installation") }
     </>
   );
 }

--- a/web/src/components/l10n/InstallerKeymapSwitcher.jsx
+++ b/web/src/components/l10n/InstallerKeymapSwitcher.jsx
@@ -62,7 +62,7 @@ export default function InstallerKeymapSwitcher() {
         {options}
       </FormSelect>) ||
       // TRANSLATORS:
-      _("Local keyboard cannot be set in remote installation") }
+      _("Keyboard layout cannot be changed in remote installation") }
     </>
   );
 }

--- a/web/src/components/l10n/InstallerKeymapSwitcher.test.jsx
+++ b/web/src/components/l10n/InstallerKeymapSwitcher.test.jsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import { plainRender } from "~/test-utils";
+
+import InstallerKeymapSwitcher from "./InstallerKeymapSwitcher";
+
+let mockChangeKeyboardFn;
+
+jest.mock("~/lib/cockpit", () => ({
+  gettext: term => term,
+}));
+
+jest.mock("~/context/installerL10n", () => ({
+  ...jest.requireActual("~/context/installerL10n"),
+  useInstallerL10n: () => ({
+    changeKeymap: mockChangeKeyboardFn,
+    keymap: "us"
+  })
+}));
+
+jest.mock("~/context/l10n", () => ({
+  ...jest.requireActual("~/context/l10n"),
+  useL10n: () => ({
+    keymaps: [
+      { id: "cz", name: "Czech" },
+      { id: "cz(qwerty)", name: "Czech (QWERTY)" },
+      { id: "de", name: "German" },
+      { id: "us", name: "English (US)" },
+      { id: "us(dvorak)", name: "English (Dvorak)" }
+    ]
+  })
+}));
+
+beforeEach(() => {
+  mockChangeKeyboardFn = jest.fn();
+});
+
+it("InstallerKeymapSwitcher", async () => {
+  const { user } = plainRender(<InstallerKeymapSwitcher />);
+
+  // the current keyboard is correctly selected
+  expect(screen.getByRole("option", { name: "English (US)" }).selected).toBe(true);
+
+  // change the keyboard
+  await user.selectOptions(
+    screen.getByRole("combobox", { label: "Keyboard" }),
+    screen.getByRole("option", { name: "Czech" })
+  );
+  expect(mockChangeKeyboardFn).toHaveBeenCalledWith("cz");
+});

--- a/web/src/components/l10n/InstallerLocaleSwitcher.jsx
+++ b/web/src/components/l10n/InstallerLocaleSwitcher.jsx
@@ -20,8 +20,10 @@
  */
 
 import React, { useCallback, useState } from "react";
+import { Link } from "react-router-dom";
+import { FormSelect, FormSelectOption, Popover } from "@patternfly/react-core";
+
 import { Icon } from "../layout";
-import { FormSelect, FormSelectOption } from "@patternfly/react-core";
 import { _ } from "~/i18n";
 import { useInstallerL10n } from "~/context/installerL10n";
 import cockpit from "~/lib/cockpit";
@@ -40,10 +42,32 @@ export default function InstallerLocaleSwitcher() {
   const options = Object.keys(languages).sort()
     .map(id => <FormSelectOption key={id} value={id} label={languages[id]} />);
 
+  // TRANSLATORS: help text for the language selector in the sidebar,
+  // %s will be replaced by the "Localization" page link
+  const [msg1, msg2] = _("The language used by the installer. The language \
+for the installed system can be set in the %s page.").split("%s");
+
+  // "hide" is a function which closes the popover
+  const description = (hide) => (
+    <>
+      {msg1}
+      {/* close the popover after clicking the link */}
+      <Link to="/l10n" onClick={hide}>
+        {_("Localization")}
+      </Link>
+      {msg2}
+    </>
+  );
+
   return (
     <>
       <h3>
-        <Icon name="translate" size="24" />{_("Display Language")}
+        <Icon name="translate" size="24" />
+        {_("Language")}&nbsp;
+        {/* smaller width of the popover so it does not overflow outside the sidebar */}
+        <Popover showClose={false} bodyContent={description} maxWidth="15em">
+          <Icon name="info" size="16" />
+        </Popover>
       </h3>
       <FormSelect
         id="language"

--- a/web/src/components/l10n/InstallerLocaleSwitcher.jsx
+++ b/web/src/components/l10n/InstallerLocaleSwitcher.jsx
@@ -26,7 +26,7 @@ import { _ } from "~/i18n";
 import { useInstallerL10n } from "~/context/installerL10n";
 import cockpit from "~/lib/cockpit";
 
-export default function LanguageSwitcher() {
+export default function InstallerLocaleSwitcher() {
   const { language, changeLanguage } = useInstallerL10n();
   const [selected, setSelected] = useState(null);
   const languages = cockpit.manifests.agama?.locales || [];

--- a/web/src/components/l10n/InstallerLocaleSwitcher.test.jsx
+++ b/web/src/components/l10n/InstallerLocaleSwitcher.test.jsx
@@ -22,7 +22,7 @@
 import React from "react";
 import { screen } from "@testing-library/react";
 import { plainRender } from "~/test-utils";
-import LanguageSwitcher from "./LanguageSwitcher";
+import InstallerLocaleSwitcher from "./InstallerLocaleSwitcher";
 
 const mockLanguage = "es-es";
 let mockChangeLanguageFn;
@@ -52,8 +52,8 @@ beforeEach(() => {
   mockChangeLanguageFn = jest.fn();
 });
 
-it("LanguageSwitcher", async () => {
-  const { user } = plainRender(<LanguageSwitcher />);
+it("InstallerLocaleSwitcher", async () => {
+  const { user } = plainRender(<InstallerLocaleSwitcher />);
   expect(screen.getByRole("option", { name: "Español" }).selected).toBe(true);
   await user.selectOptions(
     screen.getByRole("combobox", { label: "Display Language" }),

--- a/web/src/components/l10n/index.js
+++ b/web/src/components/l10n/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022] SUSE LLC
+ * Copyright (c) [2022-2023] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -19,8 +19,8 @@
  * find current contact information at www.suse.com.
  */
 
+export { default as InstallerLocaleSwitcher } from "./InstallerLocaleSwitcher";
 export { default as KeymapSelector } from "./KeymapSelector";
 export { default as L10nPage } from "./L10nPage";
-export { default as LanguageSwitcher } from "./LanguageSwitcher";
 export { default as LocaleSelector } from "./LocaleSelector";
 export { default as TimezoneSelector } from "./TimezoneSelector";

--- a/web/src/components/l10n/index.js
+++ b/web/src/components/l10n/index.js
@@ -19,6 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
+export { default as InstallerKeymapSwitcher } from "./InstallerKeymapSwitcher";
 export { default as InstallerLocaleSwitcher } from "./InstallerLocaleSwitcher";
 export { default as KeymapSelector } from "./KeymapSelector";
 export { default as L10nPage } from "./L10nPage";

--- a/web/src/context/installerL10n.jsx
+++ b/web/src/context/installerL10n.jsx
@@ -256,7 +256,11 @@ function InstallerL10nProvider({ children }) {
 
   const changeKeymap = useCallback(async (id) => {
     setKeymap(id);
+    // write the config to file (/etc/X11/xorg.conf.d/00-keyboard.conf),
+    // this also sets the console keyboard!
     await cockpit.spawn(["localectl", "set-x11-keymap", id]);
+    // set the current X11 keyboard
+    await cockpit.spawn(["setxkbmap", id], { environ: ["DISPLAY=:0"] });
   }, [setKeymap]);
 
   useEffect(() => {

--- a/web/src/context/installerL10n.jsx
+++ b/web/src/context/installerL10n.jsx
@@ -180,7 +180,7 @@ function reload(newLanguage) {
 }
 
 /**
- * Extracts keymap from localectl output.
+ * Extracts the keymap from the `setxkbmap -query` output.
  *
  * @param {string} output
  * @returns {string|undefined}

--- a/web/src/context/installerL10n.jsx
+++ b/web/src/context/installerL10n.jsx
@@ -185,9 +185,8 @@ function reload(newLanguage) {
  * @param {string} output
  * @returns {string|undefined}
  */
-function keymapFromLocalectl(output) {
-  const matcher = /X11 Layout: (.*)\n/;
-
+function keymapFromX(output) {
+  const matcher = /^layout:\s+(\S.*)$/m;
   return matcher.exec(output)?.at(1);
 }
 
@@ -275,7 +274,7 @@ function InstallerL10nProvider({ children }) {
   }, [client, language, backendPending, storeInstallerLanguage]);
 
   useEffect(() => {
-    cockpit.spawn(["localectl", "status"]).then(output => setKeymap(keymapFromLocalectl(output)));
+    cockpit.spawn(["setxkbmap", "-query"], { environ: ["DISPLAY=:0"] }).then(output => setKeymap(keymapFromX(output)));
   }, [setKeymap]);
 
   const value = { language, changeLanguage, keymap, changeKeymap };

--- a/web/src/context/installerL10n.jsx
+++ b/web/src/context/installerL10n.jsx
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-// cspell:ignore localectl
+// cspell:ignore localectl setxkbmap xorg
 // @ts-check
 
 import React, { useCallback, useEffect, useState } from "react";

--- a/web/src/context/installerL10n.test.jsx
+++ b/web/src/context/installerL10n.test.jsx
@@ -51,7 +51,8 @@ jest.mock("~/lib/cockpit", () => ({
         "es-es": "Español"
       }
     }
-  }
+  },
+  spawn: jest.fn().mockResolvedValue()
 }));
 
 // Helper component that displays a translated message depending on the

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -250,6 +250,39 @@ const setLocationSearch = (query) => {
 };
 
 /**
+ * Is the Agama server running locally?
+ *
+ * This function should be used only in special cases, the Agama behavior should
+ * be the same regardless of the user connection.
+ *
+ * The local connection can be forced by setting the `LOCAL_CONNECTION`
+ * environment variable to `1`. This can be useful for debugging or for
+ * development.
+ *
+ * @returns {boolean} `true` if the connection is local, `false` otherwise
+ */
+const localConnection = function (location = window.location) {
+  // forced local behavior
+  if (process.env.LOCAL_CONNECTION === "1") return true;
+
+  // when running in a development server use the COCKPIT_TARGET_URL value
+  // (a proxy is used) otherwise use the page URL from the browser
+  const hostname = process.env.WEBPACK_SERVE ? (new URL(COCKPIT_TARGET_URL)).hostname : location.hostname;
+
+  // using the loopback device? (hostname or IP address)
+  return hostname === "localhost" || hostname.startsWith("127.");
+};
+
+/**
+ * Is the Agama server running remotely?
+ *
+ * @see localConnection
+ *
+ * @returns {boolean} `true` if the connection is remote, `false` otherwise
+ */
+const remoteConnection = (location = window.location) => !localConnection(location);
+
+/**
  * Time for the given timezone.
  *
  * @param {string} timezone - E.g., "Atlantic/Canary".
@@ -310,6 +343,8 @@ export {
   toValidationError,
   locationReload,
   setLocationSearch,
+  localConnection,
+  remoteConnection,
   timezoneTime,
   timezoneUTCOffset
 };

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -261,7 +261,7 @@ const setLocationSearch = (query) => {
  *
  * @returns {boolean} `true` if the connection is local, `false` otherwise
  */
-const localConnection = function (location = window.location) {
+const localConnection = (location = window.location) => {
   // forced local behavior
   if (process.env.LOCAL_CONNECTION === "1") return true;
 
@@ -280,7 +280,7 @@ const localConnection = function (location = window.location) {
  *
  * @returns {boolean} `true` if the connection is remote, `false` otherwise
  */
-const remoteConnection = (location = window.location) => !localConnection(location);
+const remoteConnection = (...args) => !localConnection(...args);
 
 /**
  * Time for the given timezone.

--- a/web/src/utils.test.js
+++ b/web/src/utils.test.js
@@ -19,8 +19,10 @@
  * find current contact information at www.suse.com.
  */
 
-import { classNames, partition, noop, toValidationError,
-  localConnection, remoteConnection } from "./utils";
+import {
+  classNames, partition, noop, toValidationError,
+  localConnection, remoteConnection
+} from "./utils";
 
 describe("noop", () => {
   it("returns undefined", () => {

--- a/web/src/utils.test.js
+++ b/web/src/utils.test.js
@@ -19,7 +19,8 @@
  * find current contact information at www.suse.com.
  */
 
-import { classNames, partition, noop, toValidationError } from "./utils";
+import { classNames, partition, noop, toValidationError,
+  localConnection, remoteConnection } from "./utils";
 
 describe("noop", () => {
   it("returns undefined", () => {
@@ -59,5 +60,49 @@ describe("toValidationError", () => {
       severity: "warn"
     };
     expect(toValidationError(issue)).toEqual({ message: "Issue 1" });
+  });
+});
+
+const localURL = new URL("http://127.0.0.90/");
+const localURL2 = new URL("http://localhost:9090/");
+const remoteURL = new URL("http://example.com");
+
+describe("localConnection", () => {
+  describe("when the page URL is " + localURL, () => {
+    it("returns true", () => {
+      expect(localConnection(localURL)).toEqual(true);
+    });
+  });
+
+  describe("when the page URL is " + localURL2, () => {
+    it("returns true", () => {
+      expect(localConnection(localURL2)).toEqual(true);
+    });
+  });
+
+  describe("when the page URL is " + remoteURL, () => {
+    it("returns false", () => {
+      expect(localConnection(remoteURL)).toEqual(false);
+    });
+  });
+});
+
+describe("remoteConnection", () => {
+  describe("when the page URL is " + localURL, () => {
+    it("returns true", () => {
+      expect(remoteConnection(localURL)).toEqual(false);
+    });
+  });
+
+  describe("when the page URL is " + localURL2, () => {
+    it("returns true", () => {
+      expect(remoteConnection(localURL2)).toEqual(false);
+    });
+  });
+
+  describe("when the page URL is " + remoteURL, () => {
+    it("returns false", () => {
+      expect(remoteConnection(remoteURL)).toEqual(true);
+    });
   });
 });

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -55,7 +55,7 @@ const plugins = [
   // the current value of the environment variable, that variable is set to
   // "true" when running the development server ("npm run server")
   // https://webpack.js.org/plugins/environment-plugin/
-  new webpack.EnvironmentPlugin({ WEBPACK_SERVE: null }),
+  new webpack.EnvironmentPlugin({ WEBPACK_SERVE: null, LOCAL_CONNECTION: null }),
   // similarly for a non-environment value
   // https://webpack.js.org/plugins/define-plugin/
   // but because ESlint runs *before* the DefinePlugin we need to


### PR DESCRIPTION
## Problem

- https://trello.com/c/dlSUsO5r/3503-5-agama-allow-selecting-a-keyboard-in-the-local-installation
- It should be possible to change the keyboard layout in local installation (in remote installation you can do that in your desktop as usually)

## Solution

- Display a keyboard switcher in the side bar, displayed only in local installation
- Note: In the long term there should be some "welcome screen" displayed in the local installation which should contain settings for the language and the keyboard

## Testing

- Added a new unit test
- Tested manually

## Screenshots

| Local connection<sup>1)</sup> | Remote connection |
|----|----|
|![keyboard_local2](https://github.com/openSUSE/agama/assets/907998/48e2383a-9a6b-43a8-b6ba-1bd6791ac613) | ![keyboard_remote10](https://github.com/openSUSE/agama/assets/907998/2c84b5e7-8a11-482a-805c-45083991d663) |

<sup>1)</sup> Local connection using the loopback device or or forced via `LOCAL_CONNECTION=1` environment variable.