### PR TITLE
Added GitHub Action for merging the Ruby translations

### DIFF
--- a/.github/workflows/weblate-merge-service-po.yml
+++ b/.github/workflows/weblate-merge-service-po.yml
@@ -1,0 +1,111 @@
+name: Weblate Merge Service PO
+
+on:
+  schedule:
+    # run every Monday at 2:45AM UTC
+    - cron: "45 2 * * 0"
+
+  # allow running manually
+  workflow_dispatch:
+
+jobs:
+  merge-po:
+    # allow pushing and creating pull requests
+    permissions:
+      contents: write
+      pull-requests: write
+
+    # do not run in forks
+    if: github.repository_owner == 'openSUSE'
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: registry.opensuse.org/opensuse/tumbleweed:latest
+      volumes:
+        # bind mount the GitHub CLI tool from the Ubuntu host,
+        # it is a statically linked binary so it should work everywhere
+        - /usr/bin/gh:/usr/bin/gh
+
+    steps:
+      - name: Configure and refresh repositories
+        run: |
+          # disable unused repositories to have a faster refresh
+          zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && \
+            zypper --non-interactive --gpg-auto-import-keys ref
+
+      - name: Install tools
+        run: zypper --non-interactive install --no-recommends git gettext-tools
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "YaST Bot"
+          git config --global user.email "yast-devel@opensuse.org"
+
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          path: agama
+
+      - name: Checkout Agama-weblate sources
+        uses: actions/checkout@v3
+        with:
+          path: agama-weblate
+          repository: openSUSE/agama-weblate
+  
+      - name: Validate the service PO files
+        working-directory: ./agama-weblate
+        run:  ls service/*.po | xargs -n1 msgfmt --check-format -o /dev/null
+
+      - name: Update PO files
+        working-directory: ./agama
+        run: |
+          mkdir -p service/po
+          # delete the current translations
+          find service/po -name '*.po' -exec git rm '{}' ';'
+
+          # copy the new ones
+          cp -a ../agama-weblate/service/*.po service/po
+          git add service/po/*.po
+
+      # any changes besides the timestamps in the PO files?
+      - name: Check changes
+        id: check_changes
+        working-directory: ./agama
+        run: |
+          git diff --staged --ignore-matching-lines="POT-Creation-Date:" \
+            --ignore-matching-lines="PO-Revision-Date:" service/po > po.diff
+
+          if [ -s po.diff ]; then
+            echo "PO files updated"
+            # this is an Output Parameter
+            # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+            echo "po_updated=true" >> $GITHUB_OUTPUT
+          else
+            echo "PO files unchanged"
+            echo "po_updated=false" >> $GITHUB_OUTPUT
+          fi
+
+          rm po.diff
+
+      - name: Push updated PO files
+        # run only when a PO file has been updated
+        if: steps.check_changes.outputs.po_updated == 'true'
+        working-directory: ./agama
+        run: |
+          # use a unique branch to avoid possible conflicts with already existing branches
+          git checkout -b "po_service_merge_${GITHUB_RUN_ID}"
+          git commit -a -m "Update service PO files"$'\n\n'"Agama-weblate commit: `git -C ../agama-weblate rev-parse HEAD`"
+          git push origin "po_service_merge_${GITHUB_RUN_ID}"
+
+      - name: Create pull request
+        # run only when a PO file has been updated
+        if: steps.check_changes.outputs.po_updated == 'true'
+        working-directory: ./agama
+        run: |
+          gh pr create -B master -H "po_service_merge_${GITHUB_RUN_ID}" \
+            --label translations --label bot \
+            --title "Update service PO files" \
+            --body "Updating the service translation files from the agama-weblate repository"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

- Add a GitHub Action to merge back the updated Ruby service translations
- The code is very similar to the existing action for updating the web frontend translations ([weblate-merge-po.yml](https://github.com/openSUSE/agama/blob/master/.github/workflows/weblate-merge-po.yml))
- Later I'll try doing some refactoring and sharing some parts, but for now I think it is good enough