### PR TITLE
[web] Fix Agama selectors look&feel

### DIFF
--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -260,11 +260,15 @@ span.notification-mark[data-variant="sidebar"] {
 }
 
 ul[data-type="agama/list"] {
+  list-style: none;
+  margin-inline: 0;
+
   li {
     border: 2px solid var(--color-gray-dark);
     padding: var(--spacer-normal);
     text-align: start;
     background: var(--color-gray-light);
+    margin-block-end: 0;
 
     &:nth-child(n+2) {
       border-top: 0;

--- a/web/src/assets/styles/index.scss
+++ b/web/src/assets/styles/index.scss
@@ -1,3 +1,6 @@
+// PatternFly overrides
+@use "~/assets/styles/patternfly-overrides.scss";
+
 @use "~/assets/fonts.scss";
 @use "~/assets/styles/variables.scss";
 // TODO: merge app and global
@@ -8,5 +11,3 @@
 @use "~/assets/styles/composition.scss";
 @use "~/assets/styles/blocks.scss";
 
-// PatternFly overrides
-@use "~/assets/styles/patternfly-overrides.scss";


### PR DESCRIPTION
## Problem

The `ul` styles were overwritten in #886 to make them looks like what they are: unordered lists. However, such a changed impacted in the look&feel of the current Agama selectors.

## Solution

Restore the Agama selectors by setting their list-type and margins explicetely.

## Testing

- Tested manually

## Screenshots

| Before | After |
|-|-|
| ![Screen Shot 2024-01-08 at 16 37 13](https://github.com/openSUSE/agama/assets/1691872/a69d36df-a5ea-424f-86cd-b34ee2f0b415) | ![Screen Shot 2024-01-08 at 16 36 58](https://github.com/openSUSE/agama/assets/1691872/97499e07-47dd-45ee-b5e8-da7d1152bfd0) |

## Additional notes

No changelog entry required.

