### PR TITLE
Drop objects registry mutex

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,6 +5,10 @@ members = [
   "agama-derive",
   "agama-lib",
   "agama-locale-data",
-  "agama-settings"
+  "agama-settings",
 ]
+resolver = "2"
 
+[workspace.package]
+rust-version = "1.74"
+edition = "2021"

--- a/rust/agama-dbus-server/Cargo.toml
+++ b/rust/agama-dbus-server/Cargo.toml
@@ -2,13 +2,14 @@
 name = "agama-dbus-server"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0"
-agama-locale-data = { path="../agama-locale-data" }
-agama-lib = { path="../agama-lib" }
+agama-locale-data = { path = "../agama-locale-data" }
+agama-lib = { path = "../agama-lib" }
 log = "0.4"
 simplelog = "0.12.1"
 systemd-journal-logger = "1.0"

--- a/rust/agama-dbus-server/src/network/action.rs
+++ b/rust/agama-dbus-server/src/network/action.rs
@@ -23,11 +23,17 @@ pub enum Action {
     ),
     /// Gets a connection
     GetConnection(Uuid, Responder<Option<Connection>>),
+    /// Gets a connection
+    GetConnectionPath(String, Responder<Option<OwnedObjectPath>>),
+    /// Get connections paths
+    GetConnectionsPaths(Responder<Vec<OwnedObjectPath>>),
     /// Gets a controller connection
     GetController(
         Uuid,
         Responder<Result<ControllerConnection, NetworkStateError>>,
     ),
+    /// Get devices paths
+    GetDevicesPaths(Responder<Vec<OwnedObjectPath>>),
     /// Sets a controller's ports. It uses the Uuid of the controller and the IDs or interface names
     /// of the ports.
     SetPorts(

--- a/rust/agama-dbus-server/src/network/adapter.rs
+++ b/rust/agama-dbus-server/src/network/adapter.rs
@@ -1,8 +1,10 @@
 use crate::network::NetworkState;
+use async_trait::async_trait;
 use std::error::Error;
 
 /// A trait for the ability to read/write from/to a network service
+#[async_trait]
 pub trait Adapter {
-    fn read(&self) -> Result<NetworkState, Box<dyn Error>>;
-    fn write(&self, network: &NetworkState) -> Result<(), Box<dyn Error>>;
+    async fn read(&self) -> Result<NetworkState, Box<dyn Error>>;
+    async fn write(&self, network: &NetworkState) -> Result<(), Box<dyn Error>>;
 }

--- a/rust/agama-dbus-server/src/network/dbus.rs
+++ b/rust/agama-dbus-server/src/network/dbus.rs
@@ -8,4 +8,4 @@ pub mod service;
 mod tree;
 
 pub use service::NetworkService;
-pub(crate) use tree::{ObjectsRegistry, Tree};
+pub(crate) use tree::Tree;

--- a/rust/agama-dbus-server/src/network/system.rs
+++ b/rust/agama-dbus-server/src/network/system.rs
@@ -33,8 +33,8 @@ impl<T: Adapter> NetworkSystem<T> {
 
     /// Writes the network configuration.
     pub async fn write(&mut self) -> Result<(), Box<dyn Error>> {
-        self.adapter.write(&self.state)?;
-        self.state = self.adapter.read()?;
+        self.adapter.write(&self.state).await?;
+        self.state = self.adapter.read().await?;
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl<T: Adapter> NetworkSystem<T> {
 
     /// Populates the D-Bus tree with the known devices and connections.
     pub async fn setup(&mut self) -> Result<(), Box<dyn Error>> {
-        self.state = self.adapter.read()?;
+        self.state = self.adapter.read().await?;
         self.tree
             .set_connections(&mut self.state.connections)
             .await?;

--- a/rust/agama-dbus-server/src/network/system.rs
+++ b/rust/agama-dbus-server/src/network/system.rs
@@ -77,10 +77,16 @@ impl<T: Adapter> NetworkSystem<T> {
                 let conn = self.state.get_connection_by_uuid(uuid);
                 tx.send(conn.cloned()).unwrap();
             }
+            Action::GetConnectionPath(id, tx) => {
+                let path = self.tree.connection_path(&id);
+                tx.send(path).unwrap();
+            }
             Action::GetController(uuid, tx) => {
                 let result = self.get_controller_action(uuid);
                 tx.send(result).unwrap()
             }
+            Action::GetDevicesPaths(tx) => tx.send(self.tree.devices_paths()).unwrap(),
+            Action::GetConnectionsPaths(tx) => tx.send(self.tree.connections_paths()).unwrap(),
             Action::SetPorts(uuid, ports, rx) => {
                 let result = self.set_ports_action(uuid, *ports);
                 rx.send(result).unwrap();

--- a/rust/agama-dbus-server/tests/network.rs
+++ b/rust/agama-dbus-server/tests/network.rs
@@ -11,6 +11,7 @@ use agama_lib::network::{
     types::DeviceType,
     NetworkClient,
 };
+use async_trait::async_trait;
 use cidr::IpInet;
 use std::error::Error;
 use tokio::test;
@@ -18,12 +19,16 @@ use tokio::test;
 #[derive(Default)]
 pub struct NetworkTestAdapter(network::NetworkState);
 
+#[async_trait]
 impl Adapter for NetworkTestAdapter {
-    fn read(&self) -> Result<network::NetworkState, Box<dyn std::error::Error>> {
+    async fn read(&self) -> Result<network::NetworkState, Box<dyn std::error::Error>> {
         Ok(self.0.clone())
     }
 
-    fn write(&self, _network: &network::NetworkState) -> Result<(), Box<dyn std::error::Error>> {
+    async fn write(
+        &self,
+        _network: &network::NetworkState,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         unimplemented!("Not used in tests");
     }
 }

--- a/rust/agama-lib/src/error.rs
+++ b/rust/agama-lib/src/error.rs
@@ -6,9 +6,9 @@ use zbus;
 
 #[derive(Error, Debug)]
 pub enum ServiceError {
-    #[error("D-Bus service error")]
+    #[error("D-Bus service error: {0}")]
     DBus(#[from] zbus::Error),
-    #[error("Could not connect to Agama bus at '{0}'")]
+    #[error("Could not connect to Agama bus at '{0}': {1}")]
     DBusConnectionError(String, #[source] zbus::Error),
     // it's fine to say only "Error" because the original
     // specific error will be printed too
@@ -20,7 +20,7 @@ pub enum ServiceError {
     FailedRegistration(String),
     #[error("Failed to find these patterns: {0:?}")]
     UnknownPatterns(Vec<String>),
-    #[error("Error: {0}")]
+    #[error("Could not perform action '{0}'")]
     UnsuccessfulAction(String),
 }
 


### PR DESCRIPTION
* Drop the ObjectsRegistry mutex and use message passing.
* Use `async_trait` in the network Adapter trait, although it should not be needed in version 1.75 (another PR would follow).
* Set the minimal version to 1.74.
* Improve ServiceError messages.