### PR TITLE
Mark some Agama service strings for translation

### DIFF
--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -44,6 +44,7 @@ module Agama
   class Manager
     include WithProgress
     include Helpers
+    include Yast::I18n
 
     # @return [Logger]
     attr_reader :logger
@@ -58,6 +59,8 @@ module Agama
     #
     # @param logger [Logger]
     def initialize(config, logger)
+      textdomain "agama"
+
       @config = config
       @logger = logger
       @installation_phase = InstallationPhase.new
@@ -82,8 +85,8 @@ module Agama
       installation_phase.config
 
       start_progress(2)
-      progress.step("Probing Storage") { storage.probe }
-      progress.step("Probing Software") { software.probe }
+      progress.step(_("Probing Storage")) { storage.probe }
+      progress.step(_("Probing Software")) { software.probe }
 
       logger.info("Config phase done")
     rescue StandardError => e
@@ -103,7 +106,7 @@ module Agama
 
       Yast::Installation.destdir = "/mnt"
 
-      progress.step("Partitioning") do
+      progress.step(_("Partitioning")) do
         storage.install
         proxy.propose
         # propose software after /mnt is already separated, so it uses proper
@@ -111,14 +114,14 @@ module Agama
         software.propose
       end
 
-      progress.step("Installing Software") { software.install }
+      progress.step(_("Installing Software")) { software.install }
 
       on_target do
-        progress.step("Writing Users") { users.write }
-        progress.step("Writing Network Configuration") { network.install }
-        progress.step("Saving Language Settings") { language.finish }
-        progress.step("Writing repositories information") { software.finish }
-        progress.step("Finishing storage configuration") { storage.finish }
+        progress.step(_("Writing Users")) { users.write }
+        progress.step(_("Writing Network Configuration")) { network.install }
+        progress.step(_("Saving Language Settings")) { language.finish }
+        progress.step(_("Writing repositories information")) { software.finish }
+        progress.step(_("Finishing storage configuration")) { storage.finish }
       end
 
       logger.info("Install phase done")

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -44,6 +44,7 @@ module Agama
     class Manager
       include WithIssues
       include WithProgress
+      include Yast::I18n
 
       # @return [Config]
       attr_reader :config
@@ -53,6 +54,8 @@ module Agama
       # @param config [Config]
       # @param logger [Logger]
       def initialize(config, logger)
+        textdomain "agama"
+
         @config = config
         @logger = logger
         register_proposal_callbacks
@@ -105,10 +108,10 @@ module Agama
       def probe
         start_progress(4)
         config.pick_product(software.selected_product)
-        progress.step("Activating storage devices") { activate_devices }
-        progress.step("Probing storage devices") { probe_devices }
-        progress.step("Calculating the storage proposal") { calculate_proposal }
-        progress.step("Selecting Linux Security Modules") { security.probe }
+        progress.step(_("Activating storage devices")) { activate_devices }
+        progress.step(_("Probing storage devices")) { probe_devices }
+        progress.step(_("Calculating the storage proposal")) { calculate_proposal }
+        progress.step(_("Selecting Linux Security Modules")) { security.probe }
         update_issues
         @on_probe_callbacks&.each(&:call)
       end
@@ -116,14 +119,14 @@ module Agama
       # Prepares the partitioning to install the system
       def install
         start_progress(4)
-        progress.step("Preparing bootloader proposal") do
+        progress.step(_("Preparing bootloader proposal")) do
           # first make bootloader proposal to be sure that required packages are installed
           proposal = ::Bootloader::ProposalClient.new.make_proposal({})
           logger.debug "Bootloader proposal #{proposal.inspect}"
         end
-        progress.step("Adding storage-related packages") { add_packages }
-        progress.step("Preparing the storage devices") { perform_storage_actions }
-        progress.step("Writing bootloader sysconfig") do
+        progress.step(_("Adding storage-related packages")) { add_packages }
+        progress.step(_("Preparing the storage devices")) { perform_storage_actions }
+        progress.step(_("Writing bootloader sysconfig")) do
           # call inst bootloader to get properly initialized bootloader
           # sysconfig before package installation
           Yast::WFM.CallFunction("inst_bootloader", [])


### PR DESCRIPTION
## Problem

Although all the infrastructure to translate the Ruby-based Agama service is in-place, some strings are still not marked for translation.

## Solution

Mark the manager and software manager progress strings.