### PR TITLE
improve detection of multipath config

### DIFF
--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -293,13 +293,8 @@ module Agama
         mods = `lsmod`.lines.grep(/dm_multipath/)
         logger.warn("dm_multipath modules is not loaded") if mods.empty?
 
-        conf_file = File.exist?(MULTIPATH_CONFIG)
-        if conf_file
-          finder = File.readlines(MULTIPATH_CONFIG).grep(/find_multipaths\s+smart/)
-          logger.warn("find_multipaths is not set to smart value") if finder.empty?
-        else
-          logger.warn("#{MULTIPATH_CONFIG} does not exist")
-        end
+        conf = `multipath -t`.lines.grep(/find_multipaths "smart"/)
+        logger.warn("multipath: find_multipaths is not set to 'smart'") if conf.empty?
       end
     end
   end

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -293,8 +293,13 @@ module Agama
         mods = `lsmod`.lines.grep(/dm_multipath/)
         logger.warn("dm_multipath modules is not loaded") if mods.empty?
 
-        conf = `multipath -t`.lines.grep(/find_multipaths "smart"/)
-        logger.warn("multipath: find_multipaths is not set to 'smart'") if conf.empty?
+        binary = system("which multipath")
+        if binary
+          conf = `multipath -t`.lines.grep(/find_multipaths "smart"/)
+          logger.warn("multipath: find_multipaths is not set to 'smart'") if conf.empty?
+        else
+          logger.warn("multipath is not installed.")
+        end
       end
     end
   end


### PR DESCRIPTION
## Problem

My original pull request use configuration only from /etc/multipath.conf which is very limited as there can be multiple configurations.


## Solution

Use instead `multipath -t` to get config which multipath really uses and detect how multipath detection is configured. It is not perfect, e.g. when there are multiple config for different devices, but if user do it, then he knows what he is doing.


## Testing

- *Tested manually*