### PR TITLE
Fixed integration test

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -22,6 +22,11 @@ jobs:
 
     - name: Git Checkout
       uses: actions/checkout@v3
+      with:
+        # fetch complete history with tags, agama.gemspec calls "git describe --tags"
+        # that would fail with just last commit checked out
+        fetch-depth: 0
+        fetch-tags: true
 
     - name: Created shared YaST log directory
       run: mkdir -p /tmp/log/YaST2
@@ -43,21 +48,28 @@ jobs:
     - name: Start Cockpit service
       run:  podman exec --detach agama /usr/libexec/cockpit-ws --local-session=/usr/bin/cockpit-bridge
 
+    - name: Remove Cockpit dependency
+      # Cockpit has been already started manually, starting it again as a unit dependency would fail
+      # remove the "Requires=cockpit.socket" line
+      run:  podman exec agama bash -c "sed -i /Requires=cockpit.socket/d /checkout/service/share/agama.service"
+
     - name: Setup service
       run:  podman exec agama bash -c "cd /checkout; ./setup-services.sh"
 
     - name: Set a testing Agama configuration
-      # use just one product, it skips the product selection at the beginning
-      run:  podman exec agama bash -c "rm /checkout/products.d/ALP-Dolomite.yaml"
+      # delete all products except TW to skip the product selection at the beginning
+      run:  podman exec agama bash -c "ls /checkout/products.d/*.yaml | grep -v tumbleweed.yaml | xargs rm"
 
     - name: Show NetworkManager log
       run:  podman exec agama journalctl -u NetworkManager
 
     - name: Show the D-Bus services log
-      run:  podman exec agama bash -c "journalctl | grep agama"
+      run:  |
+          podman exec agama journalctl -u agama
+          podman exec agama systemctl status agama
 
-    - name: Check D-Bus socket
-      run:  podman exec agama ls -l /var/run/dbus/system_bus_socket
+    - name: Inspect D-Bus services
+      run:  podman exec agama busctl --address unix:path=/run/agama/bus
 
     - name: Run the Agama smoke test
       run:  podman exec agama curl http://localhost:9090/cockpit/@localhost/agama/index.html
@@ -71,11 +83,9 @@ jobs:
       run:  podman exec agama bash -c "cd /checkout/playwright && SKIP_LOGIN=true playwright test --trace on --project chromium"
 
     - name: Again show the D-Bus services log
-      run:  podman exec agama bash -c "journalctl | grep agama"
-
-    - name: Show the complete journal
-      # maybe not necessary if the above filtered journalctl calls are enough
-      run:  podman exec agama journalctl -b || echo "journal failed with $?"
+      # run even when any previous step fails
+      if: always()
+      run:  podman exec agama journalctl
 
     - name: Upload the test results
       uses: actions/upload-artifact@v3

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -13,13 +13,13 @@ import { devices } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   testDir: './tests',
   /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
+  timeout: 60 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 15000
+    timeout: 60 * 1000
   },
   /* Do not run tests in files in parallel by default */
   fullyParallel: false,

--- a/playwright/tests/root_password.spec.ts
+++ b/playwright/tests/root_password.spec.ts
@@ -27,7 +27,7 @@ test.describe('The user section', () => {
     await expect(page.locator('[role="dialog"]')).not.toBeVisible();
 
     // go back to the main page
-    await page.getByText('Back').click();
+    await page.getByRole('button', { name: 'Back', exact: true }).click();
 
     // check the summary text
     await expect(page.getByText("Root authentication set")).toBeVisible();


### PR DESCRIPTION
## Problem

- The integration test was failing
- https://github.com/openSUSE/agama/actions/runs/7395724982/job/20119447308

## Solution

During debugging I found several problems:

- The `agama.gemspec` file calls `git describe --tags`, that does not work when the Git checkout contains only the last commit and no history. Fixed by fetching the Git repository with full history. (Note: There is no significant slow down, even with the full history the Git repository is fetched in 2 seconds.)
- The Cockpit service is started manually but later systemd wants to start it as a service dependency and that fails because the port 9090 is already taken.
- The products directory now contains several YAML product files, delete all of them except the Tumbleweed configuration.
- Increased the timeout in the tests, refreshing the Tumbleweed repository sometimes might take more time and in that case the test fails because of time out.
- More precise "Back" button specification in `root_password.spec.ts` test, that text matched the "Czech (extra backslash)" text in the keyboard selection menu. (Playwright by default does a partial case-insensitive match, short texts might accidentally match a substring in longer texts.)
- Added some more debugging steps in the workflow to get more details when something fails

## Testing

- The integration test now passes without problems
- https://github.com/lslezak/agama/actions/runs/7407057992/job/20152559638
