### PR TITLE
Make TPM-based encryption more explicit

### DIFF
--- a/products.d/ALP-Dolomite.yaml
+++ b/products.d/ALP-Dolomite.yaml
@@ -63,9 +63,7 @@ security:
 storage:
   space_policy: delete
   encryption:
-    method: luks2
-    pbkd_function: pbkdf2
-    tpm_luks_open: true
+    method: tpm_fde
   volumes:
     - "/"
   volume_templates:

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -34,6 +34,7 @@ require "agama/dbus/storage/volume_conversion"
 require "agama/dbus/storage/with_iscsi_auth"
 require "agama/dbus/with_service_status"
 require "agama/storage/volume_templates_builder"
+require "agama/storage/encryption_settings"
 
 Yast.import "Arch"
 
@@ -117,11 +118,18 @@ module Agama
           proposal.available_devices.map { |d| system_devices_tree.path_for(d) }
         end
 
-        # List of meaningful mount points for the the current product.
+        # List of meaningful mount points for the current product.
         #
         # @return [Array<String>]
         def product_mount_points
           volume_templates_builder.all.map(&:mount_path).reject(&:empty?)
+        end
+
+        # List of possible encryption methods for the current system and product
+        #
+        # @return [Array<String>]
+        def encryption_methods
+          Agama::Storage::EncryptionSettings.available_methods.map { |m| m.id.to_s }
         end
 
         # Path of the D-Bus object containing the calculated proposal
@@ -160,6 +168,8 @@ module Agama
           dbus_reader :available_devices, "ao"
 
           dbus_reader :product_mount_points, "as"
+
+          dbus_reader :encryption_methods, "as"
 
           dbus_reader :result, "o"
 

--- a/service/lib/agama/storage/proposal_settings_reader.rb
+++ b/service/lib/agama/storage/proposal_settings_reader.rb
@@ -69,24 +69,19 @@ module Agama
       # @param settings [Agama::Storage::ProposalSettings]
       # @param encryption [Hash]
       def encryption_reader(settings, encryption)
-        method =
-          if try_tpm_fde?(encryption)
-            Y2Storage::EncryptionMethod::TPM_FDE
-          else
-            Y2Storage::EncryptionMethod.find(encryption.fetch("method", ""))
-          end
+        method = Y2Storage::EncryptionMethod.find(encryption.fetch("method", ""))
         pbkd_function = Y2Storage::PbkdFunction.find(encryption.fetch("pbkd_function", ""))
 
-        settings.encryption.method = method if method
+        settings.encryption.method = method if available_method?(method)
         settings.encryption.pbkd_function = pbkd_function if pbkd_function
       end
 
-      # @param encryption [Hash]
+      # @param method [Y2Storage::EncryptionMethod::Base, nil]
       # @return [Boolean]
-      def try_tpm_fde?(encryption)
-        return false unless encryption["tpm_luks_open"] == true
+      def available_method?(method)
+        return false unless method
 
-        Y2Storage::EncryptionMethod::TPM_FDE.possible?
+        EncryptionSettings.available_methods.include?(method)
       end
 
       # @param settings [Agama::Storage::ProposalSettings]

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 18 08:35:01 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- New default encryption settings: LUKS2 with PBKDF2.
+- Expose encryption methods at D-Bus API (gh#openSUSE/agama#995).
+
+-------------------------------------------------------------------
 Tue Jan 16 10:49:14 UTC 2024 - Michal Filka <mfilka@suse.com>
 
 - bsc#1210541, gh#openSUSE/agama#516

--- a/service/test/agama/dbus/storage/proposal_settings_conversion/to_dbus_test.rb
+++ b/service/test/agama/dbus/storage/proposal_settings_conversion/to_dbus_test.rb
@@ -50,8 +50,8 @@ describe Agama::DBus::Storage::ProposalSettingsConversion::ToDBus do
         "LVM"                    => false,
         "SystemVGDevices"        => [],
         "EncryptionPassword"     => "",
-        "EncryptionMethod"       => "luks1",
-        "EncryptionPBKDFunction" => "",
+        "EncryptionMethod"       => "luks2",
+        "EncryptionPBKDFunction" => "pbkdf2",
         "SpacePolicy"            => "keep",
         "SpaceActions"           => {},
         "Volumes"                => []

--- a/service/test/agama/storage/proposal_settings_reader_test.rb
+++ b/service/test/agama/storage/proposal_settings_reader_test.rb
@@ -99,8 +99,8 @@ describe Agama::Storage::ProposalSettingsReader do
           ),
           encryption:  an_object_having_attributes(
             password:      nil,
-            method:        Y2Storage::EncryptionMethod::LUKS1,
-            pbkd_function: nil
+            method:        Y2Storage::EncryptionMethod::LUKS2,
+            pbkd_function: Y2Storage::PbkdFunction::PBKDF2
           ),
           space:       an_object_having_attributes(
             policy:  :keep,
@@ -127,13 +127,13 @@ describe Agama::Storage::ProposalSettingsReader do
 
         expect(settings).to have_attributes(
           encryption: an_object_having_attributes(
-            method: Y2Storage::EncryptionMethod::LUKS1
+            method: Y2Storage::EncryptionMethod::LUKS2
           )
         )
       end
     end
 
-    context "when the config contains an unknown encryption function" do
+    context "when the config contains an unknown password derivation function" do
       let(:config_data) do
         {
           "storage" => {
@@ -144,12 +144,12 @@ describe Agama::Storage::ProposalSettingsReader do
         }
       end
 
-      it "does not set a PBKD function" do
+      it "sets the default derivation function" do
         settings = subject.read
 
         expect(settings).to have_attributes(
           encryption: an_object_having_attributes(
-            pbkd_function: be_nil
+            pbkd_function: Y2Storage::PbkdFunction::PBKDF2
           )
         )
       end

--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jan 18 08:33:52 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Make TPM-based encryption more explicit (gh#openSUSE/agama#995)
+
+-------------------------------------------------------------------
 Tue Jan 16 15:27:28 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Fix error with storage issues proxy by anticipating its creation

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -430,3 +430,8 @@ ul[data-of="agama/timezones"] {
     }
   }
 }
+
+.tpm-hint {
+  grid-template-columns: minmax(100%, 70cqw);
+  text-align: start;
+}

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -432,6 +432,15 @@ ul[data-of="agama/timezones"] {
 }
 
 .tpm-hint {
-  grid-template-columns: minmax(100%, 70cqw);
+  container-type: inline-size;
+  container-name: tpm-info;
   text-align: start;
+
+  .pf-v5-c-alert__title {
+    margin-block-end: var(--spacer-small);
+  }
+
+  .pf-v5-c-alert__description {
+    max-inline-size: 100%;
+  }
 }

--- a/web/src/assets/styles/layout.scss
+++ b/web/src/assets/styles/layout.scss
@@ -55,6 +55,8 @@
     grid-area: body;
     overflow: auto;
     padding-block: var(--spacer-normal);
+    container-type: inline-size;
+    container-name: agama-page-content;
   }
 
   footer {

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022-2023] SUSE LLC
+ * Copyright (c) [2022-2024] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -45,6 +45,17 @@ const ZFCP_CONTROLLERS_NAMESPACE = "/org/opensuse/Agama/Storage1/zfcp_controller
 const ZFCP_CONTROLLER_IFACE = "org.opensuse.Agama.Storage1.ZFCP.Controller";
 const ZFCP_DISKS_NAMESPACE = "/org/opensuse/Agama/Storage1/zfcp_disks";
 const ZFCP_DISK_IFACE = "org.opensuse.Agama.Storage1.ZFCP.Disk";
+
+/**
+ * Enum for the encryption method values
+ *
+ * @readonly
+ * @enum { string }
+ */
+const EncryptionMethods = Object.freeze({
+  LUKS2: "luks2",
+  TPM: "tpm_fde"
+});
 
 /**
  * Removes properties with undefined value
@@ -1433,4 +1444,4 @@ class StorageClient extends WithIssues(
   ), STORAGE_OBJECT
 ) { }
 
-export { StorageClient };
+export { StorageClient, EncryptionMethods };

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -227,6 +227,7 @@ class ProposalManager {
    * @typedef {object} ProposalSettings
    * @property {string} bootDevice
    * @property {string} encryptionPassword
+   * @property {string} encryptionMethod
    * @property {boolean} lvm
    * @property {string} spacePolicy
    * @property {string[]} systemVGDevices
@@ -281,6 +282,16 @@ class ProposalManager {
   async getProductMountPoints() {
     const proxy = await this.proxies.proposalCalculator;
     return proxy.ProductMountPoints;
+  }
+
+  /**
+   * Gets the list of encryption methods accepted by the proposal
+   *
+   * @returns {Promise<string[]>}
+   */
+  async getEncryptionMethods() {
+    const proxy = await this.proxies.proposalCalculator;
+    return proxy.EncryptionMethods;
   }
 
   /**
@@ -345,6 +356,7 @@ class ProposalManager {
           spacePolicy: proxy.SpacePolicy,
           systemVGDevices: proxy.SystemVGDevices,
           encryptionPassword: proxy.EncryptionPassword,
+          encryptionMethod: proxy.EncryptionMethod,
           volumes: proxy.Volumes.map(this.buildVolume),
           // NOTE: strictly speaking, installation devices does not belong to the settings. It
           // should be a separate method instead of an attribute in the settings object.
@@ -365,7 +377,7 @@ class ProposalManager {
    * @param {ProposalSettings} settings
    * @returns {Promise<number>} 0 on success, 1 on failure
    */
-  async calculate({ bootDevice, encryptionPassword, lvm, spacePolicy, systemVGDevices, volumes }) {
+  async calculate({ bootDevice, encryptionPassword, encryptionMethod, lvm, spacePolicy, systemVGDevices, volumes }) {
     const dbusVolume = (volume) => {
       return removeUndefinedCockpitProperties({
         MountPath: { t: "s", v: volume.mountPath },
@@ -381,6 +393,7 @@ class ProposalManager {
     const settings = removeUndefinedCockpitProperties({
       BootDevice: { t: "s", v: bootDevice },
       EncryptionPassword: { t: "s", v: encryptionPassword },
+      EncryptionMethod: { t: "s", v: encryptionMethod },
       LVM: { t: "b", v: lvm },
       SpacePolicy: { t: "s", v: spacePolicy },
       SystemVGDevices: { t: "as", v: systemVGDevices },

--- a/web/src/components/core/InstallationFinished.jsx
+++ b/web/src/components/core/InstallationFinished.jsx
@@ -21,14 +21,13 @@
 
 import React, { useState, useEffect } from "react";
 import {
+  Alert,
   Text,
   EmptyState,
   EmptyStateBody,
   EmptyStateHeader,
   EmptyStateIcon,
   ExpandableSection,
-  Hint,
-  HintBody,
 } from "@patternfly/react-core";
 
 import { If, Page } from "~/components/core";
@@ -39,25 +38,26 @@ import { _ } from "~/i18n";
 
 const TpmHint = () => {
   const [isExpanded, setIsExpanded] = useState(false);
+  const title = _("TPM sealing requires the new system to be booted directly.");
 
   return (
-    <Hint className="tpm-hint">
-      <HintBody>
+    <Alert isInline variant="info" className="tpm-hint" title={<strong>{title}</strong>}>
+      <div className="stack">
+        {_("If a local media was used to run this installer, remove it before the next boot.")}
         <ExpandableSection
           isExpanded={isExpanded}
           onToggle={() => setIsExpanded(!isExpanded)}
-          toggleText={
-            <strong>
-              {_("Make sure to boot directly to the new system to finish the configuration of TPM-based decryption.")}
-            </strong>
-          }
+          toggleText={isExpanded ? _("Hide details") : _("See more details")}
         >
-          <Text>
-            {_("The final step to configure the TPM to automatically open devices will take place during the first boot of the new system. For that to work, the machine needs to boot directly to the new boot loader. If a local media was used to run this installer, make sure is removed before next boot.")}
-          </Text>
+          <Text
+            dangerouslySetInnerHTML={{
+              // TRANSLATORS: Do not translate 'abbr' and 'title', they are part of the HTML markup
+              __html: _("The final step to configure the <abbr title='Trusted Platform Module'>TPM</abbr> to automatically open encrypted devices will take place during the first boot of the new system. For that to work, the machine needs to boot directly to the new boot loader.")
+            }}
+          />
         </ExpandableSection>
-      </HintBody>
-    </Hint>
+      </div>
+    </Alert>
   );
 };
 

--- a/web/src/components/core/InstallationFinished.test.jsx
+++ b/web/src/components/core/InstallationFinished.test.jsx
@@ -32,6 +32,8 @@ jest.mock("~/components/core/Sidebar", () => () => <div>Agama sidebar</div>);
 
 const finishInstallationFn = jest.fn();
 
+const storageSettings = { encryptionMethod: "luks2" };
+
 describe("InstallationFinished", () => {
   beforeEach(() => {
     createClient.mockImplementation(() => {
@@ -39,7 +41,8 @@ describe("InstallationFinished", () => {
         manager: {
           finishInstallation: finishInstallationFn,
           useIguana: () => Promise.resolve(false)
-        }
+        },
+        storage: { proposal: { getResult: jest.fn().mockResolvedValue({ settings: storageSettings }) } }
       };
     });
   });

--- a/web/src/components/core/InstallationFinished.test.jsx
+++ b/web/src/components/core/InstallationFinished.test.jsx
@@ -31,18 +31,22 @@ jest.mock("~/client");
 jest.mock("~/components/core/Sidebar", () => () => <div>Agama sidebar</div>);
 
 const finishInstallationFn = jest.fn();
-
-const storageSettings = { encryptionMethod: "luks2" };
+let encryptionMethod;
 
 describe("InstallationFinished", () => {
   beforeEach(() => {
+    encryptionMethod = "luks2";
     createClient.mockImplementation(() => {
       return {
         manager: {
           finishInstallation: finishInstallationFn,
           useIguana: () => Promise.resolve(false)
         },
-        storage: { proposal: { getResult: jest.fn().mockResolvedValue({ settings: storageSettings }) } }
+        storage: {
+          proposal: {
+            getResult: jest.fn().mockResolvedValue({ settings: { encryptionMethod } })
+          },
+        }
       };
     });
   });
@@ -62,5 +66,23 @@ describe("InstallationFinished", () => {
     const rebootButton = screen.getByRole("button", { name: /Reboot/i });
     await user.click(rebootButton);
     expect(finishInstallationFn).toHaveBeenCalled();
+  });
+
+  describe("when TPM was set to decrypt automatically on each boot", () => {
+    beforeEach(() => {
+      encryptionMethod = "tpm_fde";
+    });
+
+    it("shows the TPM reminder", async () => {
+      installerRender(<InstallationFinished />);
+      await screen.findAllByText(/TPM/);
+    });
+  });
+
+  describe("when TPM was not set to decrypt automatically on each boot", () => {
+    it("does not show the TPM reminder", () => {
+      installerRender(<InstallationFinished />);
+      expect(screen.queryByText(/TPM/)).toBeNull();
+    });
   });
 });

--- a/web/src/components/overview/StorageSection.test.jsx
+++ b/web/src/components/overview/StorageSection.test.jsx
@@ -35,6 +35,8 @@ const availableDevices = [
   { name: "/dev/sdb", size: 697932185600 }
 ];
 
+const encryptionMethods = ["luks2", "tpm_fde"];
+
 const proposalResult = {
   settings: {
     bootDevice: "/dev/sda",
@@ -48,6 +50,7 @@ const storageMock = {
   probe: jest.fn().mockResolvedValue(0),
   proposal: {
     getAvailableDevices: jest.fn().mockResolvedValue(availableDevices),
+    getEncryptionMethods: jest.fn().mockResolvedValue(encryptionMethods),
     getResult: jest.fn().mockResolvedValue(proposalResult),
     calculate: jest.fn().mockResolvedValue(0)
   },

--- a/web/src/components/storage/ProposalPage.jsx
+++ b/web/src/components/storage/ProposalPage.jsx
@@ -34,6 +34,7 @@ const initialState = {
   loading: true,
   availableDevices: [],
   volumeTemplates: [],
+  encryptionMethods: [],
   settings: {},
   actions: [],
   errors: []

--- a/web/src/components/storage/ProposalPage.jsx
+++ b/web/src/components/storage/ProposalPage.jsx
@@ -54,6 +54,11 @@ const reducer = (state, action) => {
       return { ...state, availableDevices };
     }
 
+    case "UPDATE_ENCRYPTION_METHODS": {
+      const { encryptionMethods } = action.payload;
+      return { ...state, encryptionMethods };
+    }
+
     case "UPDATE_VOLUME_TEMPLATES": {
       const { volumeTemplates } = action.payload;
       return { ...state, volumeTemplates };
@@ -87,6 +92,10 @@ export default function ProposalPage() {
 
   const loadAvailableDevices = useCallback(async () => {
     return await cancellablePromise(client.proposal.getAvailableDevices());
+  }, [client, cancellablePromise]);
+
+  const loadEncryptionMethods = useCallback(async () => {
+    return await cancellablePromise(client.proposal.getEncryptionMethods());
   }, [client, cancellablePromise]);
 
   const loadVolumeTemplates = useCallback(async () => {
@@ -127,6 +136,9 @@ export default function ProposalPage() {
     const availableDevices = await loadAvailableDevices();
     dispatch({ type: "UPDATE_AVAILABLE_DEVICES", payload: { availableDevices } });
 
+    const encryptionMethods = await loadEncryptionMethods();
+    dispatch({ type: "UPDATE_ENCRYPTION_METHODS", payload: { encryptionMethods } });
+
     const volumeTemplates = await loadVolumeTemplates();
     dispatch({ type: "UPDATE_VOLUME_TEMPLATES", payload: { volumeTemplates } });
 
@@ -137,7 +149,7 @@ export default function ProposalPage() {
     dispatch({ type: "UPDATE_ERRORS", payload: { errors } });
 
     if (result !== undefined) dispatch({ type: "STOP_LOADING" });
-  }, [calculateProposal, cancellablePromise, client, loadAvailableDevices, loadErrors, loadProposalResult, loadVolumeTemplates]);
+  }, [calculateProposal, cancellablePromise, client, loadAvailableDevices, loadEncryptionMethods, loadErrors, loadProposalResult, loadVolumeTemplates]);
 
   const calculate = useCallback(async (settings) => {
     dispatch({ type: "START_LOADING" });
@@ -200,6 +212,7 @@ export default function ProposalPage() {
         <ProposalSettingsSection
           availableDevices={state.availableDevices}
           volumeTemplates={usefulTemplates()}
+          encryptionMethods={state.encryptionMethods}
           settings={state.settings}
           onChange={changeSettings}
           isLoading={state.loading}

--- a/web/src/components/storage/ProposalPage.test.jsx
+++ b/web/src/components/storage/ProposalPage.test.jsx
@@ -43,6 +43,7 @@ const storageMock = {
   probe: jest.fn().mockResolvedValue(0),
   proposal: {
     getAvailableDevices: jest.fn().mockResolvedValue([]),
+    getEncryptionMethods: jest.fn().mockResolvedValue([]),
     getProductMountPoints: jest.fn().mockResolvedValue([]),
     getResult: jest.fn().mockResolvedValue(undefined),
     defaultVolume: jest.fn(mountPath => Promise.resolve({ mountPath })),

--- a/web/src/components/storage/ProposalSettingsSection.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.jsx
@@ -428,6 +428,8 @@ const EncryptionSettingsForm = ({
             id="encryption_method"
             label={_("Use the TPM to decrypt automatically on each boot")}
             description={
+              // TRANSLATORS: The word 'directly' is key here. For example, booting to the installer media and then choosing
+              // 'Boot from Hard Disk' from there will not work. Keep it sort (this is a hint in a form) but keep it clear.
               _("If this option is enabled, make sure to boot directly the new system after installation. Remove this installation media if needed.")
             }
             isChecked={method === tpmId}

--- a/web/src/components/storage/ProposalSettingsSection.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.jsx
@@ -413,6 +413,17 @@ const EncryptionSettingsForm = ({
     onSubmit(password, method);
   };
 
+  const Description = () => (
+    <span
+      dangerouslySetInnerHTML={{
+        // TRANSLATORS: The word 'directly' is key here. For example, booting to the installer media and then choosing
+        // 'Boot from Hard Disk' from there will not work. Keep it sort (this is a hint in a form) but keep it clear.
+        // Do not translate 'abbr' and 'title', they are part of the HTML markup.
+        __html: _("The password will not be needed to boot and access the data if the <abbr title='Trusted Platform Module'>TPM</abbr> can verify the integrity of the system. TPM sealing requires the new system to be booted directly on its first run.")
+      }}
+    />
+  );
+
   return (
     <Form id={id} onSubmit={submitForm}>
       <PasswordAndConfirmationInput
@@ -427,11 +438,7 @@ const EncryptionSettingsForm = ({
           <Checkbox
             id="encryption_method"
             label={_("Use the TPM to decrypt automatically on each boot")}
-            description={
-              // TRANSLATORS: The word 'directly' is key here. For example, booting to the installer media and then choosing
-              // 'Boot from Hard Disk' from there will not work. Keep it sort (this is a hint in a form) but keep it clear.
-              _("If this option is enabled, make sure to boot directly the new system after installation. Remove this installation media if needed.")
-            }
+            description={<Description />}
             isChecked={method === tpmId}
             onChange={changeMethod}
           />

--- a/web/src/components/storage/ProposalSettingsSection.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.jsx
@@ -385,13 +385,18 @@ created in a logical volume of the system volume group.");
  * @callback onValidateFn
  * @param {boolean} valid
  */
-const EncryptionPasswordForm = ({
+const EncryptionSettingsForm = ({
   id,
   password: passwordProp,
+  method: methodProp,
+  methods,
   onSubmit = noop,
   onValidate = noop
 }) => {
   const [password, setPassword] = useState(passwordProp || "");
+  const [method, setMethod] = useState(methodProp);
+  const tpmId = "tpm_fde";
+  const luks2Id = "luks2";
 
   useEffect(() => {
     if (password.length === 0) onValidate(false);
@@ -399,9 +404,13 @@ const EncryptionPasswordForm = ({
 
   const changePassword = (_, v) => setPassword(v);
 
+  const changeMethod = (_, value) => {
+    value ? setMethod(tpmId) : setMethod(luks2Id);
+  };
+
   const submitForm = (e) => {
     e.preventDefault();
-    onSubmit(password);
+    onSubmit(password, method);
   };
 
   return (
@@ -412,16 +421,29 @@ const EncryptionPasswordForm = ({
         onChange={changePassword}
         onValidation={onValidate}
       />
+      <If
+        condition={methods.includes(tpmId)}
+        then={
+          <Switch
+            id="encryption_method"
+            label={_("Use the TPM to decrypt automatically on each boot")}
+            isReversed
+            isChecked={method === tpmId}
+            onChange={changeMethod}
+          />
+        }
+      />
     </Form>
   );
 };
 
 /**
- * Allows to selected encryption
+ * Allows to define encryption
  * @component
  *
  * @param {object} props
  * @param {string} [props.password=""] - Password for encryption
+ * @param {string} [props.method=""] - Encryption method
  * @param {boolean} [props.isChecked=false] - Whether encryption is selected
  * @param {boolean} [props.isLoading=false] - Whether to show the selector as loading
  * @param {onChangeFn} [props.onChange=noop] - On change callback
@@ -429,14 +451,17 @@ const EncryptionPasswordForm = ({
  * @callback onChangeFn
  * @param {object} settings
  */
-const EncryptionPasswordField = ({
+const EncryptionField = ({
   password: passwordProp = "",
+  method: methodProp = "",
+  methods,
   isChecked: isCheckedProp = false,
   isLoading = false,
   onChange = noop
 }) => {
   const [isChecked, setIsChecked] = useState(isCheckedProp);
   const [password, setPassword] = useState(passwordProp);
+  const [method, setMethod] = useState(methodProp);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isFormValid, setIsFormValid] = useState(true);
 
@@ -444,10 +469,11 @@ const EncryptionPasswordField = ({
 
   const closeForm = () => setIsFormOpen(false);
 
-  const acceptForm = (newPassword) => {
+  const acceptForm = (newPassword, newMethod) => {
     closeForm();
     setPassword(newPassword);
-    onChange({ isChecked, password: newPassword });
+    setMethod(newMethod);
+    onChange({ isChecked, password: newPassword, method: newMethod });
   };
 
   const cancelForm = () => {
@@ -468,10 +494,10 @@ const EncryptionPasswordField = ({
     }
   };
 
-  const ChangePasswordButton = () => {
+  const ChangeSettingsButton = () => {
     return (
       <Tooltip
-        content={_("Change encryption password")}
+        content={_("Change encryption settings")}
         entryDelay={400}
         exitDelay={50}
         position="right"
@@ -495,17 +521,19 @@ const EncryptionPasswordField = ({
           isChecked={isChecked}
           onChange={changeSelected}
         />
-        { isChecked && <ChangePasswordButton /> }
+        { isChecked && <ChangeSettingsButton /> }
       </div>
       <Popup aria-label={_("Encryption settings")} title={_("Encryption settings")} isOpen={isFormOpen}>
-        <EncryptionPasswordForm
-          id="encryptionPasswordForm"
+        <EncryptionSettingsForm
+          id="encryptionSettingsForm"
           password={password}
+          method={method}
+          methods={methods}
           onSubmit={acceptForm}
           onValidate={validateForm}
         />
         <Popup.Actions>
-          <Popup.Confirm form="encryptionPasswordForm" type="submit" isDisabled={!isFormValid}>{_("Accept")}</Popup.Confirm>
+          <Popup.Confirm form="encryptionSettingsForm" type="submit" isDisabled={!isFormValid}>{_("Accept")}</Popup.Confirm>
           <Popup.Cancel onClick={cancelForm} />
         </Popup.Actions>
       </Popup>
@@ -618,6 +646,7 @@ const SpacePolicyField = ({
  * @param {ProposalSettings} props.settings
  * @param {StorageDevice[]} [props.availableDevices=[]]
  * @param {Volume[]} [props.volumeTemplates=[]]
+ * @param {String[]} [props.encryptionMethods=[]]
  * @param {boolean} [isLoading=false]
  * @param {onChangeFn} [props.onChange=noop]
  *
@@ -628,6 +657,7 @@ export default function ProposalSettingsSection({
   settings,
   availableDevices = [],
   volumeTemplates = [],
+  encryptionMethods = [],
   isLoading = false,
   onChange = noop
 }) {
@@ -643,8 +673,8 @@ export default function ProposalSettingsSection({
     onChange(settings);
   };
 
-  const changeEncryption = ({ password }) => {
-    onChange({ encryptionPassword: password });
+  const changeEncryption = ({ password, method }) => {
+    onChange({ encryptionPassword: password, encryptionMethod: method });
   };
 
   const changeSpacePolicy = (policy) => {
@@ -673,8 +703,10 @@ export default function ProposalSettingsSection({
         isLoading={settings.lvm === undefined}
         onChange={changeLVM}
       />
-      <EncryptionPasswordField
+      <EncryptionField
         password={settings.encryptionPassword || ""}
+        method={settings.encryptionMethod}
+        methods={encryptionMethods}
         isChecked={encryption}
         isLoading={settings.encryptionPassword === undefined}
         onChange={changeEncryption}

--- a/web/src/components/storage/ProposalSettingsSection.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.jsx
@@ -22,7 +22,7 @@
 import React, { useEffect, useState } from "react";
 import {
   Button,
-  Form, Skeleton, Switch,
+  Form, Skeleton, Switch, Checkbox,
   ToggleGroup, ToggleGroupItem,
   Tooltip
 } from "@patternfly/react-core";
@@ -424,10 +424,12 @@ const EncryptionSettingsForm = ({
       <If
         condition={methods.includes(tpmId)}
         then={
-          <Switch
+          <Checkbox
             id="encryption_method"
             label={_("Use the TPM to decrypt automatically on each boot")}
-            isReversed
+            description={
+              _("If this option is enabled, make sure to boot directly the new system after installation. Remove this installation media if needed.")
+            }
             isChecked={method === tpmId}
             onChange={changeMethod}
           />


### PR DESCRIPTION
## Problem

Sometimes, Agama decides to use the encryption method `TPM_FDE` which results in the system being configured via `fde-tools` to open the encryption devices automatically during system boot without needing to enter the password.

That happens if the configuration parameter `encryption.tpm_luks_open` is set AND the system supports TPM unlocking. If that the case, the `TPM_FDE` encryption method is used without even asking the user. In any other case, the encryption method specified at the configuration parameter `encryption.method` is used.

That's all quite obscure, the users don't know whether TPM-based unlocking is going to be configured. Not even if it's possible to configure it or not.

## Solution

This pull request introduces some changes in how the whole thing is managed.

Now if the system or the distribution being installed don't support TPM-based decryption, the encryption method `LUKS2` is used and nothing is shown in the UI.

![tpm_not_available](https://github.com/openSUSE/agama/assets/3638289/f53925cf-8101-4b13-a1ba-e19b6d78907d)

So no big change for the user except the fact that now LUKS2 with PBKDF2 as derivation function is the default for all distributions (it's a pretty sensible default for distributions based on Grub2 at 2024).

But if the system and the distribution both support to configure TPM-based opening of the LUKS devices, the user can choose between the `TPM_FDE` and the  `LUKS2` encryption methods via a checkbox shown in the UI.

![attempt](https://github.com/openSUSE/agama/assets/3638289/ed539bbb-08f8-4761-9834-c3fa05c6b27f)

The default encryption method (and thus, the default value of the checkbox) is configured per-product at `encryption.method`. If the value there is `"tpm_fde"` but the system does not support such a method (eg. there is no TPMv2 chip), Agama will use the default encryption method (`LUKS2`) as fallback.

Additionally, to make sure the user does not overlook the need to boot the machine directly to the new system in order to complete the setup, the following warning has been added to the page at the end of the installation process.

![finish-tpm-b2](https://github.com/openSUSE/agama/assets/3638289/a410242d-7680-4108-a6f7-013dca905259)

Expanded version:

![finish-tpm-a2](https://github.com/openSUSE/agama/assets/3638289/82b2d1a4-0f2b-4e39-b899-b47e96a4ea57)

Of course, if TPM encryption was not used, the hint is not there.

![finish-no-tpm2](https://github.com/openSUSE/agama/assets/3638289/de385977-08ee-4d3f-b3df-22548a45ebdf)

## Testing

- Tested manually
- New unit tests for the `InstallationFinished` page
- No tests added to the storage page, since it's going to [heavily change](https://github.com/openSUSE/agama/discussions/982) soon
