### PR TITLE
Package availability

### DIFF
--- a/doc/dbus/bus/org.opensuse.Agama.Software1.bus.xml
+++ b/doc/dbus/bus/org.opensuse.Agama.Software1.bus.xml
@@ -53,6 +53,10 @@
       <arg name="Name" direction="in" type="s"/>
       <arg name="Result" direction="out" type="b"/>
     </method>
+    <method name="IsPackageAvailable">
+      <arg name="name" direction="in" type="s"/>
+      <arg name="result" direction="out" type="b"/>
+    </method>
     <method name="UsedDiskSpace">
       <arg name="SpaceSize" direction="out" type="s"/>
     </method>

--- a/doc/dbus/org.opensuse.Agama.Software1.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Software1.doc.xml
@@ -75,6 +75,16 @@
       <arg name="Name" direction="in" type="s"/>
       <arg name="Result" direction="out" type="b"/>
     </method>
+    <!--
+      Whether a package is available for installation.
+    -->
+    <method name="IsPackageAvailable">
+      <!--
+        Name of the package.
+      -->
+      <arg name="name" direction="in" type="s"/>
+      <arg name="result" direction="out" type="b"/>
+    </method>
     <method name="UsedDiskSpace">
       <arg name="SpaceSize" direction="out" type="s"/>
     </method>

--- a/service/lib/agama/dbus/clients/software.rb
+++ b/service/lib/agama/dbus/clients/software.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022-2023] SUSE LLC
+# Copyright (c) [2022-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -114,11 +114,20 @@ module Agama
           dbus_object.ProvisionsSelected(tags)
         end
 
-        # Determines whether a package with the given name is installed
+        # Determines whether a package is installed.
         #
-        # @param name [String] Package name
+        # @param name [String] Package name.
+        # @return [Boolean]
         def package_installed?(name)
           dbus_object.IsPackageInstalled(name)
+        end
+
+        # Determines whether a package is available.
+        #
+        # @param name [String] Package name.
+        # @return [Boolean]
+        def package_available?(name)
+          dbus_object.IsPackageAvailable(name)
         end
 
         # Add the given list of resolvables to the packages proposal

--- a/service/lib/agama/dbus/software/manager.rb
+++ b/service/lib/agama/dbus/software/manager.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022-2023] SUSE LLC
+# Copyright (c) [2022-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -97,6 +97,10 @@ module Agama
 
           dbus_method :IsPackageInstalled, "in Name:s, out Result:b" do |name|
             backend.package_installed?(name)
+          end
+
+          dbus_method :IsPackageAvailable, "in name:s, out result:b" do |name|
+            backend.package_available?(name)
           end
 
           dbus_method(:UsedDiskSpace, "out SpaceSize:s") { backend.used_disk_space }

--- a/service/lib/agama/dbus/y2dir/README.md
+++ b/service/lib/agama/dbus/y2dir/README.md
@@ -1,1 +1,28 @@
-Override directory to redirect some yast modules to use D-Bus methods. It is just temporary workaround for POC.
+This directory contains some redefinitions of YaST modules in order to call to D-Bus methods instead
+of executing the actual code of the module.
+
+# Why is this needed?
+
+Agama relies on YaST code and YaST usually works as a single process. By contrast, Agama works as a
+set of different processes (software service, storage service, etc), and each service runs its own
+YaST instance.
+
+Having different YaST instances implies that the information is scattered in different processes.
+For example, only the YaST instance in the software service has the information about the software
+configuration. This means that other YaST instances need to ask to the software YaST instance for
+the information.
+
+# How to communicate among YaST instances
+
+A YaST instance can get information from other instance by doing a D-Bus call to the service running
+such an instance. For example, the YaST instance in the storage service has to call to the D-Bus API
+of the software service instead of directly calling to the software module code. To achieve that,
+the storage service replaces the implementation of the YaST software module by its own
+implementation which uses D-Bus calls.
+
+# How to replace a YaST module
+
+The code replacement of the YaST modules is done by means of the *Y2DIR* mechanism of YaST. When a
+service is started (check *agamactl* script), the YaST modules redefined by the service (under
+*lib/agama/dbus/y2dir/*) are added to the *Y2DIR* environment variable. YaST takes precedence of the
+paths at *Y2DIR*, so these files will be loaded instead of the files originally delivered by YaST.

--- a/service/lib/agama/dbus/y2dir/manager/modules/Package.rb
+++ b/service/lib/agama/dbus/y2dir/manager/modules/Package.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2022] SUSE LLC
+# Copyright (c) [2022-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,36 +22,35 @@ require "agama/dbus/clients/software"
 
 # :nodoc:
 module Yast
-  # Replacement for the Yast::Package module
-  #
-  # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/packages/src/modules/Package.rb
+  # Replacement for the Yast::Package module.
   class PackageClass < Module
     def main
       puts "Loading mocked module #{__FILE__}"
       @client = Agama::DBus::Clients::Software.new
     end
 
-    # Determines whether the package is available
+    # Determines whether a package is available.
     #
-    # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/packages/src/modules/Package.rb#L72
-    # @todo Perform a real D-Bus call.
-    def Available(_package_name)
-      true
+    # @param name [String] Package name.
+    # @return [Boolean]
+    def Available(name)
+      client.package_available?(name)
     end
 
-    # Determines whether the package is available
+    # Determines whether a set of packages is available.
     #
-    # @todo Perform a real D-Bus call.
-    def AvailableAll(_package_names)
-      true
+    # @param names [Array<String>] Names of the packages.
+    # @return [Boolean]
+    def AvailableAll(names)
+      names.all? { |name| client.package_available?(name) }
     end
 
-    # Determines whether the package is available
+    # Determines whether a package is installed in the target system.
     #
-    # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/packages/src/modules/Package.rb#L121
-    # @todo Perform a real D-Bus call.
-    def Installed(package_name, target: nil)
-      client.package_installed?(package_name)
+    # @param name [String] Package name.
+    # @return [Boolean]
+    def Installed(name, target: nil)
+      client.package_installed?(name)
     end
 
   private

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2021-2023] SUSE LLC
+# Copyright (c) [2021-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -279,12 +279,21 @@ module Agama
         @selected_patterns_change_callbacks << block
       end
 
-      # Determines whether a package is installed
+      # Determines whether a package is installed in the target system.
       #
       # @param name [String] Package name
       # @return [Boolean] true if it is installed; false otherwise
       def package_installed?(name)
         on_target { Yast::Package.Installed(name, target: :system) }
+      end
+
+      # Determines whether a package is available.
+      #
+      # @param name [String] Package name
+      # @return [Boolean]
+      def package_available?(name)
+        # Beware: apart from true and false, Available can return nil if things go wrong.
+        on_local { !!Yast::Package.Available(name) }
       end
 
       # Counts how much disk space installation will use.

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 18 14:55:36 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Add support to check availability of a package
+  (gh#openSUSE/agama#1004).
+
+-------------------------------------------------------------------
 Thu Jan 18 08:35:01 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - New default encryption settings: LUKS2 with PBKDF2.

--- a/service/test/agama/dbus/clients/software_test.rb
+++ b/service/test/agama/dbus/clients/software_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022-2023] SUSE LLC
+# Copyright (c) [2022-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -160,6 +160,30 @@ describe Agama::DBus::Clients::Software do
 
       it "returns false" do
         expect(subject.package_installed?(package)).to eq(false)
+      end
+    end
+  end
+
+  describe "#package_available?" do
+    let(:dbus_object) do
+      double(::DBus::ProxyObject, introspect: nil, IsPackageAvailable: available)
+    end
+
+    let(:package) { "NetworkManager" }
+
+    context "when the package is available" do
+      let(:available) { true }
+
+      it "returns true" do
+        expect(subject.package_available?(package)).to eq(true)
+      end
+    end
+
+    context "when the package is available" do
+      let(:available) { false }
+
+      it "returns false" do
+        expect(subject.package_available?(package)).to eq(false)
       end
     end
   end

--- a/service/test/agama/dbus/software/manager_test.rb
+++ b/service/test/agama/dbus/software/manager_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022-2023] SUSE LLC
+# Copyright (c) [2022-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -133,6 +133,16 @@ describe Agama::DBus::Software::Manager do
         "org.opensuse.Agama.Software1%%IsPackageInstalled", "NetworkManager"
       )
       expect(installed).to eq(true)
+    end
+  end
+
+  describe "D-Bus IsPackageAvailable" do
+    it "returns whether the package is available or not" do
+      expect(backend).to receive(:package_available?).with("NetworkManager").and_return(true)
+      available = subject.public_send(
+        "org.opensuse.Agama.Software1%%IsPackageAvailable", "NetworkManager"
+      )
+      expect(available).to eq(true)
     end
   end
 end

--- a/service/test/agama/software/manager_test.rb
+++ b/service/test/agama/software/manager_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022-2023] SUSE LLC
+# Copyright (c) [2022-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -402,6 +402,38 @@ describe Agama::Software::Manager do
 
       it "returns false" do
         expect(subject.package_installed?(package)).to eq(false)
+      end
+    end
+  end
+
+  describe "#package_available?" do
+    before do
+      allow(Yast::Package).to receive(:Available).with(package).and_return(available)
+    end
+
+    let(:package) { "NetworkManager" }
+
+    context "when the package is available" do
+      let(:available) { true }
+
+      it "returns true" do
+        expect(subject.package_available?(package)).to eq(true)
+      end
+    end
+
+    context "when the package is not available" do
+      let(:available) { false }
+
+      it "returns false" do
+        expect(subject.package_available?(package)).to eq(false)
+      end
+    end
+
+    context "when there is an error checking its availability" do
+      let(:available) { nil }
+
+      it "returns false" do
+        expect(subject.package_available?(package)).to eq(false)
       end
     end
   end


### PR DESCRIPTION
## Problem

The call to the sotware service to check for the availability of a package is mocked and always returns true, assuming the package is always available. Of course, the availability of a package depends of the currently selected product. 

## Solution

Perform a D-Bus call to the software service in order to know if a package is available.

Note: This change exposes a problem in our services. Asking for the product availability should be done once the software proposal is done, otherwise the result is not reliable at all, see https://github.com/openSUSE/agama/issues/1005. For example, the TPM option in the storage settings could not appear until the software service has finished, see https://github.com/openSUSE/agama/pull/995.

## Testing

* Added new unit tests
* Tested manually
