### PR TITLE
Ruby service - mark translatable strings

### DIFF
--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -24,7 +24,7 @@ jobs:
         run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && zypper ref
 
       - name: Install tools
-        run: zypper --non-interactive install --no-recommends diffutils git gettext-tools npm-default
+        run: zypper --non-interactive install --no-recommends diffutils git gettext-tools npm-default "rubygem(yast-rake)" "rubygem(gettext)" yast2-devtools
 
       - name: Checkout Agama sources
         uses: actions/checkout@v3
@@ -140,4 +140,52 @@ jobs:
           cd agama-weblate/products
           find . -name "*.po" -exec msgmerge -U '{}' products.pot \;
           git commit -a -m "Merge new POT file to product translations"$'\n\n'"Agama commit: $GITHUB_SHA"
+          git push
+
+      - name: Generate service POT file
+        run: |
+          cd agama/service
+          rake pot
+          msgfmt --statistics agama.pot
+
+      - name: Validate the generated service POT file
+        run:  msgfmt --check-format agama/service/agama.pot
+
+      - name: Update service POT file
+        run: |
+          mkdir -p agama-weblate/service
+          cp agama/service/agama.pot agama-weblate/service/agama.pot
+
+      # any change besides the timestamp in the POT file?
+      - name: Check service POT changes
+        id: check_service_changes
+        run: |
+          git -C agama-weblate diff --ignore-matching-lines="POT-Creation-Date:" service/agama.pot > pot.diff
+
+          if [ -s pot.diff ]; then
+            echo "POT file updated"
+            echo "pot_updated=true" >> $GITHUB_OUTPUT
+          else
+            echo "POT file unchanged"
+            echo "pot_updated=false" >> $GITHUB_OUTPUT
+            # reset any possible changes so they are not accidentally committed later
+            git -C agama-weblate reset --hard
+          fi
+
+      - name: Push updated service POT file
+        # run only when the POT file has been updated
+        if: steps.check_service_changes.outputs.pot_updated == 'true'
+        run: |
+          cd agama-weblate
+          git add service/agama.pot
+          git commit -m "Update service POT file"$'\n\n'"Agama commit: $GITHUB_SHA"
+          git push
+
+      - name: Merge service POT to service translations
+        # run only when the POT file has been updated
+        if: steps.check_service_changes.outputs.pot_updated == 'true'
+        run: |
+          cd agama-weblate/service
+          find . -name "*.po" -exec msgmerge -U "{}" agama.pot \;
+          git commit -a -m "Merge new POT file to service translations"$'\n\n'"Agama commit: $GITHUB_SHA"
           git push

--- a/service/.gitignore
+++ b/service/.gitignore
@@ -11,6 +11,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+*.pot
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/service/Rakefile
+++ b/service/Rakefile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# just inherit the usual YaST rake tasks
+require "yast/rake"

--- a/service/lib/agama/software/callbacks/signature.rb
+++ b/service/lib/agama/software/callbacks/signature.rb
@@ -29,11 +29,15 @@ module Agama
     module Callbacks
       # Callbacks related to signatures handling
       class Signature
+        include Yast::I18n
+
         # Constructor
         #
         # @param questions_client [Agama::DBus::Clients::Questions]
         # @param logger [Logger]
         def initialize(questions_client, logger)
+          textdomain "agama"
+
           @questions_client = questions_client
           @logger = logger
         end
@@ -56,16 +60,16 @@ module Agama
           repo = Yast::Pkg.SourceGeneralData(repo_id)
           source = if repo
             format(
-              "The file %{filename} from repository %{repo_name} (%{repo_url})",
+              _("The file %{filename} from repository %{repo_name} (%{repo_url})"),
               filename: filename, repo_name: repo["name"], repo_url: repo["url"]
             )
           else
-            format("The file %{filename}", filename: filename)
+            format(_("The file %{filename}"), filename: filename)
           end
 
           message = format(
-            "%{source} is not digitally signed. The origin and integrity of the file cannot be " \
-            "verified. Use it anyway?", source: source
+            _("%{source} is not digitally signed. The origin and integrity of the file cannot be " \
+              "verified. Use it anyway?"), source: source
           )
 
           question = Agama::Question.new(
@@ -87,8 +91,8 @@ module Agama
         def import_gpg_key(key, _repo_id)
           fingerprint = key["fingerprint"].scan(/.{4}/).join(" ")
           message = format(
-            "The key %{id} (%{name}) with fingerprint %{fingerprint} is unknown. " \
-            "Do you want to trust this key?",
+            _("The key %{id} (%{name}) with fingerprint %{fingerprint} is unknown. " \
+              "Do you want to trust this key?"),
             id: key["id"], name: key["name"], fingerprint: fingerprint
           )
 

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -56,6 +56,7 @@ module Agama
       include Helpers
       include WithIssues
       include WithProgress
+      include Yast::I18n
 
       GPG_KEYS_GLOB = "/usr/lib/rpm/gnupg/keys/gpg-*"
       private_constant :GPG_KEYS_GLOB
@@ -84,6 +85,8 @@ module Agama
       # @param config [Agama::Config]
       # @param logger [Logger]
       def initialize(config, logger)
+        textdomain "agama"
+
         @config = config
         @logger = logger
         @languages = DEFAULT_LANGUAGES
@@ -128,14 +131,14 @@ module Agama
           start_progress(4)
           store_original_repos
           Yast::PackageCallbacks.InitPackageCallbacks(logger)
-          progress.step("Initializing target repositories") { initialize_target_repos }
-          progress.step("Initializing sources") { add_base_repos }
+          progress.step(_("Initializing target repositories")) { initialize_target_repos }
+          progress.step(_("Initializing sources")) { add_base_repos }
         else
           start_progress(2)
         end
 
-        progress.step("Refreshing repositories metadata") { repositories.load }
-        progress.step("Calculating the software proposal") { propose }
+        progress.step(_("Refreshing repositories metadata")) { repositories.load }
+        progress.step(_("Calculating the software proposal")) { propose }
 
         Yast::Stage.Set("initial")
         update_issues
@@ -184,13 +187,13 @@ module Agama
       # Writes the repositories information to the installed system
       def finish
         start_progress(2)
-        progress.step("Writing repositories to the target system") do
+        progress.step(_("Writing repositories to the target system")) do
           Yast::Pkg.SourceSaveAll
           Yast::Pkg.TargetFinish
           Yast::Pkg.SourceCacheCopyTo(Yast::Installation.destdir)
           registration.finish
         end
-        progress.step("Restoring original repositories") { restore_original_repos }
+        progress.step(_("Restoring original repositories")) { restore_original_repos }
       end
 
       # Determine whether the given tag is provided by the selected packages
@@ -459,7 +462,7 @@ module Agama
       # @return [Array<Agama::Issue>]
       def repos_issues
         repositories.disabled.map do |repo|
-          Issue.new("Could not read the repository #{repo.name}",
+          Issue.new(_("Could not read repository \"%s\"") % repo.name,
             source:   Issue::Source::SYSTEM,
             severity: Issue::Severity::ERROR)
         end
@@ -469,7 +472,7 @@ module Agama
       #
       # @return [Agama::Issue]
       def missing_product_issue
-        Issue.new("Product not selected yet",
+        Issue.new(_("Product not selected yet"),
           source:   Issue::Source::CONFIG,
           severity: Issue::Severity::ERROR)
       end
@@ -478,7 +481,7 @@ module Agama
       #
       # @return [Agama::Issue]
       def missing_registration_issue
-        Issue.new("Product must be registered",
+        Issue.new(_("Product must be registered"),
           source:   Issue::Source::SYSTEM,
           severity: Issue::Severity::ERROR)
       end

--- a/service/lib/agama/software/proposal.rb
+++ b/service/lib/agama/software/proposal.rb
@@ -51,6 +51,7 @@ module Agama
     #   proposal.issues #=> []
     class Proposal
       include WithIssues
+      include Yast::I18n
 
       # @return [String,nil] Base product
       attr_accessor :base_product
@@ -62,6 +63,8 @@ module Agama
       #
       # @param logger [Logger]
       def initialize(logger: nil)
+        textdomain "agama"
+
         @logger = logger || Logger.new($stdout)
         @base_product = nil
       end
@@ -222,7 +225,7 @@ module Agama
         last_error = Yast::Pkg.LastError
         res = []
         res << last_error unless last_error.empty?
-        res << "Found #{solve_errors} dependency issues." if solve_errors > 0
+        res << (_("Found %s dependency issues.") % solve_errors) if solve_errors > 0
         res
       end
     end

--- a/service/test/agama/software/manager_test.rb
+++ b/service/test/agama/software/manager_test.rb
@@ -148,10 +148,10 @@ describe Agama::Software::Manager do
 
         expect(subject.issues).to include(
           an_object_having_attributes(
-            description: /could not read the repository Repo #1/i
+            description: /Could not read repository "Repo #1"/i
           ),
           an_object_having_attributes(
-            description: /could not read the repository Repo #2/i
+            description: /Could not read repository "Repo #2"/i
           )
         )
       end


### PR DESCRIPTION
# Service Translations

- This is just the first part of the Ruby support
- Mark the translatable texts for translation
- Added `Rakefile` to extract the texts into the POT file using `rake pot` call
- Updated the GitHub Action to create POT file also for the Ruby service

