### PR TITLE
Remove label info for single file system

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 18 10:42:53 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Do not show info icon for the file system label if there is only
+  one option (gh#openSUSE/agama#938).
+
+-------------------------------------------------------------------
 Fri Dec 15 15:03:40 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Allow selecting file system type and configure snapshots

--- a/web/src/components/storage/VolumeForm.jsx
+++ b/web/src/components/storage/VolumeForm.jsx
@@ -285,7 +285,7 @@ const FsField = ({ value, volume, onChange }) => {
     <If
       condition={isSingleFs()}
       then={
-        <FormGroup label={label} labelIcon={<Info />}>
+        <FormGroup label={label}>
           <p>{fsOptionLabel(fsOption(value))}</p>
         </FormGroup>
       }


### PR DESCRIPTION
## Problem

The input *File system type* in the dialog for adding/editing a file system shows an info icon. That icon is used to give some info about the possible file system types that can be selected. The info icon should not be shown if there is only a single option, in which the file system type is rendered as plain text instead of a selector. See https://github.com/openSUSE/agama/pull/926.

![Screenshot from 2023-12-18 10-57-42](https://github.com/openSUSE/agama/assets/1112304/8201fba4-5ae4-432b-a86d-387e9509eb28)

## Solution

Remove info icon when there is only one option.

NOTE: there is some problems associated to the info icon. For example, it takes the focus while navigating through the form. Moreover, it opens a popover, which could be a bit strange when it is used in a popup. Probably this info icon will be replaced by another approach.  

## Testing

* Tested manually

## Screenshots

![Screenshot from 2023-12-18 10-51-33](https://github.com/openSUSE/agama/assets/1112304/48925d7a-45f0-4af0-996a-95f9b4daeaf0)
