### PR TITLE
Do not crash when cannot get the list of issues

### DIFF
--- a/web/src/client/mixins.js
+++ b/web/src/client/mixins.js
@@ -82,7 +82,12 @@ const WithIssues = (superclass, object_path) => class extends superclass {
    */
   async getIssues() {
     const proxy = await this.client.proxy(ISSUES_IFACE, object_path);
-    return proxy.All.map(buildIssue);
+    try {
+      return proxy.All.map(buildIssue);
+    } catch (e) {
+      console.log(`Could not get the list of issues: ${e}`);
+      return [];
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

See #1001.

## Solution

Do not crash even if it is impossible to get the list of issues. It does not fix the root of the problem, but prevents the crashing.

## Testing

- Tested manually
