### PR TITLE
Add clang-devel and pam-devel in the setup services script

### DIFF
--- a/setup-services.sh
+++ b/setup-services.sh
@@ -124,8 +124,10 @@ which cargo || $SUDO zypper --non-interactive install cargo
 # Packages required by Rust code (see ./rust/package/agama-cli.spec)
 $SUDO zypper --non-interactive install \
   bzip2 \
+  clang-devel \
   jsonnet \
   lshw \
+  pam-devel \
   python-langtable-data \
   tar \
   timezone \


### PR DESCRIPTION
Add missing `clang-devel` and `pam-devel` dependencies to the setup script.
