### PR TITLE
[web][doc] Change references to JSDoc

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -81,15 +81,16 @@ switcher is displayed only in local installation because it cannot work in
 remote connection. This option will force displaying it even in a remote
 connection.
 
-## JSDoc Documentation
+## TypeDoc Documentation
 
-This project uses [TypeDoc](https://typedoc.org/) to generate the API documentation. The `jsdoc`
-task generates the documentation to the `jsout.out` directory. If you need to adjust any TypeDoc
-option, please check the `typedocOptions` key in the `tsconfig.js` file.
+This project uses [TypeDoc](https://typedoc.org/) to generate the API documentation. The `typedoc`
+task generates the documentation to the `typedoc.out` directory. If you need to adjust any TypeDoc
+option, please check the [`typedoc.json` file](./typedoc.json).
 
 ```
-npm run jsdoc
-xdg-open jsdoc.out/index.html
+npm run typedoc
+xdg-open typedoc.out/client/index.html
+xdg-open typedoc.out/components/index.html
 ```
 
 GitHub Actions will automatically publish the result to <https://agama-frontend.surge.sh/>.


### PR DESCRIPTION
A few weeks ago, the [documentation output was reworked a bit](https://github.com/openSUSE/agama/pull/976) to be ready for a near future in which all the project documentation could be "managed" by a static site generator. These adjustments implied a few changes that were not reflected in the README file.