### PR TITLE
Translate pattern descriptions

### DIFF
--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jan 11 12:08:29 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Translate the pattern descriptions (gh#openSUSE/agama#859)
+
+-------------------------------------------------------------------
 Thu Dec 21 14:23:48 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 7


### PR DESCRIPTION
## Problem

- After changing the language the pattern descriptions are not translated (actually they keep the previous locale setting)
- #859 

## Solution

- After changing the language refresh the repositories and reload the data to get the pattern descriptions in the new language.
- The selected packages need to be restored after the reload, the current selection is lost.

## Notes

The pattern groups (e.g. "Graphical Environments", "Base Technologies")  are not translated but they come from libzypp as well. But as they are not translated also in YaST I guess there is some serious problem, maybe there is missing translation support for that... I'll check the details later.

## Testing

- Tested manually

## Screenshots

Switching from English to Spanish, the previously selected patterns are kept.

The Gnome pattern description  is not translated, probably missing translation or they updated the original text and was not re-translated. But at least the name is translated.

[patterns.webm](https://github.com/openSUSE/agama/assets/907998/e02569df-4280-40a0-bd73-f9dc2273d201)


