### PR TITLE
Expose the software service through the HTTP/JSON API

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "url",
+ "utoipa",
  "zbus",
 ]
 

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -21,4 +21,5 @@ thiserror = "1.0.39"
 tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.14"
 url = "2.5.0"
+utoipa = "4.2.0"
 zbus = { version = "3", default-features = false, features = ["tokio"] }

--- a/rust/agama-lib/src/product.rs
+++ b/rust/agama-lib/src/product.rs
@@ -5,6 +5,6 @@ mod proxies;
 mod settings;
 mod store;
 
-pub use client::ProductClient;
+pub use client::{Product, ProductClient};
 pub use settings::ProductSettings;
 pub use store::ProductStore;

--- a/rust/agama-lib/src/product/client.rs
+++ b/rust/agama-lib/src/product/client.rs
@@ -8,7 +8,7 @@ use zbus::Connection;
 use super::proxies::RegistrationProxy;
 
 /// Represents a software product
-#[derive(Default, Debug, Serialize)]
+#[derive(Default, Debug, Serialize, utoipa::ToSchema)]
 pub struct Product {
     /// Product ID (eg., "ALP", "Tumbleweed", etc.)
     pub id: String,

--- a/rust/agama-lib/src/product/client.rs
+++ b/rust/agama-lib/src/product/client.rs
@@ -19,6 +19,7 @@ pub struct Product {
 }
 
 /// D-Bus client for the software service
+#[derive(Clone)]
 pub struct ProductClient<'a> {
     product_proxy: SoftwareProductProxy<'a>,
     registration_proxy: RegistrationProxy<'a>,

--- a/rust/agama-lib/src/product/client.rs
+++ b/rust/agama-lib/src/product/client.rs
@@ -8,7 +8,7 @@ use zbus::Connection;
 use super::proxies::RegistrationProxy;
 
 /// Represents a software product
-#[derive(Debug, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct Product {
     /// Product ID (eg., "ALP", "Tumbleweed", etc.)
     pub id: String,
@@ -16,6 +16,8 @@ pub struct Product {
     pub name: String,
     /// Product description
     pub description: String,
+    /// Whether the product is selected
+    pub selected: bool,
 }
 
 /// D-Bus client for the software service
@@ -48,6 +50,7 @@ impl<'a> ProductClient<'a> {
                     id,
                     name,
                     description: description.to_string(),
+                    ..Default::default()
                 }
             })
             .collect();

--- a/rust/agama-lib/src/product/client.rs
+++ b/rust/agama-lib/src/product/client.rs
@@ -16,8 +16,6 @@ pub struct Product {
     pub name: String,
     /// Product description
     pub description: String,
-    /// Whether the product is selected
-    pub selected: bool,
 }
 
 /// D-Bus client for the software service
@@ -50,7 +48,6 @@ impl<'a> ProductClient<'a> {
                     id,
                     name,
                     description: description.to_string(),
-                    ..Default::default()
                 }
             })
             .collect();

--- a/rust/agama-lib/src/software.rs
+++ b/rust/agama-lib/src/software.rs
@@ -5,6 +5,6 @@ pub mod proxies;
 mod settings;
 mod store;
 
-pub use client::{Pattern, SelectedBy, SoftwareClient};
+pub use client::{Pattern, SelectedBy, SoftwareClient, UnknownSelectedBy};
 pub use settings::SoftwareSettings;
 pub use store::SoftwareStore;

--- a/rust/agama-lib/src/software.rs
+++ b/rust/agama-lib/src/software.rs
@@ -5,6 +5,6 @@ pub mod proxies;
 mod settings;
 mod store;
 
-pub use client::{Pattern, SelectionReason, SoftwareClient};
+pub use client::{Pattern, SelectedBy, SoftwareClient};
 pub use settings::SoftwareSettings;
 pub use store::SoftwareStore;

--- a/rust/agama-lib/src/software.rs
+++ b/rust/agama-lib/src/software.rs
@@ -5,6 +5,6 @@ pub mod proxies;
 mod settings;
 mod store;
 
-pub use client::SoftwareClient;
+pub use client::{Pattern, SelectionReason, SoftwareClient};
 pub use settings::SoftwareSettings;
 pub use store::SoftwareStore;

--- a/rust/agama-lib/src/software/client.rs
+++ b/rust/agama-lib/src/software/client.rs
@@ -112,6 +112,9 @@ impl<'a> SoftwareClient<'a> {
         }
     }
 
+    /// Returns the required space for installing the selected patterns.
+    ///
+    /// It returns a formatted string including the size and the unit.
     pub async fn used_disk_space(&self) -> Result<String, ServiceError> {
         Ok(self.software_proxy.used_disk_space().await?)
     }

--- a/rust/agama-lib/src/software/client.rs
+++ b/rust/agama-lib/src/software/client.rs
@@ -111,4 +111,8 @@ impl<'a> SoftwareClient<'a> {
             Ok(())
         }
     }
+
+    pub async fn used_disk_space(&self) -> Result<String, ServiceError> {
+        Ok(self.software_proxy.used_disk_space().await?)
+    }
 }

--- a/rust/agama-lib/src/software/client.rs
+++ b/rust/agama-lib/src/software/client.rs
@@ -115,4 +115,9 @@ impl<'a> SoftwareClient<'a> {
     pub async fn used_disk_space(&self) -> Result<String, ServiceError> {
         Ok(self.software_proxy.used_disk_space().await?)
     }
+
+    /// Starts the process to read the repositories data.
+    pub async fn probe(&self) -> Result<(), ServiceError> {
+        Ok(self.software_proxy.probe().await?)
+    }
 }

--- a/rust/agama-lib/src/software/client.rs
+++ b/rust/agama-lib/src/software/client.rs
@@ -22,19 +22,22 @@ pub struct Pattern {
 }
 
 /// Represents the reason why a pattern is selected.
-#[derive(Clone, Copy)]
-pub enum SelectionReason {
+#[derive(Clone, Copy, Debug, Serialize)]
+pub enum SelectedBy {
     /// The pattern was selected by the user.
     User = 0,
     /// The pattern was selected automatically.
     Auto = 1,
+    /// The pattern has not be selected.
+    None = 2,
 }
 
-impl From<u8> for SelectionReason {
+impl From<u8> for SelectedBy {
     fn from(value: u8) -> Self {
         match value {
             0 => Self::User,
-            _ => Self::Auto,
+            1 => Self::Auto,
+            _ => Self::None,
         }
     }
 }
@@ -80,16 +83,14 @@ impl<'a> SoftwareClient<'a> {
             .selected_patterns()
             .await?
             .into_iter()
-            .filter(|(_id, reason)| *reason == SelectionReason::User as u8)
+            .filter(|(_id, reason)| *reason == SelectedBy::User as u8)
             .map(|(id, _reason)| id)
             .collect();
         Ok(patterns)
     }
 
     /// Returns the selected pattern and the reason each one selected.
-    pub async fn selected_patterns(
-        &self,
-    ) -> Result<HashMap<String, SelectionReason>, ServiceError> {
+    pub async fn selected_patterns(&self) -> Result<HashMap<String, SelectedBy>, ServiceError> {
         let patterns = self.software_proxy.selected_patterns().await?;
         let patterns = patterns
             .into_iter()

--- a/rust/agama-lib/src/software/client.rs
+++ b/rust/agama-lib/src/software/client.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use zbus::Connection;
 
 /// Represents a software product
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct Pattern {
     /// Pattern ID (eg., "aaa_base", "gnome")
     pub id: String,

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -4,7 +4,8 @@ use agama_dbus_server::{
     l10n::helpers,
     web::{self, run_monitor},
 };
-use clap::{Parser, Subcommand};
+use agama_lib::connection_to;
+use clap::{Args, Parser, Subcommand};
 use tokio::sync::broadcast::channel;
 use tracing_subscriber::prelude::*;
 use utoipa::OpenApi;
@@ -12,14 +13,20 @@ use utoipa::OpenApi;
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// Start the API server.
-    Serve {
-        // Address to listen on (":::3000" listens for both IPv6 and IPv4
-        // connections unless manually disabled in /proc/sys/net/ipv6/bindv6only)
-        #[arg(long, default_value = ":::3000")]
-        address: String,
-    },
+    Serve(ServeArgs),
     /// Display the API documentation in OpenAPI format.
     Openapi,
+}
+
+#[derive(Debug, Args)]
+pub struct ServeArgs {
+    // Address to listen on (":::3000" listens for both IPv6 and IPv4
+    // connections unless manually disabled in /proc/sys/net/ipv6/bindv6only)
+    #[arg(long, default_value = ":::3000")]
+    address: String,
+    // Agama D-Bus address
+    #[arg(long, default_value = "unix:path=/run/agama/bus")]
+    dbus_address: String,
 }
 
 #[derive(Parser, Debug)]
@@ -33,22 +40,26 @@ struct Cli {
 }
 
 /// Start serving the API.
-async fn serve_command(address: &str) -> anyhow::Result<()> {
+///
+/// `args`: command-line arguments.
+async fn serve_command(args: ServeArgs) -> anyhow::Result<()> {
     let journald = tracing_journald::layer().expect("could not connect to journald");
     tracing_subscriber::registry().with(journald).init();
 
-    let listener = tokio::net::TcpListener::bind(address)
+    let listener = tokio::net::TcpListener::bind(&args.address)
         .await
-        .unwrap_or_else(|_| panic!("could not listen on {}", address));
+        .unwrap_or_else(|_| panic!("could not listen on {}", &args.address));
 
     let (tx, _) = channel(16);
     run_monitor(tx.clone()).await?;
 
-    let config = web::ServiceConfig::load().unwrap();
-    let service = web::service(config, tx).await;
+    let config = web::ServiceConfig::load()?;
+    let dbus = connection_to(&args.dbus_address).await?;
+    let service = web::service(config, tx, dbus).await;
     axum::serve(listener, service)
         .await
         .expect("could not mount app on listener");
+
     Ok(())
 }
 
@@ -60,7 +71,7 @@ fn openapi_command() -> anyhow::Result<()> {
 
 async fn run_command(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
-        Commands::Serve { address } => serve_command(&address).await,
+        Commands::Serve(args) => serve_command(args).await,
         Commands::Openapi => openapi_command(),
     }
 }

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -45,7 +45,7 @@ async fn serve_command(address: &str) -> anyhow::Result<()> {
     run_monitor(tx.clone()).await?;
 
     let config = web::ServiceConfig::load().unwrap();
-    let service = web::service(config, tx);
+    let service = web::service(config, tx).await;
     axum::serve(listener, service)
         .await
         .expect("could not mount app on listener");

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -55,7 +55,7 @@ async fn serve_command(args: ServeArgs) -> anyhow::Result<()> {
 
     let config = web::ServiceConfig::load()?;
     let dbus = connection_to(&args.dbus_address).await?;
-    let service = web::service(config, tx, dbus).await;
+    let service = web::service(config, tx, dbus).await?;
     axum::serve(listener, service)
         .await
         .expect("could not mount app on listener");

--- a/rust/agama-server/src/lib.rs
+++ b/rust/agama-server/src/lib.rs
@@ -2,5 +2,6 @@ pub mod error;
 pub mod l10n;
 pub mod network;
 pub mod questions;
+pub mod software;
 pub mod web;
 pub use web::service;

--- a/rust/agama-server/src/software.rs
+++ b/rust/agama-server/src/software.rs
@@ -1,2 +1,2 @@
 pub mod web;
-pub use web::software_service;
+pub use web::{software_monitor, software_service};

--- a/rust/agama-server/src/software.rs
+++ b/rust/agama-server/src/software.rs
@@ -1,2 +1,2 @@
 pub mod web;
-pub use web::{software_monitor, software_service};
+pub use web::{software_service, software_stream};

--- a/rust/agama-server/src/software.rs
+++ b/rust/agama-server/src/software.rs
@@ -1,0 +1,2 @@
+pub mod web;
+pub use web::software_service;

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -101,17 +101,18 @@ async fn patterns_changed_stream(
 }
 
 /// Sets up and returns the axum service for the software module.
-pub async fn software_service(dbus: zbus::Connection) -> Router {
-    let product = ProductClient::new(dbus.clone()).await.unwrap();
-    let software = SoftwareClient::new(dbus).await.unwrap();
+pub async fn software_service(dbus: zbus::Connection) -> Result<Router, ServiceError> {
+    let product = ProductClient::new(dbus.clone()).await?;
+    let software = SoftwareClient::new(dbus).await?;
     let state = SoftwareState { product, software };
-    Router::new()
+    let router = Router::new()
         .route("/patterns", get(patterns))
         .route("/products", get(products))
         .route("/proposal", get(proposal))
         .route("/config", put(set_config).get(get_config))
         .route("/probe", post(probe))
-        .with_state(state)
+        .with_state(state);
+    Ok(router)
 }
 
 /// Returns the list of available products.

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -41,7 +41,7 @@ pub struct SoftwareConfig {
 
 #[derive(Error, Debug)]
 pub enum SoftwareError {
-    #[error("Service error: {0}")]
+    #[error("Software service error: {0}")]
     Error(#[from] ServiceError),
 }
 

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -109,8 +109,8 @@ pub async fn software_service(dbus: zbus::Connection) -> Router {
 #[utoipa::path(get, path = "/software/products", responses(
     (status = 200, description = "List of known products")
 ))]
-async fn products<'a>(
-    State(state): State<SoftwareState<'a>>,
+async fn products(
+    State(state): State<SoftwareState<'_>>,
 ) -> Result<Json<Vec<Product>>, SoftwareError> {
     let products = state.product.products().await?;
     Ok(Json(products))
@@ -149,8 +149,8 @@ impl From<SelectionReason> for PatternStatus {
 #[utoipa::path(get, path = "/software/patterns", responses(
     (status = 200, description = "List of known software patterns")
 ))]
-async fn patterns<'a>(
-    State(state): State<SoftwareState<'a>>,
+async fn patterns(
+    State(state): State<SoftwareState<'_>>,
 ) -> Result<Json<Vec<PatternEntry>>, SoftwareError> {
     let patterns = state.software.patterns(true).await?;
     let selected = state.software.selected_patterns().await?;

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -1,0 +1,73 @@
+//! This module implements the web API for the software module.
+//!
+//! It is a wrapper around the YaST D-Bus API.
+
+use crate::web::EventsSender;
+use agama_lib::{connection, product::Product, software::proxies::SoftwareProductProxy};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use serde_json::json;
+use thiserror::Error;
+
+#[derive(Clone)]
+struct SoftwareState<'a> {
+    software: SoftwareProductProxy<'a>,
+}
+
+#[derive(Error, Debug)]
+pub enum SoftwareError {
+    #[error("Service error: {0}")]
+    Error(#[from] zbus::Error),
+}
+
+impl IntoResponse for SoftwareError {
+    fn into_response(self) -> Response {
+        let body = json!({
+            "error": self.to_string()
+        });
+        (StatusCode::BAD_REQUEST, Json(body)).into_response()
+    }
+}
+
+/// Sets up and returns the axum service for the software module.
+///
+/// * `events`: channel to send the events to the main service.
+pub async fn software_service(_events: EventsSender) -> Router {
+    let connection = connection().await.unwrap();
+    let proxy = SoftwareProductProxy::new(&connection).await.unwrap();
+    let state = SoftwareState { software: proxy };
+    Router::new()
+        .route("/products", get(products))
+        .with_state(state)
+}
+
+/// Returns the list of available products.
+///
+/// * `state`: service state.
+async fn products<'a>(
+    State(state): State<SoftwareState<'a>>,
+) -> Result<Json<Vec<Product>>, SoftwareError> {
+    let products = state.software.available_products().await?;
+    let products = products
+        .into_iter()
+        .map(|(id, name, data)| {
+            let description = data
+                .get("description")
+                .and_then(|d| d.downcast_ref::<str>())
+                .unwrap_or("");
+
+            Product {
+                id,
+                name,
+                description: description.to_string(),
+            }
+        })
+        .collect();
+
+    Ok(Json(products))
+}

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -38,12 +38,13 @@ pub async fn service(
     config: ServiceConfig,
     events: EventsSender,
     dbus: zbus::Connection,
-) -> Router {
-    MainServiceBuilder::new(events.clone())
+) -> Result<Router, ServiceError> {
+    let router = MainServiceBuilder::new(events.clone())
         .add_service("/l10n", l10n_service(events.clone()))
-        .add_service("/software", software_service(dbus).await)
+        .add_service("/software", software_service(dbus).await?)
         .with_config(config)
-        .build()
+        .build();
+    Ok(router)
 }
 
 /// Starts monitoring the D-Bus service progress.

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -46,12 +46,12 @@ pub async fn service(config: ServiceConfig, events: EventsSender) -> Router {
 pub async fn run_monitor(events: EventsSender) -> Result<(), ServiceError> {
     let presenter = EventsProgressPresenter::new(events.clone());
     let connection = connection().await?;
-    let mut monitor = ProgressMonitor::new(connection).await?;
+    let mut monitor = ProgressMonitor::new(connection.clone()).await?;
     tokio::spawn(async move {
         if let Err(error) = monitor.run(presenter).await {
             eprintln!("Could not monitor the D-Bus server: {}", error);
         }
     });
-    tokio::spawn(async move { software_monitor(events.clone()).await });
+    software_monitor(connection, events.clone()).await;
     Ok(())
 }

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -31,10 +31,14 @@ use tokio_stream::StreamExt;
 ///
 /// * `config`: service configuration.
 /// * `events`: D-Bus connection.
-pub async fn service(config: ServiceConfig, events: EventsSender) -> Router {
+pub async fn service(
+    config: ServiceConfig,
+    events: EventsSender,
+    dbus: zbus::Connection,
+) -> Router {
     MainServiceBuilder::new(events.clone())
         .add_service("/l10n", l10n_service(events.clone()))
-        .add_service("/software", software_service(events).await)
+        .add_service("/software", software_service(dbus).await)
         .with_config(config)
         .build()
 }

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -21,6 +21,7 @@ pub use docs::ApiDoc;
 pub use event::{Event, EventsReceiver, EventsSender};
 
 use crate::l10n::web::l10n_service;
+use crate::software::web::software_service;
 use axum::Router;
 pub use service::MainServiceBuilder;
 
@@ -30,9 +31,10 @@ use self::progress::EventsProgressPresenter;
 ///
 /// * `config`: service configuration.
 /// * `events`: D-Bus connection.
-pub fn service(config: ServiceConfig, events: EventsSender) -> Router {
+pub async fn service(config: ServiceConfig, events: EventsSender) -> Router {
     MainServiceBuilder::new(events.clone())
-        .add_service("/l10n", l10n_service(events))
+        .add_service("/l10n", l10n_service(events.clone()))
+        .add_service("/software", software_service(events).await)
         .with_config(config)
         .build()
 }

--- a/rust/agama-server/src/web/docs.rs
+++ b/rust/agama-server/src/web/docs.rs
@@ -3,13 +3,27 @@ use utoipa::OpenApi;
 #[derive(OpenApi)]
 #[openapi(
     info(description = "Agama web API description"),
-    paths(super::http::ping, crate::l10n::web::locales),
+    paths(
+        super::http::ping,
+        crate::software::web::patterns,
+        crate::l10n::web::get_config,
+        crate::l10n::web::keymaps,
+        crate::l10n::web::locales,
+        crate::l10n::web::set_config,
+        crate::l10n::web::timezones,
+        crate::software::web::get_config,
+        crate::software::web::set_config,
+        crate::software::web::patterns,
+    ),
     components(
         schemas(super::http::PingResponse),
         schemas(crate::l10n::LocaleEntry),
         schemas(crate::l10n::web::LocaleConfig),
         schemas(crate::l10n::Keymap),
-        schemas(crate::l10n::TimezoneEntry)
+        schemas(crate::l10n::TimezoneEntry),
+        schemas(agama_lib::software::Pattern),
+        schemas(agama_lib::product::Product),
+        schemas(crate::software::web::PatternEntry)
     )
 )]
 pub struct ApiDoc;

--- a/rust/agama-server/src/web/docs.rs
+++ b/rust/agama-server/src/web/docs.rs
@@ -4,26 +4,28 @@ use utoipa::OpenApi;
 #[openapi(
     info(description = "Agama web API description"),
     paths(
-        super::http::ping,
-        crate::software::web::patterns,
         crate::l10n::web::get_config,
         crate::l10n::web::keymaps,
         crate::l10n::web::locales,
         crate::l10n::web::set_config,
         crate::l10n::web::timezones,
         crate::software::web::get_config,
-        crate::software::web::set_config,
         crate::software::web::patterns,
+        crate::software::web::patterns,
+        crate::software::web::set_config,
+        super::http::ping,
     ),
     components(
-        schemas(super::http::PingResponse),
-        schemas(crate::l10n::LocaleEntry),
-        schemas(crate::l10n::web::LocaleConfig),
-        schemas(crate::l10n::Keymap),
-        schemas(crate::l10n::TimezoneEntry),
-        schemas(agama_lib::software::Pattern),
         schemas(agama_lib::product::Product),
-        schemas(crate::software::web::PatternEntry)
+        schemas(agama_lib::software::Pattern),
+        schemas(crate::l10n::Keymap),
+        schemas(crate::l10n::LocaleEntry),
+        schemas(crate::l10n::TimezoneEntry),
+        schemas(crate::l10n::web::LocaleConfig),
+        schemas(crate::software::web::PatternEntry),
+        schemas(crate::software::web::SoftwareConfig),
+        schemas(crate::software::web::SoftwareProposal),
+        schemas(super::http::PingResponse),
     )
 )]
 pub struct ApiDoc;

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -1,5 +1,4 @@
-use crate::software::web::PatternStatus;
-use agama_lib::progress::Progress;
+use agama_lib::{progress::Progress, software::SelectedBy};
 use serde::Serialize;
 use std::collections::HashMap;
 use tokio::sync::broadcast::{Receiver, Sender};
@@ -10,7 +9,7 @@ pub enum Event {
     LocaleChanged { locale: String },
     Progress(Progress),
     ProductChanged { id: String },
-    PatternsChanged(HashMap<String, PatternStatus>),
+    PatternsChanged(HashMap<String, SelectedBy>),
 }
 
 pub type EventsSender = Sender<Event>;

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -7,6 +7,7 @@ use tokio::sync::broadcast::{Receiver, Sender};
 pub enum Event {
     LocaleChanged { locale: String },
     Progress(Progress),
+    ProductChanged { id: String },
 }
 
 pub type EventsSender = Sender<Event>;

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -1,5 +1,7 @@
+use crate::software::web::PatternStatus;
 use agama_lib::progress::Progress;
 use serde::Serialize;
+use std::collections::HashMap;
 use tokio::sync::broadcast::{Receiver, Sender};
 
 #[derive(Clone, Serialize)]
@@ -8,7 +10,7 @@ pub enum Event {
     LocaleChanged { locale: String },
     Progress(Progress),
     ProductChanged { id: String },
-    PatternsChanged,
+    PatternsChanged(HashMap<String, PatternStatus>),
 }
 
 pub type EventsSender = Sender<Event>;

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -8,6 +8,7 @@ pub enum Event {
     LocaleChanged { locale: String },
     Progress(Progress),
     ProductChanged { id: String },
+    PatternsChanged,
 }
 
 pub type EventsSender = Sender<Event>;

--- a/rust/agama-server/tests/service.rs
+++ b/rust/agama-server/tests/service.rs
@@ -11,19 +11,20 @@ use axum::{
     routing::get,
     Router,
 };
-use common::body_to_string;
+use common::{body_to_string, DBusServer};
 use std::error::Error;
 use tokio::{sync::broadcast::channel, test};
 use tower::ServiceExt;
 
-fn build_service() -> Router {
+async fn build_service() -> Router {
     let (tx, _) = channel(16);
-    service(ServiceConfig::default(), tx)
+    let server = DBusServer::new().start().await.unwrap();
+    service(ServiceConfig::default(), tx, server.connection()).await
 }
 
 #[test]
 async fn test_ping() -> Result<(), Box<dyn Error>> {
-    let web_service = build_service();
+    let web_service = build_service().await;
     let request = Request::builder().uri("/ping").body(Body::empty()).unwrap();
 
     let response = web_service.oneshot(request).await.unwrap();

--- a/rust/agama-server/tests/service.rs
+++ b/rust/agama-server/tests/service.rs
@@ -19,7 +19,9 @@ use tower::ServiceExt;
 async fn build_service() -> Router {
     let (tx, _) = channel(16);
     let server = DBusServer::new().start().await.unwrap();
-    service(ServiceConfig::default(), tx, server.connection()).await
+    service(ServiceConfig::default(), tx, server.connection())
+        .await
+        .unwrap()
 }
 
 #[test]


### PR DESCRIPTION
Trello: https://trello.com/c/2MjaulMd/3566-3-expose-the-software-api-over-http

This PR exposes the public[^1] part of the software API through the HTTP/JSON interface. It includes:

* `/software/patterns`: list of patterns, including whether they are selected (and by whom).
* `/software/products`: list of products.
* `/software/probe`: starts the software probing.
* `/software/config`: describing the software configuration.

```json
{
  "patterns": [
    "gnome"
  ],
  "product": "Tumbleweed"
}
```

Additionally, it exposes the following events through the websocket:

* `PatternsChanged`, containing the patterns and who selected them ('user' or 'auto').
* `ProductChanged`, with the name of the new product.

[^1] The part of the D-Bus API that it is used by the web UI.

## Implementation details

In this phase of the development, we are still deciding the best way to implement these HTTP/JSON interfaces. The implementation has two parts:

* The [HTTP/JSON interface itself](https://github.com/openSUSE/agama/blob/http-software-srv/rust/agama-server/src/software/web.rs#L104), which is implemented as a [Router](https://docs.rs/axum/latest/axum/struct.Router.html) and a set of small functions (one per each endpoing+verb).
* An [events stream](https://github.com/openSUSE/agama/blob/http-software-srv/rust/agama-server/src/software/web.rs#L60) which emits Event values (see [stream](https://tokio.rs/tokio/tutorial/streams) in the Tokio documentation).

About the service status, the zbus proxies are cached and can be cloned, so it looks like a good idea to keep our clients as part of the state.

## In the future

There are a few improvements we could consider in the future:

* Split the events in different types depending on the service (`SoftwareEvent`, `ManagerEvent`), so those services only know about their types.
* Consolidate all errors under a common one (e.g., `Error::Software(SoftwareError)`, `Error::Manager(ManagerError)`, etc.) to have a single `IntoResponse` implementation while keeping modules isolation.
