### PR TITLE
HTTPS support for the Agama web server

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -55,12 +55,16 @@ dependencies = [
  "cidr",
  "clap",
  "config",
+ "futures-util",
  "gettext-rs",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "jsonwebtoken",
  "log",
  "macaddr",
  "once_cell",
+ "openssl",
  "pam",
  "rand",
  "regex",
@@ -72,6 +76,7 @@ dependencies = [
  "systemd-journal-logger",
  "thiserror",
  "tokio",
+ "tokio-openssl",
  "tokio-stream",
  "tower",
  "tower-http",
@@ -1132,6 +1137,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-io"
@@ -1204,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1215,21 +1235,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -1431,9 +1451,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1445,6 +1465,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "smallvec",
  "tokio",
 ]
 
@@ -2014,6 +2035,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,9 +2068,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.97"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -2765,9 +2812,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
@@ -3008,6 +3055,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ffab79df67727f6acf57f1ff743091873c24c579b1e2ce4d8f53e47ded4d63d"
+dependencies = [
+ "futures-util",
+ "openssl",
+ "openssl-sys",
+ "tokio",
 ]
 
 [[package]]

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -48,6 +48,11 @@ chrono = { version = "0.4.34", default-features = false, features = [
 ] }
 pam = "0.8.0"
 serde_with = "3.6.1"
+openssl = "0.10.64"
+hyper = "1.2.0"
+hyper-util = "0.1.3"
+tokio-openssl = "0.6.4"
+futures-util = { version = "0.3.30", default-features = false, features = ["alloc"] }
 
 [[bin]]
 name = "agama-dbus-server"

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -142,12 +142,12 @@ fn https_redirect() -> Router {
         let request_host = req.headers().get("host");
         match request_host {
             // missing host in the request header, we cannot build the redirection URL, return error 400
-            None => return Ok(redirect_error()),
+            None => Ok(redirect_error()),
             Some(host) => {
                 let host_string = host.to_str();
                 match host_string {
                     // invalid host value in the request
-                    Err(_) => return Ok(redirect_error()),
+                    Err(_) => Ok(redirect_error()),
                     Ok(host_str) => return Ok(redirect_https(host_str, req.uri())),
                 }
             }
@@ -238,8 +238,8 @@ async fn start_server(address: String, service: Router, ssl_acceptor: SslAccepto
 
 /// Start serving the API.
 async fn serve_command(
-    address: &String,
-    address2: &String,
+    address: &str,
+    address2: &str,
     cert: &String,
     key: &String,
 ) -> anyhow::Result<()> {
@@ -256,14 +256,14 @@ async fn serve_command(
     let mut servers = vec![];
     if !address.is_empty() {
         servers.push(tokio::spawn(start_server(
-            address.clone(),
+            address.to_owned(),
             service.clone(),
             ssl_acceptor.clone(),
         )));
     }
     if !address2.is_empty() {
         servers.push(tokio::spawn(start_server(
-            address2.clone(),
+            address2.to_owned(),
             service.clone(),
             ssl_acceptor.clone(),
         )));

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -1,11 +1,22 @@
-use std::process::{ExitCode, Termination};
-
+use std::{path::PathBuf, pin::Pin};
+// use agama_lib::connection;
 use agama_dbus_server::{
     l10n::helpers,
     web::{self, run_monitor},
 };
+use axum::{
+    http::{Request, Response},
+    Router,
+};
 use clap::{Parser, Subcommand};
+use futures_util::pin_mut;
+use hyper::body::Incoming;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use openssl::ssl::{Ssl, SslAcceptor, SslFiletype, SslMethod};
+use std::process::{ExitCode, Termination};
 use tokio::sync::broadcast::channel;
+use tokio_openssl::SslStream;
+use tower::Service;
 use tracing_subscriber::prelude::*;
 use utoipa::OpenApi;
 
@@ -13,10 +24,28 @@ use utoipa::OpenApi;
 enum Commands {
     /// Start the API server.
     Serve {
-        // Address to listen on (":::3000" listens for both IPv6 and IPv4
+        // Address to listen to (":::3000" listens for both IPv6 and IPv4
         // connections unless manually disabled in /proc/sys/net/ipv6/bindv6only)
-        #[arg(long, default_value = ":::3000")]
+        #[arg(long, default_value = ":::3000", help = "Primary address to listen on")]
         address: String,
+        #[arg(
+            long,
+            default_value = "",
+            help = "Optional secondary address to listen to"
+        )]
+        address2: String,
+        #[arg(
+            long,
+            default_value = "",
+            help = "Path to the SSL private key file in PEM format"
+        )]
+        key: String,
+        #[arg(
+            long,
+            default_value = "",
+            help = "Path to the SSL certificate file in PEM format"
+        )]
+        cert: String,
     },
     /// Display the API documentation in OpenAPI format.
     Openapi,
@@ -32,23 +61,216 @@ struct Cli {
     pub command: Commands,
 }
 
+// check whether the connection uses SSL or not
+async fn is_ssl_stream(stream: &tokio::net::TcpStream) -> bool {
+    // a buffer for reading the first byte from the TCP connection
+    let mut buf = [0u8; 1];
+
+    // peek() receives the data without removing it from the stream,
+    // the data is not consumed, it will be read from the stream again later
+    stream.peek(&mut buf).await.unwrap();
+
+    // SSL3.0/TLS1.x starts with byte 0x16
+    // SSL2 starts with 0x80 (but should not be used as it is considered)
+    // see https://stackoverflow.com/q/3897883
+    // otherwise consider the stream as a plain HTTP stream possibly starting with
+    // "GET ... HTTP/1.1" or "POST ... HTTP/1.1" or a similar line
+    buf[0] == 0x16u8 || buf[0] == 0x80u8
+}
+
+// build a SSL acceptor using a provided SSL certificate or generate a self-signed one
+fn create_ssl_acceptor(cert_file: &String, key_file: &String) -> SslAcceptor {
+    let mut tls_builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls_server()).unwrap();
+
+    if cert_file.is_empty() && key_file.is_empty() {
+        let (cert, key) = agama_dbus_server::cert::create_certificate().unwrap();
+        tracing::info!("Generated self signed certificate: {:#?}", cert);
+        tls_builder.set_private_key(key.as_ref()).unwrap();
+        tls_builder.set_certificate(cert.as_ref()).unwrap();
+
+        // for debugging you might dump the certificate to a file:
+        // use std::io::Write;
+        // let mut cert_file = std::fs::File::create("agama_cert.pem").unwrap();
+        // let mut key_file = std::fs::File::create("agama_key.pem").unwrap();
+        // cert_file.write_all(cert.to_pem().unwrap().as_ref()).unwrap();
+        // key_file.write_all(key.private_key_to_pem_pkcs8().unwrap().as_ref()).unwrap();
+    } else {
+        tracing::info!("Loading PEM certificate: {}", cert_file);
+        tls_builder
+            .set_certificate_file(PathBuf::from(cert_file), SslFiletype::PEM)
+            .unwrap();
+
+        tracing::info!("Loading PEM key: {}", key_file);
+        tls_builder
+            .set_private_key_file(PathBuf::from(key_file), SslFiletype::PEM)
+            .unwrap();
+    }
+
+    // check that the key belongs to the certificate
+    tls_builder.check_private_key().unwrap();
+
+    tls_builder.build()
+}
+
+// build a response for the HTTP -> HTTPS redirection
+// returns 308 permanent redirect
+fn redirect_https(host: &str, uri: &hyper::Uri) -> Response<String> {
+    let builder = Response::builder()
+        // build the redirection target URL
+        .header("Location", format!("https://{}{}", host, uri))
+        .status(hyper::StatusCode::PERMANENT_REDIRECT);
+
+    builder.body(String::from("")).unwrap()
+}
+
+// build an error response for the HTTP -> HTTPS redirection when we cannot build
+// the redirect response from the original request
+// returns error 400
+fn redirect_error() -> Response<String> {
+    let builder = Response::builder().status(hyper::StatusCode::BAD_REQUEST);
+
+    let msg = "HTTP protocol is not allowed for external requests, please use HTTPS.\n";
+    builder.body(String::from(msg)).unwrap()
+}
+
+// build a router for the HTTP -> HTTPS redirection
+// if the redirection URL cannot be built from the original request it returns error 400
+// instead of the redirection
+fn https_redirect() -> Router {
+    // see https://docs.rs/axum/latest/axum/routing/struct.Router.html#example
+    let redirect_service = tower::service_fn(|req: axum::extract::Request| async move {
+        let request_host = req.headers().get("host");
+        match request_host {
+            // missing host in the request header, we cannot build the redirection URL, return error 400
+            None => return Ok(redirect_error()),
+            Some(host) => {
+                let host_string = host.to_str();
+                match host_string {
+                    // invalid host value in the request
+                    Err(_) => return Ok(redirect_error()),
+                    Ok(host_str) => return Ok(redirect_https(host_str, req.uri())),
+                }
+            }
+        }
+    });
+
+    Router::new()
+        .route_service(
+            // the wildcard path below does not match an empty path, we need to match it explicitly
+            "/",
+            redirect_service,
+        )
+        .route_service("/*path", redirect_service)
+}
+
+// start the web server
+async fn start_server(address: String, service: Router, ssl_acceptor: SslAcceptor) {
+    tracing::info!("Starting Agama web server at {}", address);
+
+    // see https://github.com/tokio-rs/axum/blob/main/examples/low-level-openssl/src/main.rs
+    // how to use axum with openSSL
+    let listener = tokio::net::TcpListener::bind(&address)
+        .await
+        .unwrap_or_else(|_| panic!("could not listen on {}", &address));
+
+    pin_mut!(listener);
+
+    let redirector = https_redirect();
+
+    loop {
+        let tower_service = service.clone();
+        let redirector_service = redirector.clone();
+        let tls_acceptor = ssl_acceptor.clone();
+
+        // Wait for a new tcp connection
+        let (tcp_stream, addr) = listener.accept().await.unwrap();
+
+        tokio::spawn(async move {
+            if is_ssl_stream(&tcp_stream).await {
+                // handle HTTPS connection
+                let ssl = Ssl::new(tls_acceptor.context()).unwrap();
+                let mut tls_stream = SslStream::new(ssl, tcp_stream).unwrap();
+                if let Err(err) = SslStream::accept(Pin::new(&mut tls_stream)).await {
+                    tracing::error!("Error during TSL handshake from {}: {}", addr, err);
+                }
+
+                let stream = TokioIo::new(tls_stream);
+                let hyper_service =
+                    hyper::service::service_fn(move |request: Request<Incoming>| {
+                        tower_service.clone().call(request)
+                    });
+
+                let ret = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+                    .serve_connection_with_upgrades(stream, hyper_service)
+                    .await;
+
+                if let Err(err) = ret {
+                    tracing::error!("Error serving connection from {}: {}", addr, err);
+                }
+            } else {
+                // handle HTTP connection
+                let stream = TokioIo::new(tcp_stream);
+                let hyper_service =
+                    hyper::service::service_fn(move |request: Request<Incoming>| {
+                        // check if it is local connection or external
+                        // the to_canonical() converts IPv4-mapped IPv6 addresses
+                        // to plain IPv4, then is_loopback() works correctly for the IPv4 connections
+                        if addr.ip().to_canonical().is_loopback() {
+                            // accept plain HTTP on the local connection
+                            tower_service.clone().call(request)
+                        } else {
+                            // redirect external connections to HTTPS
+                            redirector_service.clone().call(request)
+                        }
+                    });
+
+                let ret = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+                    .serve_connection_with_upgrades(stream, hyper_service)
+                    .await;
+
+                if let Err(err) = ret {
+                    tracing::error!("Error serving connection from {}: {}", addr, err);
+                }
+            }
+        });
+    }
+}
+
 /// Start serving the API.
-async fn serve_command(address: &str) -> anyhow::Result<()> {
+async fn serve_command(
+    address: &String,
+    address2: &String,
+    cert: &String,
+    key: &String,
+) -> anyhow::Result<()> {
     let journald = tracing_journald::layer().expect("could not connect to journald");
     tracing_subscriber::registry().with(journald).init();
-
-    let listener = tokio::net::TcpListener::bind(address)
-        .await
-        .unwrap_or_else(|_| panic!("could not listen on {}", address));
 
     let (tx, _) = channel(16);
     run_monitor(tx.clone()).await?;
 
     let config = web::ServiceConfig::load().unwrap();
     let service = web::service(config, tx);
-    axum::serve(listener, service)
-        .await
-        .expect("could not mount app on listener");
+    let ssl_acceptor = create_ssl_acceptor(cert, key);
+
+    let mut servers = vec![];
+    if !address.is_empty() {
+        servers.push(tokio::spawn(start_server(
+            address.clone(),
+            service.clone(),
+            ssl_acceptor.clone(),
+        )));
+    }
+    if !address2.is_empty() {
+        servers.push(tokio::spawn(start_server(
+            address2.clone(),
+            service.clone(),
+            ssl_acceptor.clone(),
+        )));
+    }
+
+    futures_util::future::join_all(servers).await;
+
     Ok(())
 }
 
@@ -60,7 +282,12 @@ fn openapi_command() -> anyhow::Result<()> {
 
 async fn run_command(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
-        Commands::Serve { address } => serve_command(&address).await,
+        Commands::Serve {
+            address,
+            address2,
+            key,
+            cert,
+        } => serve_command(&address, &address2, &cert, &key).await,
         Commands::Openapi => openapi_command(),
     }
 }

--- a/rust/agama-server/src/cert.rs
+++ b/rust/agama-server/src/cert.rs
@@ -42,14 +42,14 @@ pub fn create_certificate() -> Result<(X509, PKey<Private>), ErrorStack> {
             .critical()
             .key_cert_sign()
             .crl_sign()
-            .build()?
+            .build()?,
     )?;
 
     builder.append_extension(
-      SubjectAlternativeName::new()
-        .dns("agama")
-        .dns("agama.local")
-        .build(&builder.x509v3_context(None, None))?
+        SubjectAlternativeName::new()
+            .dns("agama")
+            .dns("agama.local")
+            .build(&builder.x509v3_context(None, None))?,
     )?;
 
     let subject_key_identifier =

--- a/rust/agama-server/src/cert.rs
+++ b/rust/agama-server/src/cert.rs
@@ -1,0 +1,63 @@
+use openssl::error::ErrorStack;
+use openssl::pkey::{PKey, Private};
+use openssl::rsa::Rsa;
+use openssl::x509::extension::{KeyUsage, SubjectAlternativeName};
+use openssl::x509::{X509NameBuilder, X509};
+
+use openssl::asn1::Asn1Time;
+use openssl::bn::{BigNum, MsbOption};
+use openssl::hash::MessageDigest;
+use openssl::x509::extension::{BasicConstraints, SubjectKeyIdentifier};
+
+// Generate a self-signed SSL certificate
+// see https://github.com/sfackler/rust-openssl/blob/master/openssl/examples/mk_certs.rs
+pub fn create_certificate() -> Result<(X509, PKey<Private>), ErrorStack> {
+    let rsa = Rsa::generate(2048)?;
+    let key = PKey::from_rsa(rsa)?;
+
+    let mut x509_name = X509NameBuilder::new()?;
+    x509_name.append_entry_by_text("O", "Agama")?;
+    x509_name.append_entry_by_text("CN", "localhost")?;
+    let x509_name = x509_name.build();
+
+    let mut builder = X509::builder()?;
+    builder.set_version(2)?;
+    let serial_number = {
+        let mut serial = BigNum::new()?;
+        serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
+        serial.to_asn1_integer()?
+    };
+    builder.set_serial_number(&serial_number)?;
+    builder.set_subject_name(&x509_name)?;
+    builder.set_pubkey(&key)?;
+
+    let not_before = Asn1Time::days_from_now(0)?;
+    builder.set_not_before(&not_before)?;
+    let not_after = Asn1Time::days_from_now(365)?;
+    builder.set_not_after(&not_after)?;
+
+    builder.append_extension(BasicConstraints::new().critical().ca().build()?)?;
+    builder.append_extension(
+        KeyUsage::new()
+            .critical()
+            .key_cert_sign()
+            .crl_sign()
+            .build()?
+    )?;
+
+    builder.append_extension(
+      SubjectAlternativeName::new()
+        .dns("agama")
+        .dns("agama.local")
+        .build(&builder.x509v3_context(None, None))?
+    )?;
+
+    let subject_key_identifier =
+        SubjectKeyIdentifier::new().build(&builder.x509v3_context(None, None))?;
+    builder.append_extension(subject_key_identifier)?;
+
+    builder.sign(&key, MessageDigest::sha256())?;
+    let cert = builder.build();
+
+    Ok((cert, key))
+}

--- a/rust/agama-server/src/lib.rs
+++ b/rust/agama-server/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod cert;
 pub mod l10n;
 pub mod network;
 pub mod questions;

--- a/rust/agama-server/src/lib.rs
+++ b/rust/agama-server/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod error;
 pub mod cert;
+pub mod error;
 pub mod l10n;
 pub mod network;
 pub mod questions;

--- a/rust/agama-server/tests/common/mod.rs
+++ b/rust/agama-server/tests/common/mod.rs
@@ -41,6 +41,12 @@ pub trait ServerState {}
 impl ServerState for Started {}
 impl ServerState for Stopped {}
 
+impl Default for DBusServer<Stopped> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DBusServer<Stopped> {
     pub fn new() -> Self {
         let uuid = Uuid::new_v4();

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,17 @@
 -------------------------------------------------------------------
+Thu Feb 29 09:49:18 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Web server:
+  - Accept also IPv6 connections
+  - Added SSL (HTTPS) support
+    - Use either the cerfificate specified via command line
+      arguments or generate a self-signed certificate
+    - Redirect external HTTP requests to HTTPS
+    - Allow HTTP for internal connections (http://localhost)
+  - Optionally listen on a secondary address
+    (to allow listening on both HTTP/80 and HTTPS/433 ports)
+
+-------------------------------------------------------------------
 Tue Feb 27 15:55:28 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Reorganize RPM packages (gh#openSUSE/agama#1056):


### PR DESCRIPTION
## Problem

- The communication between the user and the Agama web server needs to be encrypted

## Solution

- Enable HTTPS support using the standard openSSL library
- Automatically redirect all external HTTP requests to HTTPS
- Allow using HTTP locally (`http://localhost`)

## Testing

- Tested manually

## TODO

- [ ] Update the documentation

For later:

- [ ] Use the [gethostname crate](https://crates.io/crates/gethostname) and include the current host name in the generated self-signed certificate
- [ ] Read the SSL certificate from some default location (something like `/etc/agama.d/ssl/{certificate,key}.pem` ?)