### PR TITLE
chore: fix the agama-server crate name

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -42,49 +42,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "agama-dbus-server"
-version = "0.1.0"
-dependencies = [
- "agama-lib",
- "agama-locale-data",
- "anyhow",
- "async-trait",
- "axum",
- "axum-extra",
- "chrono",
- "cidr",
- "clap",
- "config",
- "gettext-rs",
- "http-body-util",
- "jsonwebtoken",
- "log",
- "macaddr",
- "once_cell",
- "pam",
- "rand",
- "regex",
- "serde",
- "serde_json",
- "serde_with",
- "serde_yaml",
- "simplelog",
- "systemd-journal-logger",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-http",
- "tracing",
- "tracing-journald",
- "tracing-subscriber",
- "utoipa",
- "uuid",
- "zbus",
- "zbus_macros",
-]
-
-[[package]]
 name = "agama-derive"
 version = "1.0.0"
 dependencies = [
@@ -127,6 +84,49 @@ dependencies = [
  "regex",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "agama-server"
+version = "0.1.0"
+dependencies = [
+ "agama-lib",
+ "agama-locale-data",
+ "anyhow",
+ "async-trait",
+ "axum",
+ "axum-extra",
+ "chrono",
+ "cidr",
+ "clap",
+ "config",
+ "gettext-rs",
+ "http-body-util",
+ "jsonwebtoken",
+ "log",
+ "macaddr",
+ "once_cell",
+ "pam",
+ "rand",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "serde_yaml",
+ "simplelog",
+ "systemd-journal-logger",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-journald",
+ "tracing-subscriber",
+ "utoipa",
+ "uuid",
+ "zbus",
+ "zbus_macros",
 ]
 
 [[package]]

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agama-dbus-server"
+name = "agama-server"
 version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true

--- a/rust/agama-server/src/agama-dbus-server.rs
+++ b/rust/agama-server/src/agama-dbus-server.rs
@@ -1,4 +1,4 @@
-use agama_dbus_server::{
+use agama_server::{
     l10n::{self, helpers},
     network, questions,
 };

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -1,10 +1,10 @@
 use std::process::{ExitCode, Termination};
 
-use agama_dbus_server::{
+use agama_lib::connection_to;
+use agama_server::{
     l10n::helpers,
     web::{self, run_monitor},
 };
-use agama_lib::connection_to;
 use clap::{Args, Parser, Subcommand};
 use tokio::sync::broadcast::channel;
 use tracing_subscriber::prelude::*;

--- a/rust/agama-server/tests/l10n.rs
+++ b/rust/agama-server/tests/l10n.rs
@@ -1,6 +1,6 @@
 pub mod common;
 
-use agama_dbus_server::l10n::web::l10n_service;
+use agama_server::l10n::web::l10n_service;
 use axum::{
     body::Body,
     http::{Request, StatusCode},

--- a/rust/agama-server/tests/network.rs
+++ b/rust/agama-server/tests/network.rs
@@ -1,15 +1,15 @@
 pub mod common;
 
 use self::common::{async_retry, DBusServer};
-use agama_dbus_server::network::{
-    self,
-    model::{self, Ipv4Method, Ipv6Method},
-    Adapter, NetworkAdapterError, NetworkService, NetworkState,
-};
 use agama_lib::network::{
     settings::{self},
     types::DeviceType,
     NetworkClient,
+};
+use agama_server::network::{
+    self,
+    model::{self, Ipv4Method, Ipv6Method},
+    Adapter, NetworkAdapterError, NetworkService, NetworkState,
 };
 use async_trait::async_trait;
 use cidr::IpInet;

--- a/rust/agama-server/tests/service.rs
+++ b/rust/agama-server/tests/service.rs
@@ -1,6 +1,6 @@
 pub mod common;
 
-use agama_dbus_server::{
+use agama_server::{
     service,
     web::{generate_token, MainServiceBuilder, ServiceConfig},
 };


### PR DESCRIPTION
Although the directory was renamed to `agama-server`, the crate name remained the same.