### PR TITLE
Document Avahi/mDNS in the latest Live ISO

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The command will print the found servers and their hostnames and IP addresses.
   or separate network segments.
 - mDNS might not be supported in all systems or it might be blocked by firewall.
 - On mobile phones with Android OS mDNS is supported since Android version 12.
-  (But this might be vendor dependent...)
+  (but this might be vendor dependent...).
 
 ### Manual Configuration
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Agama is a new Linux installer born in the core of the YaST team. It is designed
 * [Architecture](#architecture)
 * [How to Run](#how-to-run)
   * [Live ISO Image](#live-iso-image)
+    * [Avahi/mDNS](#avahimdns)
   * [Manual Configuration](#manual-configuration)
 * [How to Contribute](#how-to-contribute)
 * [Development Notes](#development-notes)
@@ -128,6 +129,96 @@ Service](https://download.opensuse.org/repositories/systemsmanagement:/Agama:/De
 * Make sure to download the correct ISO file according to your system architecture (eg.
  you would need to choose a file including `x86_64` if you use an Intel or AMD 64-bit processor)
  and according to the system you want to install (openSUSE vs ALP).
+
+#### Avahi/mDNS
+
+The Live ISO is configured to use mDNS (sometimes called Avahi, Zeroconf,
+Bonjour) for hostname resolution. The reason is that it might be quite difficult
+to find out which URL should be used for connecting to a running Agama
+installer.
+
+##### :warning: Security Note :warning:
+
+*Do not use the `.local` hostnames in untrusted networks (like public WiFi
+networks, shared networks), it is a security risk. An attacker can easily send
+malicious responses for the `.local` hostname resolutions and point you to a
+wrong Agama instance which could for example steal your root password!*
+
+##### Firewall Configuration
+
+If you cannot connect to a server using the `.local` domain then maybe the
+firewall is blocking the traffic. Then you need to enable the mDNS traffic using
+these commands:
+
+```shell
+# enable the mDNS traffic in the current run
+firewall-cmd --zone=public --add-service=mdns
+# make the change permanent
+firewall-cmd --permanent --zone=public --add-service=mdns
+```
+
+##### Using mDNS
+
+The Live ISO by default uses the `agama.local` host name. To connect to the
+running instance simply type `https://agama.local` in your browser. In most
+browsers the HTTPS is the default protocol so usually it is enough to just type
+`agama.local` in the web browser.
+
+If you run more Agama instances then each will you a different name. The server
+appends a number to make it unique. So the second Agama instance gets the
+`agama-2.local` hostname.
+
+If you are not sure whether there are multiple Agama instances running you scan
+the network, see the [service advertising](#service-advertising) below.
+
+Alternatively you can set a different hostname for each instance manually. Use
+the `hostname=` boot option to set a different hostname. For example set
+`hostname=foo`, `hostname=bar` and then use `https://foo.local`,
+`https://bar.local` URLs in the web browser to connect to the respective
+instance.
+
+It is possible to change the hostname later if needed:
+
+```shell
+# set the new hostname
+hostnamectl hostname <hostname>
+# restart the avahi daemon server
+systemctl restart avahi-daemon
+```
+
+The mDNS resolution also works for other services like ping or SSH. So you can
+use commands like:
+
+```shell
+ping agama.local
+ssh root@agama.local
+```
+
+##### Fallback
+
+The mDNS approach is just an addition, one more possibility how to connect to
+the machine. If it does not work for you then you can always use the old good
+classic IP address approach.
+
+##### Service Advertising
+
+The Agama Live ISO also uses Avahi service advertising. With this you can easily
+search for all running Agama instances in the local network:
+
+```shell
+avahi-browse -t -r _agama._sub._https._tcp
+```
+
+The command will print the found servers and their hostnames and IP addresses.
+
+##### Notes
+
+- mDNS works only in the same local network, it does not work over internet
+  or separate network segments.
+- mDNS might not be supported in all systems or it might be blocked by firewall.
+- On mobile phones with Android OS mDNS is supported since Android version 12.
+  (But this might be vendor dependent...)
+
 ### Manual Configuration
 
 You can run Agama from its sources by cloning and configuring the project:

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ running instance simply type `https://agama.local` in your browser. In most
 browsers the HTTPS is the default protocol so usually it is enough to just type
 `agama.local`.
 
-If you run more Agama instances then each will you a different name. The server
+If you run multiple Agama instances, each one will have a different name. The server
 appends a number to make it unique. So the second Agama instance gets the
 `agama-2.local` hostname.
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ firewall-cmd --permanent --zone=public --add-service=mdns
 The Live ISO by default uses the `agama.local` host name. To connect to the
 running instance simply type `https://agama.local` in your browser. In most
 browsers the HTTPS is the default protocol so usually it is enough to just type
-`agama.local` in the web browser.
+`agama.local`.
 
 If you run more Agama instances then each will you a different name. The server
 appends a number to make it unique. So the second Agama instance gets the

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ firewall-cmd --permanent --zone=public --add-service=mdns
 
 ##### Using mDNS
 
-The Live ISO by default uses the `agama.local` host name. To connect to the
+The Live ISO by default uses the `agama.local` hostname. To connect to the
 running instance simply type `https://agama.local` in your browser. In most
 browsers the HTTPS is the default protocol so usually it is enough to just type
 `agama.local`.

--- a/doc/deployment_guide_s390.md
+++ b/doc/deployment_guide_s390.md
@@ -110,7 +110,7 @@ Once ready boot the installation running the **sles.exec** REXX file
 sles
 ```
 
-Once the installation system finish the booting process just connect to the machine with the web browser (e.g. https://s390vsl111.suse.de:9090) or by SSH with (root / linux) user.
+Once the installation system finish the booting process just connect to the machine with the web browser (e.g. https://s390vsl111.suse.de) or by SSH with (root / linux) user.
 
 ## Screenshots of the complete installation Z/VM installation workflow
 

--- a/playwright/tests/take_screenshots.spec.ts
+++ b/playwright/tests/take_screenshots.spec.ts
@@ -4,7 +4,7 @@ import { mainPagePath } from "../lib/installer";
 // This test was designed for collecting the screenshots for the main
 // README.md file. To take screenshots of the installation process run this:
 // 
-//   RUN_INSTALLATION=1 BASE_URL=https://<host>:9090 npx playwright test --headed take_screenshots
+//   RUN_INSTALLATION=1 BASE_URL=https://<host> npx playwright test --headed take_screenshots
 // 
 // The "--headed" option shows the browser window so you can see the progress.
 // You can use the "--debug" option to run the test step-by-step.

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -29,9 +29,7 @@ const stylelint = process.env.STYLELINT ? (process.env.STYLELINT !== '0') : deve
 
 // Cockpit target managed by the development server,
 // by default connect to a locally running Cockpit
-let cockpitTarget = process.env.COCKPIT_TARGET || "localhost";
-// add the default port if not specified
-if (cockpitTarget.indexOf(":") === -1) cockpitTarget += ":9090";
+let cockpitTarget = process.env.COCKPIT_TARGET || "localhost:9090";
 cockpitTarget = "https://" + cockpitTarget;
 
 // Obtain package name from package.json


### PR DESCRIPTION
- Added Avahi/mDNS section
- Update the  default port on Live ISO (default HTTPS, no 9090 anymore)
- Related to https://build.opensuse.org/request/show/1141765