### PR TITLE
Apply ethernet config to dummy device

### DIFF
--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -312,7 +312,9 @@ impl Connection {
     }
 
     pub fn is_ethernet(&self) -> bool {
-        matches!(self, Connection::Loopback(_)) || matches!(self, Connection::Ethernet(_))
+        matches!(self, Connection::Loopback(_))
+            || matches!(self, Connection::Ethernet(_))
+            || matches!(self, Connection::Dummy(_))
     }
 
     pub fn mac_address(&self) -> String {


### PR DESCRIPTION
## Problem

Dummy has ethernet config inside NetworkManager, but `is_ethernet()` doesn't include dummy.

## Solution

Add dummy to `is_ethernet()`

## Testing

- *Tested manually*