### PR TITLE
[web] Fix some icon sizes

### DIFF
--- a/web/src/DevServerWrapper.jsx
+++ b/web/src/DevServerWrapper.jsx
@@ -33,7 +33,7 @@ const loginPath = "/cockpit/@localhost/system/terminal.html";
 // id of the password field in the login dialog
 const loginId = "login-password-input";
 
-const ErrorIcon = () => <Icon name="error" className="icon-big" />;
+const ErrorIcon = () => <Icon name="error" className="icon-xxxl" />;
 
 /**
  * This is a helper wrapper used in the development server only. It displays

--- a/web/src/components/core/DBusError.jsx
+++ b/web/src/components/core/DBusError.jsx
@@ -26,7 +26,7 @@ import { Page } from "~/components/core";
 import { _ } from "~/i18n";
 import { locationReload } from "~/utils";
 
-const ErrorIcon = () => <Icon name="error" className="icon-big" />;
+const ErrorIcon = () => <Icon name="error" className="icon-xxxl" />;
 
 function DBusError() {
   return (


### PR DESCRIPTION
CSS classes for icon sizes were changed at 68c8e280025f262db06c9b77f25ef74c30cfd2d7 but some `icon-big` references were not updated to their `icon-xxxl` counterpart.

This PR fix it.