### PR TITLE
agama-web-server: accept both IPv6 and IPv4 connections

### DIFF
--- a/rust/agama-dbus-server/src/agama-web-server.rs
+++ b/rust/agama-dbus-server/src/agama-web-server.rs
@@ -13,8 +13,9 @@ use utoipa::OpenApi;
 enum Commands {
     /// Start the API server.
     Serve {
-        /// Address to listen on (default: "0.0.0.0:3000")
-        #[arg(long, default_value = "0.0.0.0:3000")]
+        // Address to listen on (":::3000" listens for both IPv6 and IPv4
+        // connections unless manually disabled in /proc/sys/net/ipv6/bindv6only)
+        #[arg(long, default_value = ":::3000")]
         address: String,
     },
     /// Display the API documentation in OpenAPI format.


### PR DESCRIPTION
## Problem

- IPv6 not accepted by the webserver
- `curl http://ipv6-localhost:3000` does not work


## Solution

- Enable using both protocols, binding to the IPv6 address actually enables using both IPv4 and IPv6 protocols (unless the dualstack is manually disabled in `/proc/sys/net/ipv6/bindv6only`, by default it is enabled).

## Testing

- Tested manually, `http://ipv6-localhost:3000` works fine
