### PR TITLE
Display most representative country in timezone selector

### DIFF
--- a/doc/dbus/bus/org.opensuse.Agama1.Locale.bus.xml
+++ b/doc/dbus/bus/org.opensuse.Agama1.Locale.bus.xml
@@ -70,9 +70,12 @@
      * The timezone identifier (e.g., "Europe/Berlin").
      * A list containing each part of the name in the language set by the
        UILocale property.
+     * The name, in the language set by UILocale, of the main country
+       associated to the timezone (typically, the name of the city that is
+       part of the identifier) or empty string if there is no country.
      -->
     <method name="ListTimezones">
-      <arg type="a(sas)" direction="out"/>
+      <arg type="a(sass)" direction="out"/>
     </method>
     <method name="Commit">
     </method>

--- a/doc/dbus/org.opensuse.Agama1.Locale.doc.xml
+++ b/doc/dbus/org.opensuse.Agama1.Locale.doc.xml
@@ -34,9 +34,12 @@
      * The timezone identifier (e.g., "Europe/Berlin").
      * A list containing each part of the name in the language set by the
        UILocale property.
+     * The name, in the language set by UILocale, of the main country
+       associated to the timezone (typically, the name of the city that is
+       part of the identifier) or empty string if there is no country.
      -->
     <method name="ListTimezones">
-      <arg type="a(sas)" direction="out"/>
+      <arg type="a(sass)" direction="out"/>
     </method>
     <method name="Commit">
     </method>

--- a/rust/agama-dbus-server/src/locale.rs
+++ b/rust/agama-dbus-server/src/locale.rs
@@ -187,7 +187,7 @@ impl Locale {
         };
 
         let mut timezones_db = TimezonesDatabase::new();
-        timezones_db.read(&locale)?;
+        timezones_db.read(&ui_locale.language)?;
         let mut default_timezone = DEFAULT_TIMEZONE.to_string();
         if !timezones_db.exists(&default_timezone) {
             default_timezone = timezones_db.entries().get(0).unwrap().code.to_string();

--- a/rust/agama-dbus-server/src/locale.rs
+++ b/rust/agama-dbus-server/src/locale.rs
@@ -122,12 +122,21 @@ impl Locale {
     /// * The timezone identifier (e.g., "Europe/Berlin").
     /// * A list containing each part of the name in the language set by the
     ///   UILocale property.
-    fn list_timezones(&self) -> Result<Vec<(String, Vec<String>)>, Error> {
+    /// * The name, in the language set by UILocale, of the main country
+    ///   associated to the timezone (typically, the name of the city that is
+    ///   part of the identifier) or empty string if there is no country.
+    fn list_timezones(&self) -> Result<Vec<(String, Vec<String>, String)>, Error> {
         let timezones: Vec<_> = self
             .timezones_db
             .entries()
             .iter()
-            .map(|tz| (tz.code.to_string(), tz.parts.clone()))
+            .map(|tz| {
+                (
+                    tz.code.to_string(),
+                    tz.parts.clone(),
+                    tz.country.clone().unwrap_or_default(),
+                )
+            })
             .collect();
         Ok(timezones)
     }

--- a/rust/agama-dbus-server/src/locale/timezone.rs
+++ b/rust/agama-dbus-server/src/locale/timezone.rs
@@ -1,7 +1,9 @@
 //! This module provides support for reading the timezones database.
 
 use crate::error::Error;
+use agama_locale_data::territory::Territories;
 use agama_locale_data::timezone_part::TimezoneIdParts;
+use std::collections::HashMap;
 
 /// Represents a timezone, including each part as localized.
 #[derive(Debug)]
@@ -10,6 +12,8 @@ pub struct TimezoneEntry {
     pub code: String,
     /// Localized parts (e.g., "Atlántico", "Canarias").
     pub parts: Vec<String>,
+    /// Localized name of the territory this timezone is associated to
+    pub country: Option<String>,
 }
 
 #[derive(Default)]
@@ -49,13 +53,26 @@ impl TimezonesDatabase {
     fn get_timezones(&self, ui_language: &str) -> Result<Vec<TimezoneEntry>, Error> {
         let timezones = agama_locale_data::get_timezones();
         let tz_parts = agama_locale_data::get_timezone_parts()?;
+        let territories = agama_locale_data::get_territories()?;
+        let tz_countries = agama_locale_data::get_timezone_countries()?;
+        const COUNTRYLESS: [&str; 2] = ["UTC", "Antarctica/South_Pole"];
+
         let ret = timezones
             .into_iter()
-            .map(|tz| {
+            .filter_map(|tz| {
                 let parts = translate_parts(&tz, ui_language, &tz_parts);
-                TimezoneEntry { code: tz, parts }
+                let country = translate_country(&tz, ui_language, &tz_countries, &territories);
+                match country {
+                    None if !COUNTRYLESS.contains(&tz.as_str()) => None,
+                    _ => Some(TimezoneEntry {
+                        code: tz,
+                        parts,
+                        country,
+                    }),
+                }
             })
             .collect();
+
         Ok(ret)
     }
 }
@@ -69,6 +86,23 @@ fn translate_parts(timezone: &str, ui_language: &str, tz_parts: &TimezoneIdParts
                 .unwrap_or(part.to_owned())
         })
         .collect()
+}
+
+fn translate_country(
+    timezone: &str,
+    lang: &str,
+    countries: &HashMap<String, String>,
+    territories: &Territories,
+) -> Option<String> {
+    let tz = match timezone {
+        "Asia/Rangoon" => "Asia/Yangon",
+        "Europe/Kiev" => "Europe/Kyiv",
+        _ => timezone,
+    };
+    let country_id = countries.get(tz)?;
+    let territory = territories.find_by_id(country_id)?;
+    let name = territory.names.name_for(lang)?;
+    Some(name)
 }
 
 #[cfg(test)]
@@ -89,7 +123,32 @@ mod tests {
         assert_eq!(
             found.parts,
             vec!["Europa".to_string(), "Berlín".to_string()]
-        )
+        );
+        assert_eq!(found.country, Some("Alemania".to_string()));
+    }
+
+    #[test]
+    fn test_read_timezone_without_country() {
+        let mut db = TimezonesDatabase::new();
+        db.read("es").unwrap();
+        let timezone = db
+            .entries()
+            .into_iter()
+            .find(|tz| tz.code == "UTC")
+            .unwrap();
+        assert_eq!(timezone.country, None);
+    }
+
+    #[test]
+    fn test_read_kiev_country() {
+        let mut db = TimezonesDatabase::new();
+        db.read("en").unwrap();
+        let timezone = db
+            .entries()
+            .into_iter()
+            .find(|tz| tz.code == "Europe/Kiev")
+            .unwrap();
+        assert_eq!(timezone.country, Some("Ukraine".to_string()));
     }
 
     #[test]

--- a/rust/agama-locale-data/src/lib.rs
+++ b/rust/agama-locale-data/src/lib.rs
@@ -115,21 +115,21 @@ mod tests {
     #[test]
     fn test_get_languages() {
         let result = get_languages().unwrap();
-        let first = result.language.first().expect("no keyboards");
+        let first = result.language.first().expect("no languages");
         assert_eq!(first.id, "aa")
     }
 
     #[test]
     fn test_get_territories() {
         let result = get_territories().unwrap();
-        let first = result.territory.first().expect("no keyboards");
+        let first = result.territory.first().expect("no territories");
         assert_eq!(first.id, "001") // looks strange, but it is meta id for whole world
     }
 
     #[test]
     fn test_get_timezone_parts() {
         let result = get_timezone_parts().unwrap();
-        let first = result.timezone_part.first().expect("no keyboards");
+        let first = result.timezone_part.first().expect("no timezone parts");
         assert_eq!(first.id, "Abidjan")
     }
 

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 21 11:12:45 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- The result of ListTimezones includes the localized country name
+  for each timezone (gh#openSUSE/agama#946)
+
+-------------------------------------------------------------------
 Fri Dec 15 16:29:20 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Update agama-cli dependencies including the zerocopy crate to

--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Dec 21 11:18:37 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Display countries at timezone selector (gh#openSUSE/agama#946).
+
+-------------------------------------------------------------------
 Mon Dec 18 10:42:53 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Do not show info icon for the file system label if there is only

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -385,14 +385,14 @@ ul[data-of="agama/keymaps"] {
 ul[data-of="agama/timezones"] {
   li {
     display: grid;
-    grid-template-columns: 1fr 2fr 1fr 1fr;
+    grid-template-columns: 2fr 1fr 1fr;
 
     > :last-child {
       grid-column: 1 / -1;
       font-size: 80%;
     }
 
-    > :nth-child(4) {
+    > :nth-child(3) {
       color: var(--color-gray-dimmed);
       text-align: end;
     }

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -385,14 +385,14 @@ ul[data-of="agama/keymaps"] {
 ul[data-of="agama/timezones"] {
   li {
     display: grid;
-    grid-template-columns: 1fr 2fr 1fr;
+    grid-template-columns: 1fr 2fr 1fr 1fr;
 
     > :last-child {
       grid-column: 1 / -1;
       font-size: 80%;
     }
 
-    > :nth-child(3) {
+    > :nth-child(4) {
       color: var(--color-gray-dimmed);
       text-align: end;
     }

--- a/web/src/client/l10n.js
+++ b/web/src/client/l10n.js
@@ -31,6 +31,7 @@ const LOCALE_PATH = "/org/opensuse/Agama1/Locale";
  * @typedef {object} Timezone
  * @property {string} id - Timezone id (e.g., "Atlantic/Canary").
  * @property {Array<string>} parts - Name of the timezone parts (e.g., ["Atlantic", "Canary"]).
+ * @property {string} country - Name of the country associated to the zone or empty string (e.g., "Spain").
  * @property {number} utcOffset - UTC offset.
  */
 
@@ -230,13 +231,13 @@ class L10nClient {
   /**
    * @private
    *
-   * @param {[string, Array<string>]} dbusTimezone
+   * @param {[string, Array<string>, string]} dbusTimezone
    * @returns {Timezone}
    */
-  buildTimezone([id, parts]) {
+  buildTimezone([id, parts, country]) {
     const utcOffset = timezoneUTCOffset(id);
 
-    return ({ id, parts, utcOffset });
+    return ({ id, parts, country, utcOffset });
   }
 
   /**

--- a/web/src/components/l10n/TimezoneSelector.jsx
+++ b/web/src/components/l10n/TimezoneSelector.jsx
@@ -70,13 +70,11 @@ const timezoneDetails = (timezone) => {
  * @param {Date} props.date - Date to show a time.
  */
 const TimezoneItem = ({ timezone, date }) => {
-  const [part1, ...restParts] = timezone.parts;
   const time = timezoneTime(timezone.id, { date }) || "";
 
   return (
     <>
-      <div>{part1}</div>
-      <div>{restParts.join('-')}</div>
+      <div>{timezone.parts.join('-')}</div>
       <div>{timezone.country}</div>
       <div>{time || ""}</div>
       <div>{timezone.details}</div>

--- a/web/src/components/l10n/TimezoneSelector.jsx
+++ b/web/src/components/l10n/TimezoneSelector.jsx
@@ -77,6 +77,7 @@ const TimezoneItem = ({ timezone, date }) => {
     <>
       <div>{part1}</div>
       <div>{restParts.join('-')}</div>
+      <div>{timezone.country}</div>
       <div>{time || ""}</div>
       <div>{timezone.details}</div>
     </>


### PR DESCRIPTION
## Problems

Problem 1.

In the timezone selector the countries are only displayed if they are part of the name of the timezone (eg. America/Argentina/Buenos_Aires). In most cases, the name of the timezone includes only the global region and a concrete city (eg. Europe/Madrid). That makes hard to find the right timezone since the most intuitive mechanism (typing the name of the user country in the search box) is usually useless.

![spain-old](https://github.com/openSUSE/agama/assets/3638289/e51c9eac-09ec-471e-af75-e03b4ba5a0e2)

Problem 2.

There are some duplicated or controversial timezones that are not associated to any country. For more details [this gist](https://gist.github.com/ancorgs/8bd5f42ea847e1ba7590bc7e3d54cdad).

![buenos_aires-old](https://github.com/openSUSE/agama/assets/3638289/b45e0dd2-4483-485b-b050-c8cac08a9b3c)

## Solution

Add the "most representative country" to each timezone and display that in the UI. That information is read from the file `/usr/share/zoneinfo/zone.tab`.

That makes it easier to find timezones.

![spain-new](https://github.com/openSUSE/agama/assets/3638289/cb4ecafc-303c-4c28-94d4-33570a6bfc5d)

Timezones without a country (except those that really make sense) are filtered out. That removes controversy and duplicates.

![buenos_aires-new](https://github.com/openSUSE/agama/assets/3638289/4a221099-ec78-4626-8005-c76a42b1f1dd)

Works even for the two timezones that have a different identifier at langtable and at `zone.tab`. Again, see the [previously mentioned gist](https://gist.github.com/ancorgs/8bd5f42ea847e1ba7590bc7e3d54cdad).

![rangoon-new](https://github.com/openSUSE/agama/assets/3638289/8239362b-ae3b-4848-842f-98bbf8fad070)

## Testing

- Added new unit tests
- Tested manually (as shown in the screenshots)