### PR TITLE
Avoid a deadlock updating the network D-Bus tree

### DIFF
--- a/rust/agama-dbus-server/src/network/system.rs
+++ b/rust/agama-dbus-server/src/network/system.rs
@@ -119,7 +119,9 @@ impl<T: Adapter> NetworkSystem<T> {
                 let tree = Arc::clone(&self.tree);
                 tokio::spawn(async move {
                     let mut tree = tree.lock().await;
-                    _ = tree.set_connections(&mut connections).await;
+                    if let Err(e) = tree.set_connections(&mut connections).await {
+                        log::error!("Could not update the D-Bus tree: {}", e);
+                    }
                 });
             }
         }


### PR DESCRIPTION
## Problem

If the network service receives an `Apply` at the same time as any other request, it may get blocked.

## Solution

Updating the tree must be done in a separate task. Otherwise, it could fight with an incoming request for the ObjectServer mutex, blocking the actions dispatching.

## Using tokio-console

I decided to use [tokio-console](https://docs.rs/tokio-console/latest/tokio_console/) to make it easier to find the problem. This tool collects and displays information about the asynchronous tasks in your program. In the screenshot below you can see that the D-Bus `Set` dispatchers are blocked.

![Captura desde 2023-12-29 10-52-45](https://github.com/openSUSE/agama/assets/15836/648e5f1e-eb6b-431b-be40-45cdeaf9e980)

Once you find the problem, it is kind of "obvious", but it may take some time until you figure out what is happening.

To use `tokio-console` you need to add some instrumentation to your program and, at this point, it implies adding some unstable Tokio APIs. So if you want to give it a try, you can try the code in the [tokio-console branch](https://github.com/openSUSE/agama/compare/tokio-console).