### PR TITLE
A little fix in the "About Agama" text

### DIFF
--- a/web/src/components/core/About.jsx
+++ b/web/src/components/core/About.jsx
@@ -51,9 +51,9 @@ export default function About() {
           {
             // TRANSLATORS: content of the "About" popup (1/2)
             _("Agama is an experimental installer for (open)SUSE systems. It \
-still under development so, please, do not use it in \
+is still under development so, please, do not use it in \
 production environments. If you want to give it a try, we \
-recommend to use a virtual machine to prevent any possible \
+recommend using a virtual machine to prevent from any possible \
 data loss.")
           }
         </Text>

--- a/web/src/components/core/About.jsx
+++ b/web/src/components/core/About.jsx
@@ -53,7 +53,7 @@ export default function About() {
             _("Agama is an experimental installer for (open)SUSE systems. It \
 is still under development so, please, do not use it in \
 production environments. If you want to give it a try, we \
-recommend using a virtual machine to prevent from any possible \
+recommend using a virtual machine to prevent any possible \
 data loss.")
           }
         </Text>


### PR DESCRIPTION
- Added missing "is"
- Using better phrase "we recommend using"
