### PR TITLE
Fixed merging service translations

### DIFF
--- a/.github/workflows/weblate-merge-service-po.yml
+++ b/.github/workflows/weblate-merge-service-po.yml
@@ -65,6 +65,7 @@ jobs:
           find service/po -name '*.po' -exec git rm '{}' ';'
 
           # copy the new ones
+          mkdir -p service/po
           cp -a ../agama-weblate/service/*.po service/po
           git add service/po/*.po
 


### PR DESCRIPTION
## Problem

- The [GitHub action fails](https://github.com/openSUSE/agama/actions/runs/7235892794/job/19713844130#step:9:12)


## Solution

- In the previous step it calls `git rm` to remove the old translations
- Unfortunately after removing the last file in the directory Git also removes the empty directory so the next step which copies the new translations fails because of missing target directory

