### PR TITLE
Avoid duplicated keymaps

### DIFF
--- a/rust/agama-locale-data/src/locale.rs
+++ b/rust/agama-locale-data/src/locale.rs
@@ -100,7 +100,7 @@ impl FromStr for KeymapId {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let re = KEYMAP_ID_REGEX
-            .get_or_init(|| Regex::new(r"(\w+)((\((?<var1>\w+)\)|-(?<var2>\w+)))?").unwrap());
+            .get_or_init(|| Regex::new(r"([\w.]+)((\((?<var1>.+)\)|-(?<var2>.+)))?").unwrap());
 
         if let Some(parts) = re.captures(s) {
             let mut variant = None;
@@ -152,6 +152,24 @@ mod test {
                 variant: Some("ast".to_string())
             },
             keymap_id2
+        );
+
+        let keymap_id3 = KeymapId::from_str("pt-nativo-us").unwrap();
+        assert_eq!(
+            KeymapId {
+                layout: "pt".to_string(),
+                variant: Some("nativo-us".to_string())
+            },
+            keymap_id3
+        );
+
+        let keymap_id4 = KeymapId::from_str("lt.std").unwrap();
+        assert_eq!(
+            KeymapId {
+                layout: "lt.std".to_string(),
+                variant: None
+            },
+            keymap_id4
         );
     }
 }

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan  8 17:02:40 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Fix the list of keymaps to avoid duplicated values
+  (gh#openSUSE/agama#981).
+
+-------------------------------------------------------------------
 Thu Dec 21 14:23:33 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 7


### PR DESCRIPTION
## Problem

The list of available keymaps contains some duplicated values.

## Solution

Fix the regexp to obtain the layout and variant names from `localectl`. Now it allows layouts with dots (e.g., *lt.std*) and variants with dashes (e.g., *pt-nativo-epo*).

Note for reviewers: regexp can be checked with https://rustexp.lpil.uk/.

## Testing

* Added new unit tests.
* Tested manually.

## Screenshots

<details>
<summary>Toggle</summary>

![localhost_8080_(iPad Mini) (23)](https://github.com/openSUSE/agama/assets/1112304/eaabbb77-59ea-49c7-9628-1aed4f5e1229)

![localhost_8080_(iPad Mini) (22)](https://github.com/openSUSE/agama/assets/1112304/a8f161bb-f429-4c5d-b323-4b2f6c01eb53)

</details>