### PR TITLE
[web] Drop intrusive warning shown in the storage proposal page

### DIFF
--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 21 17:40:01 UTC 2024 - David Diaz <dgonzalez@suse.com>
+
+- Stop rendering a warning at the top of storage page
+  (gh#openSUSE/agama#1048).
+
+-------------------------------------------------------------------
 Tue Feb 20 13:13:51 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Add section for space policy to the storage page

--- a/web/src/components/storage/ProposalPage.jsx
+++ b/web/src/components/storage/ProposalPage.jsx
@@ -20,12 +20,10 @@
  */
 
 import React, { useCallback, useReducer, useEffect } from "react";
-import { Alert } from "@patternfly/react-core";
 
 import { _ } from "~/i18n";
 import { useInstallerClient } from "~/context/installer";
 import { toValidationError, useCancellablePromise } from "~/utils";
-import { Icon } from "~/components/layout";
 import { Page } from "~/components/core";
 import {
   ProposalActionsSection,
@@ -210,11 +208,6 @@ export default function ProposalPage() {
 
     return (
       <>
-        <Alert
-          isInline
-          customIcon={<Icon name="info" size="xxs" />}
-          title={_("Devices will not be modified until installation starts.")}
-        />
         <ProposalSettingsSection
           availableDevices={state.availableDevices}
           volumeTemplates={usefulTemplates()}

--- a/web/src/components/storage/ProposalPage.test.jsx
+++ b/web/src/components/storage/ProposalPage.test.jsx
@@ -116,12 +116,6 @@ it("loads the proposal data", async () => {
   await screen.findByText(/\/dev\/vda/);
 });
 
-it("renders a warning about modified devices", async () => {
-  installerRender(<ProposalPage />);
-
-  await screen.findByText(/Devices will not be modified/);
-});
-
 it("renders the settings, find space and actions sections", async () => {
   installerRender(<ProposalPage />);
 


### PR DESCRIPTION
Since the Agama UI's regular workflow is to keep the system unchanged until installation begins, warning users about it is actually not needed. Thus, we agreed to use these intrusive warnings only in cases when/where Agama will take immediate action.

| Before | After |
|-|-|
|![Screen Shot 2024-02-21 at 17 39 07](https://github.com/openSUSE/agama/assets/1691872/6ead9f5d-3892-4dfe-9043-172f7c9fc8cc) | ![Screen Shot 2024-02-21 at 17 38 48](https://github.com/openSUSE/agama/assets/1691872/f1059225-811f-49dc-997a-9a2ba0d50603) |


