### PR TITLE
Expose partitions on D-Bus

### DIFF
--- a/service/lib/agama/dbus/storage/device.rb
+++ b/service/lib/agama/dbus/storage/device.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2023] SUSE LLC
+# Copyright (c) [2023-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -39,11 +39,13 @@ module Agama
         #
         # @param storage_device [Y2Storage::Device] Storage device
         # @param path [::DBus::ObjectPath] Path for the D-Bus object
+        # @param tree [DevicesTree] D-Bus tree in which the device is exported
         # @param logger [Logger, nil]
-        def initialize(storage_device, path, logger: nil)
+        def initialize(storage_device, path, tree, logger: nil)
           super(path, logger: logger)
 
           @storage_device = storage_device
+          @tree = tree
           add_interfaces
         end
 
@@ -51,6 +53,9 @@ module Agama
 
         # @return [Y2Storage::Device]
         attr_reader :storage_device
+
+        # @return [DevicesTree]
+        attr_reader :tree
 
         # Adds the required interfaces according to the storage object
         def add_interfaces # rubocop:disable Metrics/CyclomaticComplexity
@@ -82,7 +87,9 @@ module Agama
         #
         # @return [Boolean]
         def partition_table?
-          storage_device.is?(:blk_device) && storage_device.partition_table?
+          storage_device.is?(:blk_device) &&
+            storage_device.respond_to?(:partition_table?) &&
+            storage_device.partition_table?
         end
       end
     end

--- a/service/lib/agama/dbus/storage/device.rb
+++ b/service/lib/agama/dbus/storage/device.rb
@@ -35,6 +35,9 @@ module Agama
       #
       # The D-Bus object includes the required interfaces for the storage object that it represents.
       class Device < BaseObject
+        # @return [Y2Storage::Device]
+        attr_reader :storage_device
+
         # Constructor
         #
         # @param storage_device [Y2Storage::Device] Storage device
@@ -49,10 +52,26 @@ module Agama
           add_interfaces
         end
 
-      private
+        # Sets the represented storage device.
+        #
+        # @note A properties changed signal is emitted for each interface.
+        # @raise [RuntimeError] If the given device has a different sid.
+        #
+        # @param value [Y2Storage::Device]
+        def storage_device=(value)
+          if value.sid != storage_device.sid
+            raise "Cannot update the D-Bus object because the given device has a different sid: " \
+                  "#{value} instead of #{storage_device.sid}"
+          end
 
-        # @return [Y2Storage::Device]
-        attr_reader :storage_device
+          @storage_device = value
+
+          interfaces_and_properties.each do |interface, properties|
+            dbus_properties_changed(interface, properties, [])
+          end
+        end
+
+      private
 
         # @return [DevicesTree]
         attr_reader :tree

--- a/service/lib/agama/dbus/storage/devices_tree.rb
+++ b/service/lib/agama/dbus/storage/devices_tree.rb
@@ -74,6 +74,7 @@ module Agama
         # TODO: export LVM VGs and file systems of directly formatted devices.
         #
         # @param devicegraph [Y2Storage::Devicegraph]
+        # @return [Array<Y2Storage::Device>]
         def devices(devicegraph)
           devices = devicegraph.disk_devices + devicegraph.software_raids
           devices + partitions_from(devices)

--- a/service/lib/agama/dbus/storage/interfaces/block.rb
+++ b/service/lib/agama/dbus/storage/interfaces/block.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2023] SUSE LLC
+# Copyright (c) [2023-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -67,6 +67,13 @@ module Agama
             storage_device.size.to_i
           end
 
+          # Size of the space that could be theoretically reclaimed by shrinking the device.
+          #
+          # @return [Integer]
+          def block_recoverable_size
+            storage_device.recoverable_size.to_i
+          end
+
           # Name of the currently installed systems
           #
           # @return [Array<String>]
@@ -85,6 +92,7 @@ module Agama
                 dbus_reader :block_udev_ids, "as", dbus_name: "UdevIds"
                 dbus_reader :block_udev_paths, "as", dbus_name: "UdevPaths"
                 dbus_reader :block_size, "t", dbus_name: "Size"
+                dbus_reader :block_recoverable_size, "t", dbus_name: "RecoverableSize"
                 dbus_reader :block_systems, "as", dbus_name: "Systems"
               end
             end

--- a/service/lib/agama/dbus/storage/interfaces/partition_table.rb
+++ b/service/lib/agama/dbus/storage/interfaces/partition_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2023] SUSE LLC
+# Copyright (c) [2023-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -39,20 +39,18 @@ module Agama
             storage_device.partition_table.type.to_s
           end
 
-          # Name of the partitions
+          # Paths of the D-Bus objects representing the partitions.
           #
-          # TODO: return the path of the partition objects once the partitions are exported.
-          #
-          # @return [Array<String>]
+          # @return [Array<::DBus::ObjectPath>]
           def partition_table_partitions
-            storage_device.partition_table.partitions.map(&:name)
+            storage_device.partition_table.partitions.map { |p| tree.path_for(p) }
           end
 
           def self.included(base)
             base.class_eval do
               dbus_interface PARTITION_TABLE_INTERFACE do
                 dbus_reader :partition_table_type, "s", dbus_name: "Type"
-                dbus_reader :partition_table_partitions, "as", dbus_name: "Partitions"
+                dbus_reader :partition_table_partitions, "ao", dbus_name: "Partitions"
               end
             end
           end

--- a/service/package/rubygem-agama.changes
+++ b/service/package/rubygem-agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Jan 29 13:51:30 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Export partitions on D-Bus (gh#openSUSE/agama#1016).
+
+-------------------------------------------------------------------
 Thu Jan 18 14:55:36 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Add support to check availability of a package

--- a/service/test/agama/dbus/storage/interfaces/block_examples.rb
+++ b/service/test/agama/dbus/storage/interfaces/block_examples.rb
@@ -79,6 +79,18 @@ shared_examples "Block interface" do
       end
     end
 
+    describe "#block_recoverable_size" do
+      before do
+        allow(device).to receive(:recoverable_size).and_return(size)
+      end
+
+      let(:size) { Y2Storage::DiskSize.new(1024) }
+
+      it "returns the recoverable size in bytes" do
+        expect(subject.block_recoverable_size).to eq(1024)
+      end
+    end
+
     describe "#block_systems" do
       let(:filesystem1) { instance_double(Y2Storage::Filesystems::Base, is?: false) }
       let(:filesystem2) { instance_double(Y2Storage::Filesystems::Base, is?: false) }

--- a/service/test/agama/dbus/storage/interfaces/partition_table_examples.rb
+++ b/service/test/agama/dbus/storage/interfaces/partition_table_examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2023] SUSE LLC
+# Copyright (c) [2023-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -34,8 +34,9 @@ shared_examples "PartitionTable interface" do
     end
 
     describe "#partition_table_partitions" do
-      it "returns the name of the partitions" do
-        expect(subject.partition_table_partitions).to contain_exactly("/dev/md0p1")
+      it "returns the path of the partitions" do
+        md0p1 = devicegraph.find_by_name("/dev/md0p1")
+        expect(subject.partition_table_partitions).to contain_exactly(tree.path_for(md0p1))
       end
     end
   end


### PR DESCRIPTION
## Problem

The Agama storage service currently exports a tree of devices on D-Bus. Such a tree only contains objects for the candidate devices for the installation. But the information about their partitions is missing. Partitions are need for serveral reasons, for example, to indicate how to find space in the selected devices. 

## Solution

Make the tree of devices to include objects for the partitions. The partition object implements the *org.opensuse.Agama.Storage1.Block* interface.

~~~
# busctl --address unix:path=/run/agama/bus tree org.opensuse.Agama.Storage1
└─/org
  └─/org/opensuse
    └─/org/opensuse/Agama
      └─/org/opensuse/Agama/Storage1
        ├─/org/opensuse/Agama/Storage1/Proposal
        └─/org/opensuse/Agama/Storage1/system
          ├─/org/opensuse/Agama/Storage1/system/68
          ├─/org/opensuse/Agama/Storage1/system/69
          ├─/org/opensuse/Agama/Storage1/system/70
          ├─/org/opensuse/Agama/Storage1/system/71
          ├─/org/opensuse/Agama/Storage1/system/77
          ├─/org/opensuse/Agama/Storage1/system/79
          ├─/org/opensuse/Agama/Storage1/system/80
          ├─/org/opensuse/Agama/Storage1/system/82
          ├─/org/opensuse/Agama/Storage1/system/83
          └─/org/opensuse/Agama/Storage1/system/85

# busctl --address unix:path=/run/agama/bus introspect org.opensuse.Agama.Storage1 /org/opensuse/Agama/Storage1/system/68 org.opensuse.Agama.Storage1.PartitionTable
NAME                                       TYPE      SIGNATURE RESULT/VALUE                             FLAGS
.Partitions                                property  ao        1 "/org/opensuse/Agama/Storage1/system/… emits-change
.Type                                      property  s         "gpt"                                    emits-change

# busctl --address unix:path=/run/agama/bus get-property org.opensuse.Agama.Storage1 /org/opensuse/Agama/Storage1/system/68 org.opensuse.Agama.Storage1.PartitionTable Partitions
ao 1 "/org/opensuse/Agama/Storage1/system/77"

# busctl --address unix:path=/run/agama/bus introspect org.opensuse.Agama.Storage1 /org/opensuse/Agama/Storage1/system/77
NAME                                TYPE      SIGNATURE RESULT/VALUE               FLAGS
org.freedesktop.DBus.Introspectable interface -         -                          -
.Introspect                         method    -         s                          -
org.freedesktop.DBus.Properties     interface -         -                          -
.Get                                method    ss        v                          -
.GetAll                             method    s         a{sv}                      -
.Set                                method    ssv       -                          -
.PropertiesChanged                  signal    sa{sv}as  -                          -
org.opensuse.Agama.Storage1.Block   interface -         -                          -
.Active                             property  b         true                       emits-change
.Name                               property  s         "/dev/vdb1"                emits-change
.RecoverableSize                    property  t         2145386496                 emits-change
.Size                               property  t         2147483648                 emits-change
.Systems                            property  as        0                          emits-change
.UdevIds                            property  as        0                          emits-change
.UdevPaths                          property  as        1 "pci-0000:08:00.0-part1" emits-change
~~~

## Testing

* Added new unit tests
* Tested manually
