### PR TITLE
Preserve network configuration provided via kernel boot line

### DIFF
--- a/service/lib/agama/network.rb
+++ b/service/lib/agama/network.rb
@@ -52,6 +52,7 @@ module Agama
     attr_reader :logger
 
     ETC_NM_DIR = "/etc/NetworkManager"
+    RUN_NM_DIR = "/run/NetworkManager"
     private_constant :ETC_NM_DIR
 
     def enable_service
@@ -67,6 +68,13 @@ module Agama
     # Copies NetworkManager configuration files
     def copy_files
       return unless Dir.exist?(ETC_NM_DIR)
+
+      # runtime configuration is copied first, so in case of later modification
+      # on same interface it gets overwriten.
+      copy_directory(
+        File.join(RUN_NM_DIR, "system-connections"),
+        File.join(Yast::Installation.destdir, ETC_NM_DIR, "system-connections")
+      )
 
       copy_directory(
         File.join(ETC_NM_DIR, "system-connections"),

--- a/service/lib/agama/network.rb
+++ b/service/lib/agama/network.rb
@@ -70,7 +70,7 @@ module Agama
       return unless Dir.exist?(ETC_NM_DIR)
 
       # runtime configuration is copied first, so in case of later modification
-      # on same interface it gets overwriten.
+      # on same interface it gets overwriten (bsc#1210541).
       copy_directory(
         File.join(RUN_NM_DIR, "system-connections"),
         File.join(Yast::Installation.destdir, ETC_NM_DIR, "system-connections")

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan 16 10:49:14 UTC 2024 - Michal Filka <mfilka@suse.com>
+
+- bsc#1210541, gh#openSUSE/agama#516
+  - copy NM's runtime config created on dracut's request to the target 
+-------------------------------------------------------------------
 Thu Jan 11 15:32:44 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Handle the encoding included in the UILocale D-Bus property


### PR DESCRIPTION
## Problem

Network configuration provided by kernel boot line is lost

- [*bsc1210541*](https://bugzilla.suse.com/show_bug.cgi?id=1210541)


## Solution

Even NM's runtime configuration is copied to the target at the end of installation


## Testing

- *Tested manually*

