### PR TITLE
Limit the dependency on fde-tools to x86_64 and aarch64

### DIFF
--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -55,7 +55,9 @@
     Requires:       exfat-utils
     Requires:       f2fs-tools
     Requires:       fcoe-utils
+    %ifarch x86_64 aarch64
     Requires:       fde-tools
+    %endif
     Requires:       jfsutils
     Requires:       libstorage-ng-lang
     Requires:       lvm2


### PR DESCRIPTION
The `fde-tools` package is available only in `x86_64` and `aarch64` architectures. Thus, we need to adjust the dependency in the spec file.
