### PR TITLE
OBS does not keep the executable flags :-/

### DIFF
--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -18,7 +18,7 @@
   install --directory %{buildroot}/usr/share/agama/conf.d
   install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/conf.d/*.yaml %{buildroot}/usr/share/agama/conf.d/
   # run a script for installing the translations
-  "%{SOURCE2}" "%{SOURCE1}"
+  sh "%{SOURCE2}" "%{SOURCE1}"
 :main:
   :preamble: |-
     # Override build.rpm, see also https://github.com/openSUSE/obs-build/blob/master/configs/


### PR DESCRIPTION
## Problem

Package build failed:

```
[   10s] + /home/abuild/rpmbuild/SOURCES/install_translations.sh /home/abuild/rpmbuild/SOURCES/po.tar.bz2
[   10s] /var/tmp/rpm-tmp.LhuJ21: line 44: /home/abuild/rpmbuild/SOURCES/install_translations.sh: Permission denied
[   10s] error: Bad exit status from /var/tmp/rpm-tmp.LhuJ21 (%install)
```

## Solution

- Start the script via shell explicitly

## Testing

- Tested manually using `osc` locally
