### PR TITLE
Add wireless hidden property to network model

### DIFF
--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -744,6 +744,7 @@ pub struct WirelessConfig {
     pub channel: Option<u32>,
     pub bssid: Option<macaddr::MacAddr6>,
     pub wep_security: Option<WEPSecurity>,
+    pub hidden: bool,
 }
 
 impl TryFrom<ConnectionConfig> for WirelessConfig {

--- a/rust/package/agama-cli.changes
+++ b/rust/package/agama-cli.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 29 15:37:56 UTC 2024 - Jorik Cronenberg <jorik.cronenberg@suse.com>
+
+- Add hidden property for wireless in network model
+  (gh#openSUSE/agama#1024).
+
+-------------------------------------------------------------------
 Mon Jan 29 10:22:49 UTC 2024 - Jorik Cronenberg <jorik.cronenberg@suse.com>
 
 - Add more wireless options to network model


### PR DESCRIPTION
## Problem

Wireless property hidden is missing in network model.


## Solution

Add property. Sorry that I forgot it in my previous PR.


## Testing

- *Extended unit test*
- *Tested manually*
- *Tested with the migration https://github.com/jcronenberg/agama/pull/69*