### PR TITLE
Add dependency on timezone

### DIFF
--- a/rust/package/agama-cli.spec
+++ b/rust/package/agama-cli.spec
@@ -32,6 +32,7 @@ BuildRequires:  cargo-packaging
 BuildRequires:  pkgconfig(openssl)
 # used in tests for dbus service
 BuildRequires:  python-langtable-data
+BuildRequires:  timezone
 BuildRequires:  dbus-1-common
 # required by agama-dbus-server integration tests
 BuildRequires:  dbus-1-daemon
@@ -42,6 +43,8 @@ Requires:       bzip2
 Requires:       tar
 # required for translating the keyboards descriptions
 Requires:       xkeyboard-config-lang
+# required for getting the list of timezones
+Requires:       timezone
 
 %description
 Command line program to interact with the agama service.


### PR DESCRIPTION
Add timezone dependency in agama-cli as it needs access to `/usr/share/timezone/zone.tab`.
