### PR TITLE
File system and snapshots config

### DIFF
--- a/service/lib/agama/storage/volume_outline.rb
+++ b/service/lib/agama/storage/volume_outline.rb
@@ -76,7 +76,7 @@ module Agama
 
       # Whether snapshots option can be configured
       #
-      # @return [Boolean]
+      # @return [Boolean] false by default
       attr_accessor :snapshots_configurable
       alias_method :snapshots_configurable?, :snapshots_configurable
 
@@ -93,7 +93,7 @@ module Agama
       def initialize
         @required = false
         @adjust_by_ram = false
-        @snapshots_configurable = true
+        @snapshots_configurable = false
         @filesystems = []
         @base_min_size = Y2Storage::DiskSize.zero
         @base_max_size = Y2Storage::DiskSize.unlimited

--- a/service/lib/agama/storage/volume_templates_builder.rb
+++ b/service/lib/agama/storage/volume_templates_builder.rb
@@ -154,7 +154,7 @@ module Agama
           outline.required = fetch(outline_data, "required", false)
           outline.filesystems = fetch(outline_data, "filesystems", [])
           outline.filesystems.map! { |fs| fs_type(fs) }
-          outline.snapshots_configurable = fetch(outline_data, "snapshots_configurable", true)
+          outline.snapshots_configurable = fetch(outline_data, "snapshots_configurable", false)
 
           size = fetch(outline_data, "auto_size", {})
           min = parse_disksize(fetch(size, :base_min))

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 15 15:04:43 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Set snapshots as not configurable by default
+  (gh#openSUSE/agama#926).
+
+-------------------------------------------------------------------
 Tue Dec  5 09:49:10 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Explicitly add dependencies instead of relying on the live ISO

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -338,6 +338,21 @@ describe Agama::DBus::Storage::Manager do
         }
       end
 
+      let(:config_data) do
+        { "storage" => { "volumes" => [], "volume_templates" => cfg_templates } }
+      end
+
+      let(:cfg_templates) do
+        [
+          {
+            "mount_path" => "/",
+            "outline"    => {
+              "snapshots_configurable" => true
+            }
+          }
+        ]
+      end
+
       it "calculates a proposal with settings having a volume with values from D-Bus" do
         expect(proposal).to receive(:calculate) do |settings|
           volume = settings.volumes.first
@@ -354,10 +369,6 @@ describe Agama::DBus::Storage::Manager do
 
       context "and the D-Bus volume does not include some values" do
         let(:dbus_volume1) { { "MountPath" => "/" } }
-
-        let(:config_data) do
-          { "storage" => { "volumes" => [], "volume_templates" => cfg_templates } }
-        end
 
         let(:cfg_templates) do
           [

--- a/service/test/agama/dbus/storage/proposal_settings_conversion/to_dbus_test.rb
+++ b/service/test/agama/dbus/storage/proposal_settings_conversion/to_dbus_test.rb
@@ -81,7 +81,7 @@ describe Agama::DBus::Storage::ProposalSettingsConversion::ToDBus do
               "Required"              => false,
               "FsTypes"               => [],
               "SupportAutoSize"       => false,
-              "SnapshotsConfigurable" => true,
+              "SnapshotsConfigurable" => false,
               "SnapshotsAffectSizes"  => false,
               "SizeRelevantVolumes"   => []
             }

--- a/service/test/agama/dbus/storage/volume_conversion/from_dbus_test.rb
+++ b/service/test/agama/dbus/storage/volume_conversion/from_dbus_test.rb
@@ -55,7 +55,10 @@ describe Agama::DBus::Storage::VolumeConversion::FromDBus do
   end
 
   let(:outline) do
-    { "filesystems" => ["xfs", "ext3", "ext4"] }
+    {
+      "filesystems"            => ["xfs", "ext3", "ext4"],
+      "snapshots_configurable" => true
+    }
   end
 
   describe "#convert" do

--- a/service/test/agama/dbus/storage/volume_conversion/to_dbus_test.rb
+++ b/service/test/agama/dbus/storage/volume_conversion/to_dbus_test.rb
@@ -70,7 +70,7 @@ describe Agama::DBus::Storage::VolumeConversion::ToDBus do
           "Required"              => false,
           "FsTypes"               => [],
           "SupportAutoSize"       => false,
-          "SnapshotsConfigurable" => true,
+          "SnapshotsConfigurable" => false,
           "SnapshotsAffectSizes"  => false,
           "SizeRelevantVolumes"   => []
         }

--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 15 15:03:40 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Allow selecting file system type and configure snapshots
+  (gh#openSUSE/agama/926).
+
+-------------------------------------------------------------------
 Sat Dec  2 18:06:02 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 6

--- a/web/src/assets/styles/global.scss
+++ b/web/src/assets/styles/global.scss
@@ -60,10 +60,6 @@ li {
   svg {
     vertical-align: middle;
   }
-
-  span {
-    margin-inline-start: var(--spacer-small);
-  }
 }
 
 // Style focus making use of :focus-visible

--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -225,3 +225,9 @@ table td > .pf-v5-c-empty-state {
     --pf-v5-c-expandable-section__content--PaddingLeft: var(--spacer-normal);
   }
 }
+
+.pf-v5-c-form__group-label-help {
+  margin: 0;
+  padding: 0;
+  vertical-align: top;
+}

--- a/web/src/components/storage/VolumeForm.jsx
+++ b/web/src/components/storage/VolumeForm.jsx
@@ -29,7 +29,7 @@ import { sprintf } from "sprintf-js";
 import { _, N_ } from "~/i18n";
 import { FormValidationError, If, NumericTextInput } from '~/components/core';
 import { DEFAULT_SIZE_UNIT, SIZE_METHODS, SIZE_UNITS, parseToBytes, splitSize } from '~/components/storage/utils';
-import { Icon } from "../layout";
+import { Icon } from "~/components/layout";
 
 /**
  * Callback function for notifying a form input change
@@ -278,6 +278,7 @@ const FsField = ({ value, volume, onChange }) => {
     );
   };
 
+  // TRANSLATORS: label for the file system selector.
   const label = _("File system type");
 
   return (

--- a/web/src/components/storage/VolumeForm.jsx
+++ b/web/src/components/storage/VolumeForm.jsx
@@ -22,13 +22,14 @@
 import React, { useReducer, useState } from "react";
 import {
   InputGroup, InputGroupItem, Form, FormGroup, FormSelect, FormSelectOption, MenuToggle,
-  Radio, Select, SelectOption, SelectList
+  Popover, Radio, Select, SelectOption, SelectList
 } from "@patternfly/react-core";
 import { sprintf } from "sprintf-js";
 
 import { _, N_ } from "~/i18n";
 import { FormValidationError, If, NumericTextInput } from '~/components/core';
 import { DEFAULT_SIZE_UNIT, SIZE_METHODS, SIZE_UNITS, parseToBytes, splitSize } from '~/components/storage/utils';
+import { Icon } from "../layout";
 
 /**
  * Callback function for notifying a form input change
@@ -259,18 +260,36 @@ const FsField = ({ value, volume, onChange }) => {
     return fsTypes.length === 1 && (fsTypes[0] !== "Btrfs" || !snapshotsConfigurable);
   };
 
+  const Info = () => {
+    // TRANSLATORS: info about possible file system types.
+    const text = _("The options for the file system type depends on the product and the mount point.");
+
+    return (
+      <Popover showClose={false} bodyContent={text} maxWidth="18em">
+        <button
+          type="button"
+          aria-label={_("More info for file system types")}
+          onClick={e => e.preventDefault()}
+          className="pf-v5-c-form__group-label-help"
+        >
+          <Icon name="info" size="16" />
+        </button>
+      </Popover>
+    );
+  };
+
   const label = _("File system type");
 
   return (
     <If
       condition={isSingleFs()}
       then={
-        <FormGroup label={label}>
-          <p>{fsOptionLabel(value.fsType)}</p>
+        <FormGroup label={label} labelIcon={<Info />}>
+          <p>{fsOptionLabel(fsOption(value))}</p>
         </FormGroup>
       }
       else={
-        <FormGroup isRequired label={label} fieldId="fsType">
+        <FormGroup isRequired label={label} labelIcon={<Info />} fieldId="fsType">
           <FsSelect id="fsType" value={value} volume={volume} onChange={onChange} />
         </FormGroup>
       }

--- a/web/src/components/storage/VolumeForm.test.jsx
+++ b/web/src/components/storage/VolumeForm.test.jsx
@@ -105,8 +105,8 @@ it("renders a control for displaying/selecting the file system type", async () =
 
   const fsTypeButton = screen.getByRole("button", { name: "File system type" });
   await user.click(fsTypeButton);
-  screen.getByRole("option", { name: "Btrfs with snapshots" });
-  screen.getByRole("option", { name: "Btrfs without snapshots" });
+  screen.getByRole("option", { name: /Btrfs with snapshots/ });
+  screen.getByRole("option", { name: "Btrfs" });
   screen.getByRole("option", { name: "Ext4" });
 });
 


### PR DESCRIPTION
## Problem

The file system type cannot be selected when adding or editing a file system. The file system is always created with its default file system type. 

* https://trello.com/c/JnSKpQnu/3418-3-storage-modify-basic-attributes-fstype-snapshots-etc-for-pre-defined-volumes

## Solution

Add a selector for the file system type.

* If the product allows configuring snapshots, then the selector includes both *Btrfs* and *Btrfs with snapshots* (and the rest of possible types). 
* If there is only an option for the file system type (e.g., *swap*), then the selector is not offered. A plain text with the unique value is shown.

Follow-up: https://github.com/openSUSE/agama/issues/932

## Testing

* Added new unit tests
* Tested manually

## Screenshots

[Screencast from 2023-12-15 14-52-33.webm](https://github.com/openSUSE/agama/assets/1112304/feac328d-8ffd-4485-be5b-997b2aad49b6)



