### PR TITLE
Add more wireless options to network model

### DIFF
--- a/rust/agama-dbus-server/src/network/error.rs
+++ b/rust/agama-dbus-server/src/network/error.rs
@@ -31,6 +31,8 @@ pub enum NetworkStateError {
     UnexpectedConfiguration,
     #[error("Invalid WEP authentication algorithm: '{0}'")]
     InvalidWEPAuthAlg(String),
+    #[error("Invalid WEP key type: '{0}'")]
+    InvalidWEPKeyType(u32),
 }
 
 impl From<NetworkStateError> for zbus::fdo::Error {

--- a/rust/agama-dbus-server/src/network/error.rs
+++ b/rust/agama-dbus-server/src/network/error.rs
@@ -29,6 +29,8 @@ pub enum NetworkStateError {
     NotControllerConnection(String),
     #[error("Unexpected configuration")]
     UnexpectedConfiguration,
+    #[error("Invalid WEP authentication algorithm: '{0}'")]
+    InvalidWepAuthAlg(String),
 }
 
 impl From<NetworkStateError> for zbus::fdo::Error {

--- a/rust/agama-dbus-server/src/network/error.rs
+++ b/rust/agama-dbus-server/src/network/error.rs
@@ -30,7 +30,7 @@ pub enum NetworkStateError {
     #[error("Unexpected configuration")]
     UnexpectedConfiguration,
     #[error("Invalid WEP authentication algorithm: '{0}'")]
-    InvalidWepAuthAlg(String),
+    InvalidWEPAuthAlg(String),
 }
 
 impl From<NetworkStateError> for zbus::fdo::Error {

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -743,7 +743,7 @@ pub struct WirelessConfig {
     pub band: Option<WirelessBand>,
     pub channel: Option<u32>,
     pub bssid: Option<macaddr::MacAddr6>,
-    pub wep_security: Option<WepSecurity>,
+    pub wep_security: Option<WEPSecurity>,
 }
 
 impl TryFrom<ConnectionConfig> for WirelessConfig {
@@ -842,15 +842,15 @@ impl TryFrom<&str> for SecurityProtocol {
 }
 
 #[derive(Debug, Default, PartialEq, Clone)]
-pub struct WepSecurity {
-    pub auth_alg: WepAuthAlg,
-    pub wep_key_type: WepKeyType,
+pub struct WEPSecurity {
+    pub auth_alg: WEPAuthAlg,
+    pub wep_key_type: WEPKeyType,
     pub keys: Vec<String>,
     pub wep_key_index: u32,
 }
 
 #[derive(Debug, Default, PartialEq, Clone)]
-pub enum WepKeyType {
+pub enum WEPKeyType {
     #[default]
     Unknown = 0,
     Key = 1,
@@ -858,7 +858,7 @@ pub enum WepKeyType {
 }
 
 #[derive(Debug, Default, PartialEq, Clone)]
-pub enum WepAuthAlg {
+pub enum WEPAuthAlg {
     #[default]
     Unset,
     Open,
@@ -866,27 +866,27 @@ pub enum WepAuthAlg {
     Leap,
 }
 
-impl TryFrom<&str> for WepAuthAlg {
+impl TryFrom<&str> for WEPAuthAlg {
     type Error = NetworkStateError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
-            "open" => Ok(WepAuthAlg::Open),
-            "shared" => Ok(WepAuthAlg::Shared),
-            "leap" => Ok(WepAuthAlg::Leap),
-            "" => Ok(WepAuthAlg::Unset),
-            _ => Err(NetworkStateError::InvalidWepAuthAlg(value.to_string())),
+            "open" => Ok(WEPAuthAlg::Open),
+            "shared" => Ok(WEPAuthAlg::Shared),
+            "leap" => Ok(WEPAuthAlg::Leap),
+            "" => Ok(WEPAuthAlg::Unset),
+            _ => Err(NetworkStateError::InvalidWEPAuthAlg(value.to_string())),
         }
     }
 }
 
-impl fmt::Display for WepAuthAlg {
+impl fmt::Display for WEPAuthAlg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match &self {
-            WepAuthAlg::Open => "open",
-            WepAuthAlg::Shared => "shared",
-            WepAuthAlg::Leap => "shared",
-            WepAuthAlg::Unset => "",
+            WEPAuthAlg::Open => "open",
+            WEPAuthAlg::Shared => "shared",
+            WEPAuthAlg::Leap => "shared",
+            WEPAuthAlg::Unset => "",
         };
         write!(f, "{}", name)
     }

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -857,6 +857,19 @@ pub enum WEPKeyType {
     Passphrase = 2,
 }
 
+impl TryFrom<u32> for WEPKeyType {
+    type Error = NetworkStateError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(WEPKeyType::Unknown),
+            1 => Ok(WEPKeyType::Key),
+            2 => Ok(WEPKeyType::Passphrase),
+            _ => Err(NetworkStateError::InvalidWEPKeyType(value)),
+        }
+    }
+}
+
 #[derive(Debug, Default, PartialEq, Clone)]
 pub enum WEPAuthAlg {
     #[default]

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -743,6 +743,7 @@ pub struct WirelessConfig {
     pub band: Option<WirelessBand>,
     pub channel: Option<u32>,
     pub bssid: Option<macaddr::MacAddr6>,
+    pub wep_security: Option<WepSecurity>,
 }
 
 impl TryFrom<ConnectionConfig> for WirelessConfig {
@@ -837,6 +838,57 @@ impl TryFrom<&str> for SecurityProtocol {
                 value.to_string(),
             )),
         }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Clone)]
+pub struct WepSecurity {
+    pub auth_alg: WepAuthAlg,
+    pub wep_key_type: WepKeyType,
+    pub keys: Vec<String>,
+    pub wep_key_index: u32,
+}
+
+#[derive(Debug, Default, PartialEq, Clone)]
+pub enum WepKeyType {
+    #[default]
+    Unknown = 0,
+    Key = 1,
+    Passphrase = 2,
+}
+
+#[derive(Debug, Default, PartialEq, Clone)]
+pub enum WepAuthAlg {
+    #[default]
+    Unset,
+    Open,
+    Shared,
+    Leap,
+}
+
+impl TryFrom<&str> for WepAuthAlg {
+    type Error = NetworkStateError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "open" => Ok(WepAuthAlg::Open),
+            "shared" => Ok(WepAuthAlg::Shared),
+            "leap" => Ok(WepAuthAlg::Leap),
+            "" => Ok(WepAuthAlg::Unset),
+            _ => Err(NetworkStateError::InvalidWepAuthAlg(value.to_string())),
+        }
+    }
+}
+
+impl fmt::Display for WepAuthAlg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match &self {
+            WepAuthAlg::Open => "open",
+            WepAuthAlg::Shared => "shared",
+            WepAuthAlg::Leap => "shared",
+            WepAuthAlg::Unset => "",
+        };
+        write!(f, "{}", name)
     }
 }
 

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -740,6 +740,9 @@ pub struct WirelessConfig {
     pub ssid: SSID,
     pub password: Option<String>,
     pub security: SecurityProtocol,
+    pub band: Option<WirelessBand>,
+    pub channel: Option<u32>,
+    pub bssid: Option<macaddr::MacAddr6>,
 }
 
 impl TryFrom<ConnectionConfig> for WirelessConfig {
@@ -833,6 +836,34 @@ impl TryFrom<&str> for SecurityProtocol {
             _ => Err(NetworkStateError::InvalidSecurityProtocol(
                 value.to_string(),
             )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum WirelessBand {
+    A,  // 5GHz
+    BG, // 2.4GHz
+}
+
+impl fmt::Display for WirelessBand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match &self {
+            WirelessBand::A => "a",
+            WirelessBand::BG => "bg",
+        };
+        write!(f, "{}", value)
+    }
+}
+
+impl TryFrom<&str> for WirelessBand {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "a" => Ok(WirelessBand::A),
+            "bg" => Ok(WirelessBand::BG),
+            _ => Err(anyhow::anyhow!("Invalid band: {}", value)),
         }
     }
 }

--- a/rust/agama-dbus-server/src/network/nm/dbus.rs
+++ b/rust/agama-dbus-server/src/network/nm/dbus.rs
@@ -735,28 +735,28 @@ fn wireless_config_from_dbus(conn: &OwnedNestedHash) -> Option<WirelessConfig> {
             let wep_key_type: u32 = *wep_key_type.downcast_ref()?;
             match wep_key_type {
                 // 0 shouldn't appear because it is treated as empty but just in case
-                0 => WepKeyType::Unknown,
-                1 => WepKeyType::Key,
-                2 => WepKeyType::Passphrase,
+                0 => WEPKeyType::Unknown,
+                1 => WEPKeyType::Key,
+                2 => WEPKeyType::Passphrase,
                 _ => {
                     log::error!("\"wep-key-type\" from NetworkManager not valid");
-                    WepKeyType::default()
+                    WEPKeyType::default()
                 }
             }
         } else {
-            WepKeyType::default()
+            WEPKeyType::default()
         };
         let auth_alg = if let Some(auth_alg) = security.get("auth-alg") {
-            WepAuthAlg::try_from(auth_alg.downcast_ref()?).ok()?
+            WEPAuthAlg::try_from(auth_alg.downcast_ref()?).ok()?
         } else {
-            WepAuthAlg::default()
+            WEPAuthAlg::default()
         };
         let wep_key_index: u32 = if let Some(wep_key_index) = security.get("wep-tx-keyidx") {
             *wep_key_index.downcast_ref()?
         } else {
             0
         };
-        wireless_config.wep_security = Some(WepSecurity {
+        wireless_config.wep_security = Some(WEPSecurity {
             wep_key_type,
             auth_alg,
             wep_key_index,
@@ -1020,7 +1020,7 @@ mod test {
             ("key-mgmt".to_string(), Value::new("wpa-psk").to_owned()),
             (
                 "wep-key-type".to_string(),
-                Value::new(WepKeyType::Key as u32).to_owned(),
+                Value::new(WEPKeyType::Key as u32).to_owned(),
             ),
             ("auth-alg".to_string(), Value::new("open").to_owned()),
             ("wep-tx-keyidx".to_string(), Value::new(1_u32).to_owned()),
@@ -1046,8 +1046,8 @@ mod test {
                 Some(macaddr::MacAddr6::from_str("12:34:56:78:9A:BC").unwrap())
             );
             let wep_security = wireless.wep_security.as_ref().unwrap();
-            assert_eq!(wep_security.wep_key_type, WepKeyType::Key);
-            assert_eq!(wep_security.auth_alg, WepAuthAlg::Open);
+            assert_eq!(wep_security.wep_key_type, WEPKeyType::Key);
+            assert_eq!(wep_security.auth_alg, WEPAuthAlg::Open);
             assert_eq!(wep_security.wep_key_index, 1);
         }
     }
@@ -1086,9 +1086,9 @@ mod test {
             band: Some(WirelessBand::BG),
             channel: Some(10),
             bssid: Some(macaddr::MacAddr6::from_str("12:34:56:78:9A:BC").unwrap()),
-            wep_security: Some(WepSecurity {
-                auth_alg: WepAuthAlg::Open,
-                wep_key_type: WepKeyType::Key,
+            wep_security: Some(WEPSecurity {
+                auth_alg: WEPAuthAlg::Open,
+                wep_key_type: WEPKeyType::Key,
                 wep_key_index: 1,
                 keys: vec![
                     "5b73215e232f4c577c5073455d".to_string(),
@@ -1140,21 +1140,21 @@ mod test {
         let password: &str = security.get("psk").unwrap().downcast_ref().unwrap();
         assert_eq!(password, "wpa-password");
 
-        let auth_alg: WepAuthAlg = security
+        let auth_alg: WEPAuthAlg = security
             .get("auth-alg")
             .unwrap()
             .downcast_ref::<str>()
             .unwrap()
             .try_into()
             .unwrap();
-        assert_eq!(auth_alg, WepAuthAlg::Open);
+        assert_eq!(auth_alg, WEPAuthAlg::Open);
 
         let wep_key_type: u32 = *security
             .get("wep-key-type")
             .unwrap()
             .downcast_ref::<u32>()
             .unwrap();
-        assert_eq!(wep_key_type, WepKeyType::Key as u32);
+        assert_eq!(wep_key_type, WEPKeyType::Key as u32);
 
         let wep_key_index: u32 = *security
             .get("wep-tx-keyidx")

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 29 10:22:49 UTC 2024 - Jorik Cronenberg <jorik.cronenberg@suse.com>
+
+- Add more wireless options to network model
+  (gh#openSUSE/agama#1014).
+
+-------------------------------------------------------------------
 Thu Jan 23 18:00:00 UTC 2024 - Clemens Famulla-Conrad <cfamullaconrad@suse.de>
 
 - Add Bridge model (gh#openSUSE/agama#1008)


### PR DESCRIPTION
## Problem

For the migration there are a few wireless options that yast2lan has that are missing in agama.

## Solution

Add the missing options.

## Testing

- *Added new unit tests*
- *Tested manually*
- *Tested with the migration: https://github.com/jcronenberg/agama/pull/69*