### PR TITLE
Package the Ruby service translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .yardoc/
 .vscode/tasks.json
 /*.pot
+*.mo
+*.bz2

--- a/Rakefile
+++ b/Rakefile
@@ -110,6 +110,21 @@ task package: [] do
     gem2rpm = File.join(package_dir, "gem2rpm.yml")
     sh "gem2rpm --local --config #{gem2rpm} --template opensuse #{gem} > package/#{package_name}.spec"
     FileUtils.mv(gem, package_dir)
+
+    # build the translations tarball
+    #
+    # NOTE: the following code was inspired by the
+    # packaging_rake_tasks/lib/tasks/tarball.rake file
+    #
+    # set the file time stamps according to the latest commit
+    mtime = `git show -s --format=%ci`.chomp
+    # For the reproducible output:
+    # - use the GNU format (the default POSIX format contains some time stamps)
+    # - sort the files (in a locale independent way)
+    # - set the owner and group to "root"
+    # - set the fixed modification time
+    sh("LC_ALL=C tar -c -j -f #{Shellwords.escape(package_dir)}/po.tar.bz2 --format=gnu --sort=name " \
+      "--owner=root --group=root --mtime=#{Shellwords.escape(mtime)} po/*.po")
   end
 end
 

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -1,8 +1,13 @@
 ---
 :sourceurl: "%{mod_full_name}.gem"
+:sources:
+  - po.tar.bz2
+  - install_translations.sh
 :preamble: |-
   %global rb_build_versions %{rb_default_ruby}
   BuildRequires:  dbus-1-common
+  # "msgfmt" tool
+  BuildRequires:  gettext-runtime
   Requires:       dbus-1-common
 :post_install: |-
   install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/dbus.conf %{buildroot}%{_datadir}/dbus-1/agama.conf
@@ -12,6 +17,8 @@
   install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/agama-proxy-setup.service %{buildroot}%{_unitdir}/agama-proxy-setup.service
   install --directory %{buildroot}/usr/share/agama/conf.d
   install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/conf.d/*.yaml %{buildroot}/usr/share/agama/conf.d/
+  # run a script for installing the translations
+  "%{SOURCE2}" "%{SOURCE1}"
 :main:
   :preamble: |-
     # Override build.rpm, see also https://github.com/openSUSE/obs-build/blob/master/configs/
@@ -71,4 +78,6 @@
     %{_unitdir}/agama-proxy-setup.service\n
     %dir %{_datadir}/agama\n
     %dir %{_datadir}/agama/conf.d\n
-    %{_datadir}/agama/conf.d\n"
+    %{_datadir}/agama/conf.d\n
+    %dir /usr/share/YaST2\n
+    /usr/share/YaST2/locale\n"

--- a/service/package/install_translations.sh
+++ b/service/package/install_translations.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+# a helper script for compiling and installing the translations
+
+PODIR=$(mktemp --directory --suffix "-agama-po")
+
+tar xfjv "$1" -C "$PODIR"
+find "$PODIR" -name "*.po" -exec sh -c 'L=`basename "{}" .po` && mkdir -p "$RPM_BUILD_ROOT/usr/share/YaST2/locale/$L/LC_MESSAGES" && msgfmt -o "$RPM_BUILD_ROOT/usr/share/YaST2/locale/$L/LC_MESSAGES/agama.mo" "{}"' \;
+
+rm -rf "$PODIR"


### PR DESCRIPTION
## Problem

- The Ruby service translations are not package to RPM

## Solution

- Enhance the `rake package` task to create the `package/po.tar.bz2` file with all `po/*.po` files
- Update the `gem2rpm.yml` to unpack the `po.tar.bz2` archive and build the binary `*.mo` files from the text `*.po` files (the MO files are smaller and easier to parse) during RPM build
- The MO files are installed into the usual YaST2 translation directory (`/usr/share/YaST2/locale`) so it can be read the same way as the standard YaST translations, no change in the code is required


## Testing

- Tested manually - I built the package locally using the `osc` command, the built RPM contains the `/usr/share/YaST2/locale/cs/LC_MESSAGES/agama.mo` file 

