### PR TITLE
[web] Does not mangle names ending in PageMenu

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec 22 09:29:59 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- UI: Fix page menus placement in production mode,
+   rendering them in the page header (gh#openSUSE/agama#925,
+   gh#openSUSE/agama#950).
+
+-------------------------------------------------------------------
 Thu Dec 21 14:24:02 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 7

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -144,6 +144,12 @@ module.exports = {
     minimize: production,
     minimizer: [
       new TerserJSPlugin({
+        // src/components/core/Page.jsx is using a type?.name.endsWith("PageMenu") for extracting page menus.
+        // Thus, it's needed not mangling function names ending in PageMenu to keep it working in production
+        // until adopting a better solution, if any.
+        terserOptions: {
+          keep_fnames: /PageMenu$/,
+        },
         extractComments: {
           condition: true,
           filename: `[file].LICENSE.txt?query=[query]&filebase=[base]`,


### PR DESCRIPTION
## Problem

`core/Page` component changed a lot in #925 and got _the ability_ to work with it's children in order to been able to extract some of them for placing in the right place.

It's the case of the `Page.Actions` and `Page.Menu`, but while the former are extracted by checking their `type`, for the latest it's needed to relay on their `type.name` since they can be wrapped in another component due to their potential complexity.

Thus, it was required that components intended to be used as page menus were named ending in _PageMenu_, but this does not work as expected when minification comes into scene. 

## Solution

Until we have something better, the solution by now is asking [TerserWebpackPlugin](https://webpack.js.org/plugins/terser-webpack-plugin/) to keep functions names for these functions (aka components) ending in _PageMenu_. A few bytes more for the production build, but in exchange everything works as expected.

Fixes #949 

## Testing

Tested manually

## Screenshots

|Before | After |
|-|-|
|![Page Menu missplaced](https://github.com/openSUSE/agama/assets/1691872/dbfe338b-751c-4110-ab8b-6f5f7a68fc5a) | ![Page Menu in place](https://github.com/openSUSE/agama/assets/1691872/b0fd3638-47cc-42ec-a3d9-b07751227862) |


