### PR TITLE
Adapt the web user interface to log in the new server

### DIFF
--- a/rust/WEB-SERVER.md
+++ b/rust/WEB-SERVER.md
@@ -71,7 +71,7 @@ The web server uses a bearer token for HTTP authentication. You can get the toke
 password to the `/auth` endpoint.
 
 ```
-$ curl http://localhost:3000/auth \
+$ curl http://localhost:3000/api/auth \
     -H "Content-Type: application/json" \
     -d '{"password": "your-password"}' 
 {"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3MDg1MTA5MzB9.3HmKAC5u4H_FigMqEa9e74OFAq40UldjlaExrOGqE0U"}⏎

--- a/rust/agama-locale-data/src/locale.rs
+++ b/rust/agama-locale-data/src/locale.rs
@@ -86,6 +86,15 @@ pub struct KeymapId {
     pub variant: Option<String>,
 }
 
+impl Default for KeymapId {
+    fn default() -> Self {
+        Self {
+            layout: "us".to_string(),
+            variant: None,
+        }
+    }
+}
+
 #[derive(Error, Debug, PartialEq)]
 #[error("Invalid keymap ID: {0}")]
 pub struct InvalidKeymap(String);

--- a/rust/agama-server/src/l10n.rs
+++ b/rust/agama-server/src/l10n.rs
@@ -7,14 +7,16 @@ pub mod web;
 use crate::error::Error;
 use agama_locale_data::{KeymapId, LocaleCode};
 use anyhow::Context;
-pub use keyboard::Keymap;
 use keyboard::KeymapsDatabase;
-pub use locale::LocaleEntry;
 use locale::LocalesDatabase;
 use std::process::Command;
-pub use timezone::TimezoneEntry;
 use timezone::TimezonesDatabase;
 use zbus::{dbus_interface, Connection};
+
+pub use keyboard::Keymap;
+pub use locale::LocaleEntry;
+pub use timezone::TimezoneEntry;
+pub use web::LocaleConfig;
 
 pub struct Locale {
     timezone: String,

--- a/rust/agama-server/src/l10n/web.rs
+++ b/rust/agama-server/src/l10n/web.rs
@@ -16,7 +16,10 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::sync::{Arc, RwLock};
+use std::{
+    process::Command,
+    sync::{Arc, RwLock},
+};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -29,6 +32,8 @@ pub enum LocaleError {
     InvalidKeymap(#[from] InvalidKeymap),
     #[error("Cannot translate: {0}")]
     OtherError(#[from] Error),
+    #[error("Cannot change the local keymap: {0}")]
+    CouldNotSetKeymap(#[from] std::io::Error),
 }
 
 impl IntoResponse for LocaleError {
@@ -84,6 +89,8 @@ pub struct LocaleConfig {
     timezone: Option<String>,
     /// User-interface locale. It is actually not related to the `locales` property.
     ui_locale: Option<String>,
+    /// User-interface locale. It is relevant only on local installations.
+    ui_keymap: Option<String>,
 }
 
 #[utoipa::path(get, path = "/l10n/timezones", responses(
@@ -153,6 +160,17 @@ async fn set_config(
         });
     }
 
+    if let Some(ui_keymap) = &value.ui_keymap {
+        data.ui_keymap = ui_keymap.parse()?;
+        Command::new("/usr/bin/localectl")
+            .args(["set-x11-keymap", &ui_keymap])
+            .output()?;
+        Command::new("/usr/bin/setxkbmap")
+            .arg(&ui_keymap)
+            .env("DISPLAY", ":0")
+            .output()?;
+    }
+
     _ = state.events.send(Event::L10nConfigChanged(changes));
 
     Ok(Json(()))
@@ -168,6 +186,7 @@ async fn get_config(State(state): State<LocaleState>) -> Json<LocaleConfig> {
         keymap: Some(data.keymap()),
         timezone: Some(data.timezone().to_string()),
         ui_locale: Some(data.ui_locale().to_string()),
+        ui_keymap: Some(data.ui_keymap.to_string()),
     })
 }
 

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -220,10 +220,15 @@ async fn get_config(
     State(state): State<SoftwareState<'_>>,
 ) -> Result<Json<SoftwareConfig>, SoftwareError> {
     let product = state.product.product().await?;
+    let product = if product.is_empty() {
+        None
+    } else {
+        Some(product)
+    };
     let patterns = state.software.user_selected_patterns().await?;
     let config = SoftwareConfig {
         patterns: Some(patterns),
-        product: Some(product),
+        product: product,
     };
     Ok(Json(config))
 }

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -1,3 +1,4 @@
+use crate::l10n::web::LocaleConfig;
 use agama_lib::{progress::Progress, software::SelectedBy};
 use serde::Serialize;
 use std::collections::HashMap;
@@ -6,6 +7,7 @@ use tokio::sync::broadcast::{Receiver, Sender};
 #[derive(Clone, Serialize)]
 #[serde(tag = "type")]
 pub enum Event {
+    L10nConfigChanged(LocaleConfig),
     LocaleChanged { locale: String },
     Progress(Progress),
     ProductChanged { id: String },

--- a/rust/agama-server/src/web/http.rs
+++ b/rust/agama-server/src/web/http.rs
@@ -70,7 +70,7 @@ pub async fn login(
 }
 
 #[utoipa::path(delete, path = "/auth", responses(
-    (status = 204, description = "The user have been logged out")
+    (status = 204, description = "The user has been logged out")
 ))]
 pub async fn logout(_claims: TokenClaims) -> Result<impl IntoResponse, AuthError> {
     let mut headers = HeaderMap::new();

--- a/rust/agama-server/src/web/http.rs
+++ b/rust/agama-server/src/web/http.rs
@@ -41,10 +41,10 @@ pub struct LoginRequest {
     pub password: String,
 }
 
-#[utoipa::path(post, path = "/authenticate", responses(
+#[utoipa::path(post, path = "/auth", responses(
     (status = 200, description = "The user have been successfully authenticated", body = AuthResponse)
 ))]
-pub async fn authenticate(
+pub async fn login(
     State(state): State<ServiceState>,
     Json(login): Json<LoginRequest>,
 ) -> Result<impl IntoResponse, AuthError> {
@@ -69,9 +69,22 @@ pub async fn authenticate(
     Ok((headers, content))
 }
 
-#[utoipa::path(get, path = "/authenticate", responses(
+#[utoipa::path(delete, path = "/auth", responses(
+    (status = 204, description = "The user have been logged out")
+))]
+pub async fn logout(_claims: TokenClaims) -> Result<impl IntoResponse, AuthError> {
+    let mut headers = HeaderMap::new();
+    let cookie = "token=deleted; HttpOnly; Expires=Thu, 01 Jan 1970 00:00:00 GMT".to_string();
+    headers.insert(
+        SET_COOKIE,
+        cookie.parse().expect("could not build a valid cookie"),
+    );
+    Ok(headers)
+}
+
+#[utoipa::path(get, path = "/auth", responses(
     (status = 200, description = "Check whether the user is authenticated")
 ))]
-pub async fn show_authenticate(_claims: TokenClaims) -> Result<(), AuthError> {
+pub async fn session(_claims: TokenClaims) -> Result<(), AuthError> {
     Ok(())
 }

--- a/rust/agama-server/src/web/http.rs
+++ b/rust/agama-server/src/web/http.rs
@@ -1,7 +1,7 @@
 //! Implements the handlers for the HTTP-based API.
 
 use super::{
-    auth::{generate_token, AuthError},
+    auth::{generate_token, AuthError, TokenClaims},
     state::ServiceState,
 };
 use axum::{
@@ -67,4 +67,11 @@ pub async fn authenticate(
     );
 
     Ok((headers, content))
+}
+
+#[utoipa::path(get, path = "/authenticate", responses(
+    (status = 200, description = "Check whether the user is authenticated")
+))]
+pub async fn show_authenticate(_claims: TokenClaims) -> Result<(), AuthError> {
+    Ok(())
 }

--- a/rust/agama-server/src/web/http.rs
+++ b/rust/agama-server/src/web/http.rs
@@ -41,8 +41,8 @@ pub struct LoginRequest {
     pub password: String,
 }
 
-#[utoipa::path(post, path = "/auth", responses(
-    (status = 200, description = "The user have been successfully authenticated", body = AuthResponse)
+#[utoipa::path(post, path = "/api/auth", responses(
+    (status = 200, description = "The user has been successfully authenticated.", body = AuthResponse)
 ))]
 pub async fn login(
     State(state): State<ServiceState>,
@@ -69,8 +69,8 @@ pub async fn login(
     Ok((headers, content))
 }
 
-#[utoipa::path(delete, path = "/auth", responses(
-    (status = 204, description = "The user has been logged out")
+#[utoipa::path(delete, path = "/api/auth", responses(
+    (status = 204, description = "The user has been logged out.")
 ))]
 pub async fn logout(_claims: TokenClaims) -> Result<impl IntoResponse, AuthError> {
     let mut headers = HeaderMap::new();
@@ -82,8 +82,10 @@ pub async fn logout(_claims: TokenClaims) -> Result<impl IntoResponse, AuthError
     Ok(headers)
 }
 
-#[utoipa::path(get, path = "/auth", responses(
-    (status = 200, description = "Check whether the user is authenticated")
+/// Check whether the user is authenticated.
+#[utoipa::path(get, path = "/api/auth", responses(
+    (status = 200, description = "The user is authenticated."),
+    (status = 400, description = "The user is not authenticated.")
 ))]
 pub async fn session(_claims: TokenClaims) -> Result<(), AuthError> {
     Ok(())

--- a/rust/agama-server/src/web/http.rs
+++ b/rust/agama-server/src/web/http.rs
@@ -41,7 +41,7 @@ pub struct LoginRequest {
     pub password: String,
 }
 
-#[utoipa::path(get, path = "/authenticate", responses(
+#[utoipa::path(post, path = "/authenticate", responses(
     (status = 200, description = "The user have been successfully authenticated", body = AuthResponse)
 ))]
 pub async fn authenticate(

--- a/rust/agama-server/src/web/service.rs
+++ b/rust/agama-server/src/web/service.rs
@@ -1,3 +1,4 @@
+use super::http::{login, logout, session};
 use super::{auth::TokenClaims, config::ServiceConfig, state::ServiceState, EventsSender};
 use axum::{
     extract::Request,
@@ -19,7 +20,7 @@ use tower_http::{compression::CompressionLayer, services::ServeDir, trace::Trace
 ///
 /// * A static assets directory (`public_dir`).
 /// * A websocket at the `/ws` path.
-/// * An authentication endpointg at `/authenticate`.
+/// * An authentication endpoint at `/auth`.
 /// * A 'ping' endpoint at '/ping'.
 /// * A number of authenticated services that are added using the `add_service` function.
 pub struct MainServiceBuilder {
@@ -81,10 +82,7 @@ impl MainServiceBuilder {
                 state.clone(),
             ))
             .route("/ping", get(super::http::ping))
-            .route(
-                "/authenticate",
-                post(super::http::authenticate).get(super::http::show_authenticate),
-            );
+            .route("/auth", post(login).get(session).delete(logout));
 
         let serve = ServeDir::new(self.public_dir);
         Router::new()

--- a/rust/agama-server/src/web/service.rs
+++ b/rust/agama-server/src/web/service.rs
@@ -81,7 +81,10 @@ impl MainServiceBuilder {
                 state.clone(),
             ))
             .route("/ping", get(super::http::ping))
-            .route("/authenticate", post(super::http::authenticate));
+            .route(
+                "/authenticate",
+                post(super::http::authenticate).get(super::http::show_authenticate),
+            );
 
         let serve = ServeDir::new(self.public_dir);
         Router::new()

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -24,8 +24,8 @@ import { Outlet } from "react-router-dom";
 
 import { useInstallerClient, useInstallerClientStatus } from "~/context/installer";
 import { useProduct } from "./context/product";
-import { STARTUP, INSTALL } from "~/client/phase";
-import { BUSY } from "~/client/status";
+import { CONFIG, INSTALL, STARTUP } from "~/client/phase";
+import { BUSY, IDLE } from "~/client/status";
 
 import { DBusError, If, Installation } from "~/components/core";
 import { Loading } from "./components/layout";
@@ -51,22 +51,29 @@ function App() {
 
   useEffect(() => {
     if (client) {
-      return client.manager.onPhaseChange(setPhase);
+      // FIXME: adapt to the new API
+      // return client.manager.onPhaseChange(setPhase);
+      setPhase(CONFIG);
     }
   }, [client, setPhase]);
 
   useEffect(() => {
     if (client) {
-      return client.manager.onStatusChange(setStatus);
+      setStatus(IDLE);
+      // FIXME: adapt to the new API
+      // return client.manager.onStatusChange(setStatus);
     }
   }, [client, setStatus]);
 
   useEffect(() => {
     const loadPhase = async () => {
-      const phase = await client.manager.getPhase();
-      const status = await client.manager.getStatus();
-      setPhase(phase);
-      setStatus(status);
+      setPhase(CONFIG);
+      setStatus(IDLE);
+      // FIXME: adapt to the new API
+      // const phase = await client.manager.getPhase();
+      // const status = await client.manager.getStatus();
+      // setPhase(phase);
+      // setStatus(status);
     };
 
     if (client) {

--- a/web/src/Main.jsx
+++ b/web/src/Main.jsx
@@ -21,15 +21,17 @@
 
 import React from "react";
 import { Outlet } from "react-router-dom";
-import { Questions } from "~/components/questions";
+// import { Questions } from "~/components/questions";
 
 function Main() {
-  return (
-    <>
-      <Questions />
-      <Outlet />
-    </>
-  );
+  // FIXME: adapt to the new API
+  // return (
+  //   <>
+  //     <Questions />
+  //     <Outlet />
+  //   </>
+  // );
+  return <Outlet />;
 }
 
 export default Main;

--- a/web/src/Protected.jsx
+++ b/web/src/Protected.jsx
@@ -25,10 +25,9 @@ import { useAuth } from "./context/auth";
 import { AppProviders } from "./context/app";
 
 export default function Protected() {
-  const { isAuthenticated } = useAuth();
+  const { isLoggedIn } = useAuth();
 
-  console.log("authenticated", isAuthenticated);
-  if (isAuthenticated !== true) {
+  if (isLoggedIn !== true) {
     return <Navigate to="/login" />;
   }
 

--- a/web/src/Protected.jsx
+++ b/web/src/Protected.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2023] SUSE LLC
+ * Copyright (c) [2024] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -19,34 +19,22 @@
  * find current contact information at www.suse.com.
  */
 
-// @ts-check
-
 import React from "react";
-import { InstallerClientProvider } from "./installer";
-import { InstallerL10nProvider } from "./installerL10n";
-import { L10nProvider } from "./l10n";
-import { ProductProvider } from "./product";
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "./context/auth";
+import { AppProviders } from "./context/app";
 
-/**
- * Combines all application providers.
- *
- * @param {object} props
- * @param {React.ReactNode} [props.children] - content to display within the provider.
- */
-function AgamaProviders({ children }) {
+export default function Protected() {
+  const { isAuthenticated } = useAuth();
+
+  console.log("authenticated", isAuthenticated);
+  if (isAuthenticated !== true) {
+    return <Navigate to="/login" />;
+  }
+
   return (
-    <InstallerClientProvider>
-      <InstallerL10nProvider>
-        <L10nProvider>
-          <ProductProvider>
-            {children}
-          </ProductProvider>
-        </L10nProvider>
-      </InstallerL10nProvider>
-    </InstallerClientProvider>
+    <AppProviders>
+      <Outlet />
+    </AppProviders>
   );
 }
-
-export {
-  AgamaProviders
-};

--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -90,7 +90,6 @@ table td > .pf-v5-c-empty-state {
   padding-block: var(--pf-v5-c-modal-box__body--PaddingTop);
 }
 
-.pf-v5-c-form__actions,
 .pf-v5-c-modal-box__footer {
   // We prefer buttons placed at the right
   flex-direction: row-reverse;
@@ -223,6 +222,10 @@ table td > .pf-v5-c-empty-state {
     --pf-v5-c-expandable-section__content--PaddingRight: var(--spacer-normal);
     --pf-v5-c-expandable-section__content--PaddingLeft: var(--spacer-normal);
   }
+}
+
+.pf-v5-c-form__group.pf-m-action {
+  --pf-v5-c-form__group--m-action--MarginTop: var(--spacer-small);
 }
 
 .pf-v5-c-form__group-label-help {

--- a/web/src/client/http.js
+++ b/web/src/client/http.js
@@ -48,7 +48,7 @@ class WSClient {
   /**
    * Registers a handler for events.
    *
-   * The handler is executer for all the events. It is up to the callback to
+   * The handler is executed for all the events. It is up to the callback to
    * filter the relevant events.
    *
    * @param {(object) => void} func - Handler function to register.

--- a/web/src/client/http.js
+++ b/web/src/client/http.js
@@ -87,7 +87,7 @@ class HTTPClient {
     httpUrl.pathname = url.pathname.concat("api");
     this.baseUrl = httpUrl.toString();
 
-    const wsUrl = new URL(url);
+    const wsUrl = new URL(url.toString());
     wsUrl.pathname = wsUrl.pathname.concat("api/ws");
     wsUrl.protocol = (url.protocol === "http:") ? "ws" : "wss";
     this.ws = new WSClient(wsUrl);

--- a/web/src/client/http.js
+++ b/web/src/client/http.js
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// @ts-check
+
+/**
+ * @callback RemoveFn
+ * @return {void}
+ */
+
+/**
+ * Agama WebSocket client.
+ *
+ * Connects to the Agama WebSocket server and reacts on the events.
+ * This class is not expected to be used directly, but through the
+ * HTTPClient API.
+ */
+class WSClient {
+  /**
+   * @param {URL} url - Websocket URL.
+   */
+  constructor(url) {
+    this.client = new WebSocket(url.toString());
+    this.client.onmessage = (event) => {
+      this.dispatchEvent(event);
+    };
+    this.handlers = [];
+  }
+
+  /**
+   * Registers a handler for events.
+   *
+   * The handler is executer for all the events. It is up to the callback to
+   * filter the relevant events.
+   *
+   * @param {(object) => void} func - Handler function to register.
+   * @return {RemoveFn}
+   */
+  onEvent(func) {
+    this.handlers.push(func);
+    return () => {
+      const position = this.handlers.indexOf(func);
+      if (position > -1) this.handlers.splice(position, 1);
+    };
+  }
+
+  /**
+   * @private
+   *
+   * Dispatchs an event by running all the handlers.
+   *
+   * @param {object} event - Event object, which is basically a websocket message.
+   */
+  dispatchEvent(event) {
+    const eventObject = JSON.parse(event.data);
+    this.handlers.forEach((f) => f(eventObject));
+  }
+}
+
+/**
+ * Agama HTTP API client.
+ */
+class HTTPClient {
+  /**
+   * @param {URL} url - URL of the HTTP API.
+   */
+  constructor(url) {
+    const httpUrl = new URL(url.toString());
+    httpUrl.pathname = url.pathname.concat("api");
+    this.baseUrl = httpUrl.toString();
+
+    const wsUrl = new URL(url);
+    wsUrl.pathname = wsUrl.pathname.concat("api/ws");
+    wsUrl.protocol = (url.protocol === "http:") ? "ws" : "wss";
+    this.ws = new WSClient(wsUrl);
+  }
+
+  /**
+   * @param {string} url - Endpoint URL (e.g., "/l10n/config").
+   * @return {Promise<object>} Server response.
+   */
+  async get(url) {
+    const response = await fetch(`${this.baseUrl}/${url}`, {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    return await response.json();
+  }
+
+  /**
+   * @param {string} url - Endpoint URL (e.g., "/l10n/config").
+   * @param {object} data - Data to submit
+   * @return {Promise<object>} Server response.
+   */
+  async post(url, data) {
+    const response = await fetch(`${this.baseUrl}/${url}`, {
+      method: "POST",
+      body: JSON.stringify(data),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    return await response.json();
+  }
+
+  /**
+   * @param {string} url - Endpoint URL (e.g., "/l10n/config").
+   * @param {object} data - Data to submit
+   * @return {Promise<object>} Server response.
+   */
+  async put(url, data) {
+    const response = await fetch(`${this.baseUrl}/${url}`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    return await response.json();
+  }
+
+  /**
+   * Registers a handler for a given type of events.
+   *
+   * @param {string} type - Event type (e.g., "LocaleChanged").
+   * @param {(object) => void} func - Handler function to register.
+   * @return {RemoveFn} - Function to remove the handler.
+   */
+  onEvent(type, func) {
+    return this.ws.onEvent((event) => {
+      if (event.type === type) {
+        func(event);
+      }
+    });
+  }
+}
+
+export { HTTPClient };

--- a/web/src/client/index.js
+++ b/web/src/client/index.js
@@ -27,6 +27,7 @@ import { Monitor } from "./monitor";
 import { SoftwareClient } from "./software";
 import { StorageClient } from "./storage";
 import { UsersClient } from "./users";
+import { ProductClient } from "./software";
 import phase from "./phase";
 import { QuestionsClient } from "./questions";
 import { NetworkClient } from "./network";
@@ -39,6 +40,7 @@ import { HTTPClient } from "./http";
  * @property {ManagerClient} manager - manager client.
  * @property {Monitor} monitor - service monitor.
  * @property {NetworkClient} network - network client.
+ * @property {ProductClient} product - product client.
  * @property {SoftwareClient} software - software client.
  * @property {StorageClient} storage - storage client.
  * @property {UsersClient} users - users client.
@@ -71,8 +73,9 @@ import { HTTPClient } from "./http";
  */
 const createClient = (url) => {
   const client = new HTTPClient(url);
-  console.log("client", client);
   const l10n = new L10nClient(client);
+  // TODO: unify with the manager client
+  const product = new ProductClient(client);
   // const manager = new ManagerClient(address);
   // const monitor = new Monitor(address, MANAGER_SERVICE);
   // const network = new NetworkClient(address);
@@ -133,6 +136,7 @@ const createClient = (url) => {
 
   return {
     l10n,
+    product,
     // manager,
     // monitor,
     // network,

--- a/web/src/client/index.js
+++ b/web/src/client/index.js
@@ -24,10 +24,9 @@
 import { L10nClient } from "./l10n";
 import { ManagerClient } from "./manager";
 import { Monitor } from "./monitor";
-import { SoftwareClient } from "./software";
+import { ProductClient, SoftwareClient } from "./software";
 import { StorageClient } from "./storage";
 import { UsersClient } from "./users";
-import { ProductClient } from "./software";
 import phase from "./phase";
 import { QuestionsClient } from "./questions";
 import { NetworkClient } from "./network";

--- a/web/src/client/l10n.js
+++ b/web/src/client/l10n.js
@@ -218,8 +218,7 @@ class L10nClient {
    * @return {Promise<object>} Localization configuration.
    */
   async getConfig() {
-    const config = await this.client.get("/l10n/config");
-    return config.json();
+    return await this.client.get("/l10n/config");
   }
 
   /**

--- a/web/src/client/l10n.js
+++ b/web/src/client/l10n.js
@@ -57,7 +57,7 @@ class L10nClient {
   /**
    * Selected locale to translate the installer UI.
    *
-   * @return {Promise<String>} Locale id.
+   * @return {Promise<String>} Locale ID.
    */
   async getUILocale() {
     const config = await this.client.get("/l10n/config");
@@ -67,11 +67,35 @@ class L10nClient {
   /**
    * Sets the locale to translate the installer UI.
    *
-   * @param {String} id - Locale id.
+   * @param {String} id - Locale ID.
    * @return {Promise<void>}
    */
   async setUILocale(id) {
     return this.client.put("/l10n/config", { ui_locale: id });
+  }
+
+  /**
+   * Selected keymap for the installer.
+   *
+   * This setting is only relevant in the local installation.
+   *
+   * @return {Promise<String>} Keymap ID.
+   */
+  async getUIKeymap() {
+    const config = await this.client.get("/l10n/config");
+    return config.ui_locale;
+  }
+
+  /**
+   * Sets the keymap to use in the installer.
+   *
+   * This setting is only relevant in the local installation.
+   *
+   * @param {String} id - Keymap ID.
+   * @return {Promise<void>}
+   */
+  async setUIKeymap(id) {
+    return this.client.put("/l10n/config", { ui_keymap: id });
   }
 
   /**

--- a/web/src/client/software.js
+++ b/web/src/client/software.js
@@ -297,8 +297,62 @@ class SoftwareBaseClient {
  */
 class SoftwareClient extends WithIssues(
   WithProgress(
-    WithStatus(SoftwareBaseClient, SOFTWARE_PATH), SOFTWARE_PATH
-  ), SOFTWARE_PATH
-) { }
+    WithStatus(SoftwareBaseClient, SOFTWARE_PATH),
+    SOFTWARE_PATH,
+  ),
+  SOFTWARE_PATH,
+) {}
 
-export { SoftwareClient };
+class ProductClient {
+  /**
+   * @param {import("./http").HTTPClient} client - HTTP client.
+   */
+  constructor(client) {
+    this.client = client;
+  }
+
+  /**
+   * Returns the list of available products.
+   *
+   * @return {Promise<Array<Product>>}
+   */
+  async getAll() {
+    const products = await this.client.get("/software/products");
+    return products;
+  }
+
+  /**
+   * Returns the identifier of the selected product.
+   *
+   * @return {Promise<string>} Selected identifier.
+   */
+  async getSelected() {
+    const config = await this.client.get("/software/config");
+    return config.product;
+  }
+
+  /**
+   * Selects a product for installation.
+   *
+   * @param {string} id - Product ID.
+   */
+  async select(id) {
+    await this.client.put("/software/config", { product: id });
+  }
+
+  /**
+   * Registers a callback to run when the select product changes.
+   *
+   * @param {(id: string) => void} handler - Callback function.
+   * @return {import ("./http").RemoveFn} Function to remove the callback.
+   */
+  onChange(handler) {
+    return this.client.onEvent("ProductChanged", ({ id }) => {
+      if (id) {
+        handler(id);
+      }
+    });
+  }
+}
+
+export { ProductClient, SoftwareClient };

--- a/web/src/components/core/About.jsx
+++ b/web/src/components/core/About.jsx
@@ -27,7 +27,23 @@ import { Icon } from "~/components/layout";
 import { Popup } from "~/components/core";
 import { _ } from "~/i18n";
 
-export default function About() {
+/**
+ * Renders a button and a dialog to allow user read about what Agama is
+ * @component
+ *
+ * @param {object} props
+ * @param {boolean} [props.showIcon=true] - Whether render a "help" icon into the button.
+ * @param {string} [props.iconSize="s"] - The size for the button icon.
+ * @param {string} [props.buttonText="About Agama"] - The text for the button.
+ * @param {string} [props.buttonVariant="link"] - The button variant.
+ *   See {@link https://www.patternfly.org/components/button#variant-examples PF/Button}.
+ */
+export default function About({
+  showIcon = true,
+  iconSize = "s",
+  buttonText = _("About Agama"),
+  buttonVariant = "link"
+}) {
   const [isOpen, setIsOpen] = useState(false);
 
   const open = () => setIsOpen(true);
@@ -36,11 +52,11 @@ export default function About() {
   return (
     <>
       <Button
-        variant="link"
-        icon={<Icon name="help" size="s" />}
+        variant={buttonVariant}
+        icon={showIcon && <Icon name="help" size={iconSize} />}
         onClick={open}
       >
-        {_("About Agama")}
+        { buttonText }
       </Button>
 
       <Popup

--- a/web/src/components/core/About.jsx
+++ b/web/src/components/core/About.jsx
@@ -19,13 +19,18 @@
  * find current contact information at www.suse.com.
  */
 
+// @ts-check
+
 import React, { useState } from "react";
 import { Button, Text } from "@patternfly/react-core";
+import { _ } from "~/i18n";
 import { sprintf } from "sprintf-js";
-
 import { Icon } from "~/components/layout";
 import { Popup } from "~/components/core";
-import { _ } from "~/i18n";
+
+/**
+ * @typedef {import("@patternfly/react-core").ButtonProps} ButtonProps
+ */
 
 /**
  * Renders a button and a dialog to allow user read about what Agama is
@@ -35,7 +40,7 @@ import { _ } from "~/i18n";
  * @param {boolean} [props.showIcon=true] - Whether render a "help" icon into the button.
  * @param {string} [props.iconSize="s"] - The size for the button icon.
  * @param {string} [props.buttonText="About Agama"] - The text for the button.
- * @param {string} [props.buttonVariant="link"] - The button variant.
+ * @param {ButtonProps["variant"]} [props.buttonVariant="link"] - The button variant.
  *   See {@link https://www.patternfly.org/components/button#variant-examples PF/Button}.
  */
 export default function About({

--- a/web/src/components/core/About.test.jsx
+++ b/web/src/components/core/About.test.jsx
@@ -27,6 +27,35 @@ import { plainRender } from "~/test-utils";
 import About from "./About";
 
 describe("About", () => {
+  it("renders a help icon inside the button by default", () => {
+    const { container } = plainRender(<About />);
+    const icon = container.querySelector('svg');
+    expect(icon).toHaveAttribute("data-icon-name", "help");
+  });
+
+  it("does not render a help icon inside the button if showIcon=false", () => {
+    const { container } = plainRender(<About showIcon={false} />);
+    const icon = container.querySelector('svg');
+    expect(icon).toBeNull();
+  });
+
+  it("allows setting its icon size", () => {
+    const { container } = plainRender(<About iconSize="xxs" />);
+    const icon = container.querySelector('svg');
+    expect(icon.classList.contains("icon-xxs")).toBe(true);
+  });
+
+  it("allows setting its button text", () => {
+    plainRender(<About buttonText="What is this?"/>);
+    screen.getByRole("button", { name: "What is this?" });
+  });
+
+  it("allows setting its button variant", () => {
+    plainRender(<About buttonVariant="tertiary"/>);
+    const button = screen.getByRole("button", { name: "About Agama" });
+    expect(button.classList.contains("pf-m-tertiary")).toBe(true);
+  });
+
   it("allows user to read 'About Agama'", async () => {
     const { user } = plainRender(<About />);
 

--- a/web/src/components/core/About.test.jsx
+++ b/web/src/components/core/About.test.jsx
@@ -46,12 +46,12 @@ describe("About", () => {
   });
 
   it("allows setting its button text", () => {
-    plainRender(<About buttonText="What is this?"/>);
+    plainRender(<About buttonText="What is this?" />);
     screen.getByRole("button", { name: "What is this?" });
   });
 
   it("allows setting its button variant", () => {
-    plainRender(<About buttonVariant="tertiary"/>);
+    plainRender(<About buttonVariant="tertiary" />);
     const button = screen.getByRole("button", { name: "About Agama" });
     expect(button.classList.contains("pf-m-tertiary")).toBe(true);
   });

--- a/web/src/components/core/If.jsx
+++ b/web/src/components/core/If.jsx
@@ -59,7 +59,7 @@
  *   ...
  *
  * @param {object} props
- * @param {boolean} props.condition
+ * @param {truthy} props.condition
  * @param {JSX.Element} [props.then=null] - the content to be rendered when the condition is true
  * @param {JSX.Element} [props.else=null] - the content to be rendered when the condition is false
  */

--- a/web/src/components/core/If.jsx
+++ b/web/src/components/core/If.jsx
@@ -59,7 +59,7 @@
  *   ...
  *
  * @param {object} props
- * @param {truthy} props.condition
+ * @param {any} props.condition
  * @param {JSX.Element} [props.then=null] - the content to be rendered when the condition is true
  * @param {JSX.Element} [props.else=null] - the content to be rendered when the condition is false
  */

--- a/web/src/components/core/LoginPage.jsx
+++ b/web/src/components/core/LoginPage.jsx
@@ -40,18 +40,17 @@ import { Center } from "~/components/layout";
 /**
  * Renders the UI that lets the user log into the system.
  * @component
- *
  */
 export default function LoginPage() {
   const [password, setPassword] = useState("");
-  const { isAuthenticated, login: loginFn } = useAuth();
+  const { isLoggedIn, login: loginFn } = useAuth();
 
   const login = async (e) => {
     e.preventDefault();
     await loginFn(password);
   };
 
-  if (isAuthenticated) {
+  if (isLoggedIn) {
     return <Navigate to="/" />;
   }
 

--- a/web/src/components/core/LoginPage.jsx
+++ b/web/src/components/core/LoginPage.jsx
@@ -20,18 +20,26 @@
  */
 
 import React, { useState } from "react";
+import { Navigate } from "react-router-dom";
 import {
   ActionGroup,
   Button,
   Form,
   FormGroup,
-  TextInput,
 } from "@patternfly/react-core";
-import { Navigate } from "react-router-dom";
-import PasswordInput from "./PasswordInput";
+import { sprintf } from "sprintf-js";
 import { _ } from "~/i18n";
 import { useAuth } from "~/context/auth";
+import { About, Page, PasswordInput, Section } from "~/components/core";
+import { Center } from "~/components/layout";
 
+// @ts-check
+
+/**
+ * Renders the UI that lets the user log into the system.
+ * @component
+ *
+ */
 export default function LoginPage() {
   const [password, setPassword] = useState("");
   const { isAuthenticated, login: loginFn } = useAuth();
@@ -45,30 +53,45 @@ export default function LoginPage() {
     return <Navigate to="/" />;
   }
 
+  // TRANSLATORS: Title for a form to provide the password for the root user. %s
+  // will be replaced by "root"
+  const sectionTitle = sprintf(_("Login as %s"), "root");
   return (
-    <Form id="login" onSubmit={login}>
-      <FormGroup fieldId="username">
-        <TextInput
-          id="username"
-          name="username"
-          label="Username"
-          value="root"
-          disabled
-        />
-      </FormGroup>
+    <Page mountSidebar={false} title="Agama">
+      <Center>
+        <Section title={sectionTitle}>
+          <p
+            dangerouslySetInnerHTML={{
+              __html: sprintf(
+                _("The installer requires %s user privileges. Please, provide its password to log into the system."),
+                "<b>root</b>"
+              )
+            }}
+          />
 
-      <FormGroup fieldId="password">
-        <PasswordInput
-          id="password"
-          name="password"
-          value={password}
-          onChange={(_, v) => setPassword(v)}
-        />
-      </FormGroup>
+          <Form id="login" onSubmit={login} aria-label={_("Login form")}>
+            <FormGroup fieldId="password">
+              <PasswordInput
+                id="password"
+                name="password"
+                value={password}
+                aria-label={_("Password input")}
+                onChange={(_, v) => setPassword(v)}
+              />
+            </FormGroup>
 
-      <ActionGroup>
-        <Button type="submit" variant="primary">{_("Log in")}</Button>
-      </ActionGroup>
-    </Form>
+            <ActionGroup>
+              <Button type="submit" variant="primary">
+                {_("Log in")}
+              </Button>
+            </ActionGroup>
+          </Form>
+        </Section>
+      </Center>
+
+      <Page.Actions>
+        <About showIcon={false} iconSize="xs" buttonText={_("What is this?")} buttonVariant="link" />
+      </Page.Actions>
+    </Page>
   );
 }

--- a/web/src/components/core/LoginPage.jsx
+++ b/web/src/components/core/LoginPage.jsx
@@ -19,6 +19,8 @@
  * find current contact information at www.suse.com.
  */
 
+// @ts-check
+
 import React, { useState } from "react";
 import { Navigate } from "react-router-dom";
 import {

--- a/web/src/components/core/LoginPage.jsx
+++ b/web/src/components/core/LoginPage.jsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState } from "react";
+import {
+  ActionGroup,
+  Button,
+  Form,
+  FormGroup,
+  TextInput,
+} from "@patternfly/react-core";
+import { Navigate } from "react-router-dom";
+import PasswordInput from "./PasswordInput";
+import { _ } from "~/i18n";
+import { useAuth } from "~/context/auth";
+
+export default function LoginPage() {
+  const [password, setPassword] = useState("");
+  const { isAuthenticated, login: loginFn } = useAuth();
+
+  const login = async (e) => {
+    e.preventDefault();
+    await loginFn(password);
+  };
+
+  if (isAuthenticated) {
+    return <Navigate to="/" />;
+  }
+
+  return (
+    <Form id="login" onSubmit={login}>
+      <FormGroup fieldId="username">
+        <TextInput
+          id="username"
+          name="username"
+          label="Username"
+          value="root"
+          disabled
+        />
+      </FormGroup>
+
+      <FormGroup fieldId="password">
+        <PasswordInput
+          id="password"
+          name="password"
+          value={password}
+          onChange={(_, v) => setPassword(v)}
+        />
+      </FormGroup>
+
+      <ActionGroup>
+        <Button type="submit" variant="primary">{_("Log in")}</Button>
+      </ActionGroup>
+    </Form>
+  );
+}

--- a/web/src/components/core/LoginPage.jsx
+++ b/web/src/components/core/LoginPage.jsx
@@ -64,6 +64,8 @@ export default function LoginPage() {
           <p
             dangerouslySetInnerHTML={{
               __html: sprintf(
+               // TRANSLATORS: An explanation about required privileges for login into the installer. %s
+               // will be replaced by "root"
                 _("The installer requires %s user privileges. Please, provide its password to log into the system."),
                 "<b>root</b>"
               )

--- a/web/src/components/core/LoginPage.test.jsx
+++ b/web/src/components/core/LoginPage.test.jsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen, within } from "@testing-library/react";
+import { plainRender } from "~/test-utils";
+import { LoginPage } from "~/components/core";
+
+let mockIsAuthenticated;
+const mockLoginFn = jest.fn();
+
+jest.mock("~/context/auth", () => ({
+  ...jest.requireActual("~/context/auth"),
+  useAuth: () => {
+    return {
+      isAuthenticated: mockIsAuthenticated,
+      login: mockLoginFn
+    };
+  }
+}));
+
+describe("LoginPage", () => {
+  beforeAll(() => {
+    mockIsAuthenticated = false;
+    jest.spyOn(console, "error").mockImplementation();
+  });
+
+  afterAll(() => {
+    console.error.mockRestore();
+  });
+
+  describe("when user is not authenticated", () => {
+    it("renders reference to root", () => {
+      plainRender(<LoginPage />);
+      screen.getAllByText(/root/);
+    });
+
+    it("allows entering a password", async () => {
+      const { user } = plainRender(<LoginPage />);
+      const form = screen.getByRole("form", { name: "Login form" });
+      const passwordInput = within(form).getByLabelText("Password input");
+      const loginButton = within(form).getByRole("button", { name: "Log in" });
+
+      await user.type(passwordInput, "s3cr3t");
+      await user.click(loginButton);
+
+      expect(mockLoginFn).toHaveBeenCalledWith("s3cr3t");
+    });
+
+    it("renders a button to know more about the project", async () => {
+      const { user } = plainRender(<LoginPage />);
+      const button = screen.getByRole("button", { name: "What is this?" });
+
+      await user.click(button);
+
+      const dialog = await screen.findByRole("dialog");
+      within(dialog).getByText(/About/);
+    });
+  });
+
+  describe("when user is already authenticated", () => {
+    beforeEach(() => {
+      mockIsAuthenticated = true;
+    });
+
+    it("redirects to root route", async () => {
+      plainRender(<LoginPage />);
+      // react-router-dom Navigate is mocked. See test-utils for more details.
+      await screen.findByText("Navigating to /");
+    });
+  });
+});

--- a/web/src/components/core/Page.jsx
+++ b/web/src/components/core/Page.jsx
@@ -19,15 +19,21 @@
  * find current contact information at www.suse.com.
  */
 
+// @ts-check
+
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@patternfly/react-core";
-
 import { _ } from "~/i18n";
 import { partition } from "~/utils";
 import { Icon } from "~/components/layout";
 import { If, PageMenu, Sidebar } from "~/components/core";
+// @ts-ignore
 import logoUrl from "~/assets/suse-horizontal-logo.svg";
+
+/**
+ * @typedef {import("@patternfly/react-core").ButtonProps} ButtonProps
+ */
 
 /**
  * Wrapper component for holding Page actions
@@ -37,8 +43,8 @@ import logoUrl from "~/assets/suse-horizontal-logo.svg";
  *
  * @see Page examples.
  *
- * @param {object} [props] - component props
- * @param {React.ReactNode} [props.children] - components to be rendered as actions
+ * @param {object} props - Component props.
+ * @param {React.ReactNode} props.children - Components to be rendered as actions.
  */
 const Actions = ({ children }) => <>{children}</>;
 
@@ -59,17 +65,20 @@ const Menu = PageMenu;
  *
  * @see Page examples.
  *
- * @param {object} [props] - Component props.
- * @param {function} [props.onClick] - Callback to be triggered when action is clicked.
- * @param {string} [props.navigateTo] - Route to navigate after triggering the onClick callback, if given.
- * @param {React.ReactNode} props.children - Content of the action.
- * @param {object} [props.props] - other props passed down to the internal PF/Button. See {@link https://www.patternfly.org/components/button/#button}.
+ * @typedef {object} ActionProps
+ * @property {string} [navigateTo]
+ *
+ * @typedef {ActionProps & ButtonProps} PageActionProps
+ *
+ * @param {PageActionProps} props
  */
-const Action = ({ navigateTo, onClick, children, ...props }) => {
+const Action = ({ navigateTo, children, ...props }) => {
   const navigate = useNavigate();
 
-  props.onClick = () => {
-    if (typeof onClick === "function") onClick();
+  const onClickFn = props.onClick;
+
+  props.onClick = (e) => {
+    if (typeof onClickFn === "function") onClickFn(e);
     if (navigateTo) navigate(navigateTo);
   };
 
@@ -153,7 +162,7 @@ const BackAction = () => {
  * @param {string} [props.title="Agama"] - The title for the page. By default it
  *   uses the name of the tool, do not mark it for translation.
  * @param {boolean} [props.mountSidebar=true] - Whether include the core/Sidebar component.
- * @param {JSX.Element} [props.children] - The page content.
+ * @param {JSX.Element[]} [props.children] - The page content.
  *
  */
 const Page = ({

--- a/web/src/components/core/Page.jsx
+++ b/web/src/components/core/Page.jsx
@@ -152,10 +152,16 @@ const BackAction = () => {
  * @param {string} [props.icon] - The icon for the page.
  * @param {string} [props.title="Agama"] - The title for the page. By default it
  *   uses the name of the tool, do not mark it for translation.
+ * @param {boolean} [props.mountSidebar=true] - Whether include the core/Sidebar component.
  * @param {JSX.Element} [props.children] - The page content.
  *
  */
-const Page = ({ icon, title = "Agama", children }) => {
+const Page = ({
+  icon,
+  title = "Agama",
+  mountSidebar = true,
+  children
+}) => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   /**
@@ -195,15 +201,20 @@ const Page = ({ icon, title = "Agama", children }) => {
         </h1>
         <div data-type="agama/header-actions">
           { menu }
-          <button
-            onClick={openSidebar}
-            className="plain-control"
-            aria-label={_("Show global options")}
-            aria-controls="global-options"
-            aria-expanded={sidebarOpen}
-          >
-            <Icon name="menu" />
-          </button>
+          <If
+            condition={mountSidebar}
+            then={
+              <button
+                onClick={openSidebar}
+                className="plain-control"
+                aria-label={_("Show global options")}
+                aria-controls="global-options"
+                aria-expanded={sidebarOpen}
+              >
+                <Icon name="menu" />
+              </button>
+            }
+          />
         </div>
       </header>
 
@@ -218,7 +229,10 @@ const Page = ({ icon, title = "Agama", children }) => {
         <img src={logoUrl} alt="Logo of SUSE" />
       </footer>
 
-      <Sidebar isOpen={sidebarOpen} onClose={closeSidebar} />
+      <If
+        condition={mountSidebar}
+        then={<Sidebar isOpen={sidebarOpen} onClose={closeSidebar} />}
+      />
     </div>
   );
 };

--- a/web/src/components/core/Page.test.jsx
+++ b/web/src/components/core/Page.test.jsx
@@ -120,13 +120,21 @@ describe("Page", () => {
     screen.getByRole("button", { name: "Back" });
   });
 
-  it("renders the Agama sidebar", async () => {
+  it("renders the Agama sidebar by default", async () => {
     const { user } = installerRender(<Page />, { withL10n: true });
-
     const openSidebarButton = screen.getByRole("button", { name: "Show global options" });
 
     await user.click(openSidebarButton);
+
     screen.getByRole("complementary", { name: /options/i });
+  });
+
+  it("does not render the Agama sidebar when mountSidebar=false", () => {
+    installerRender(<Page mountSidebar={false} />, { withL10n: true });
+    const openSidebarButton = screen.queryByRole("button", { name: "Show global options" });
+    const sidebar = screen.queryByRole("complementary", { name: /options/i, hidden: true });
+    expect(openSidebarButton).toBeNull();
+    expect(sidebar).toBeNull();
   });
 });
 

--- a/web/src/components/core/PasswordInput.jsx
+++ b/web/src/components/core/PasswordInput.jsx
@@ -19,24 +19,28 @@
  * find current contact information at www.suse.com.
  */
 
+// @ts-check
+
+import React, { useState } from "react";
+import { Button, InputGroup, TextInput } from "@patternfly/react-core";
+import { _ } from "~/i18n";
+import { Icon } from "~/components/layout";
+
+/**
+ * @typedef {import("@patternfly/react-core").TextInputProps} TextInputProps
+ *
+ * Props matching the {@link https://www.patternfly.org/components/forms/text-input PF/TextInput},
+ * except `type` that will be forced to 'password'.
+ * @typedef {Omit<TextInputProps, 'type'>} PasswordInputProps
+ */
+
 /**
  * Renders a password input field and a toggle button that can be used to reveal
  * and hide the password
  * @component
  *
- * @param {string} id - the identifier for the field.
- * @param {Object} props - props matching the {@link https://www.patternfly.org/components/forms/text-input PF/TextInput},
- *                         except `type` that will be ignored.
+ * @param {PasswordInputProps} props
  */
-import React, { useState } from "react";
-import {
-  Button,
-  InputGroup,
-  TextInput
-} from "@patternfly/react-core";
-import { Icon } from "~/components/layout";
-import { _ } from "~/i18n";
-
 export default function PasswordInput({ id, ...props }) {
   const [showPassword, setShowPassword] = useState(false);
   const visibilityIconName = showPassword ? "visibility_off" : "visibility";

--- a/web/src/components/core/Popup.jsx
+++ b/web/src/components/core/Popup.jsx
@@ -19,11 +19,18 @@
  * find current contact information at www.suse.com.
  */
 
+// @ts-check
+
 import React from "react";
 import { Button, Modal } from "@patternfly/react-core";
-
 import { _ } from "~/i18n";
 import { partition } from "~/utils";
+
+/**
+ * @typedef {import("@patternfly/react-core").ModalProps} ModalProps
+ * @typedef {import("@patternfly/react-core").ButtonProps} ButtonProps
+ * @typedef {Omit<ButtonProps, 'variant'>} ButtonWithoutVariantProps
+ */
 
 /**
  * Wrapper component for holding Popup actions
@@ -33,6 +40,7 @@ import { partition } from "~/utils";
  *
  * @see Popup examples.
  *
+ * @param {object} props
  * @param {React.ReactNode} [props.children] - a collection of Action components
  */
 const Actions = ({ children }) => <>{children}</>;
@@ -42,13 +50,10 @@ const Actions = ({ children }) => <>{children}</>;
  *
  * Built on top of {@link https://www.patternfly.org/components/button PF/Button}
  *
- * @see Popup examples.
- *
- * @param {React.ReactNode} props.children - content of the action
- * @param {object} [props] - PF/Button props, see {@link https://www.patternfly.org/components/button#props}
+ * @param {ButtonProps} props
  */
-const Action = ({ children, ...props }) => (
-  <Button { ...props }>
+const Action = ({ children, ...buttonProps }) => (
+  <Button { ...buttonProps }>
     {children}
   </Button>
 );
@@ -68,11 +73,10 @@ const Action = ({ children, ...props }) => (
  *     <Text>Upload</Text>
  *   </PrimaryAction>
  *
- * @param {React.ReactNode} props.children - content of the action
- * @param {object} [props] - {@link Action} props
+ * @param {ButtonWithoutVariantProps} props
  */
-const PrimaryAction = ({ children, ...props }) => (
-  <Action { ...props } variant="primary">{ children }</Action>
+const PrimaryAction = ({ children, ...actionProps }) => (
+  <Action { ...actionProps } variant="primary">{ children }</Action>
 );
 
 /**
@@ -84,11 +88,10 @@ const PrimaryAction = ({ children, ...props }) => (
  * @example <caption>Using it with a custom text</caption>
  *   <Confirm onClick={accept}>Accept</Confirm>
  *
- * @param {React.ReactNode} [props.children="confirm"] - content of the action
- * @param {object} [props] - {@link Action} props
+ * @param {ButtonWithoutVariantProps} props
  */
-const Confirm = ({ children = _("Confirm"), ...props }) => (
-  <PrimaryAction key="confirm" { ...props }>{ children }</PrimaryAction>
+const Confirm = ({ children = _("Confirm"), ...actionProps }) => (
+  <PrimaryAction key="confirm" { ...actionProps }>{ children }</PrimaryAction>
 );
 
 /**
@@ -106,11 +109,10 @@ const Confirm = ({ children = _("Confirm"), ...props }) => (
  *     <Text>Dismiss</Text>
  *   </SecondaryAction>
  *
- * @param {React.ReactNode} props.children - content of the action
- * @param {object} [props] - {@link Action} props
+ * @param {ButtonWithoutVariantProps} props
  */
-const SecondaryAction = ({ children, ...props }) => (
-  <Action { ...props } variant="secondary">{ children }</Action>
+const SecondaryAction = ({ children, ...actionProps }) => (
+  <Action { ...actionProps } variant="secondary">{ children }</Action>
 );
 
 /**
@@ -122,11 +124,10 @@ const SecondaryAction = ({ children, ...props }) => (
  * @example <caption>Using it with a custom text</caption>
  *   <Cancel onClick={dismiss}>Dismiss</Confirm>
  *
- * @param {React.ReactNode} [props.children="Cancel"] - content of the action
- * @param {object} [props] - {@link Action} props
+ * @param {ButtonWithoutVariantProps} props
  */
-const Cancel = ({ children = _("Cancel"), ...props }) => (
-  <SecondaryAction key="cancel" { ...props }>{ children }</SecondaryAction>
+const Cancel = ({ children = _("Cancel"), ...actionProps }) => (
+  <SecondaryAction key="cancel" { ...actionProps }>{ children }</SecondaryAction>
 );
 
 /**
@@ -144,11 +145,10 @@ const Cancel = ({ children = _("Cancel"), ...props }) => (
  *     <Text>Do not set</Text>
  *   </AncillaryAction>
  *
- * @param {React.ReactNode} props.children - content of the action
- * @param {object} [props] - {@link Action} props
+ * @param {ButtonWithoutVariantProps} props
  */
-const AncillaryAction = ({ children, ...props }) => (
-  <Action { ...props } variant="link">{ children }</Action>
+const AncillaryAction = ({ children, ...actionsProps }) => (
+  <Action { ...actionsProps } variant="link">{ children }</Action>
 );
 
 /**
@@ -187,13 +187,7 @@ const AncillaryAction = ({ children, ...props }) => (
  *     </Popup.Actions>
  *   </Popup>
  *
- * @param {object} props - component props
- * @param {boolean} [props.isOpen=false] - whether the popup is displayed or not
- * @param {boolean} [props.showClose=false] - whether the popup should include a "X" action for closing it
- * @param {string} [props.variant="small"] - the popup size, based on PF/Modal `variant` prop
- * @param {React.ReactNode} props.children - the popup content and actions
- * @param {object} [pfModalProps] - PF/Modal props, See {@link https://www.patternfly.org/components/modal#props}
- *
+ * @param {ModalProps} props
  */
 const Popup = ({
   isOpen = false,
@@ -205,6 +199,7 @@ const Popup = ({
   const [actions, content] = partition(React.Children.toArray(children), child => child.type === Actions);
 
   return (
+    /** @ts-ignore */
     <Modal
       { ...pfModalProps }
       isOpen={isOpen}

--- a/web/src/components/core/Section.jsx
+++ b/web/src/components/core/Section.jsx
@@ -56,7 +56,7 @@ import { If, ValidationErrors } from "~/components/core";
  * @property {string} [className] - Class name for section html tag.
  * @property {string} [id] - Id of the section ("software", "product", "storage", "storage-actions", ...)
  * @property {import("~/client/mixins").ValidationError[]} [props.errors] - Validation errors to be shown before the title.
- * @property {React.ReactElement} [children] - The section content.
+ * @property {JSX.Element[]} [children] - The section content.
  * @property {string} [aria-label] - aria-label attribute, required if title if not given
  *
  * @param { SectionProps } props

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -40,10 +40,14 @@ import useNodeSiblings from "~/hooks/useNodeSiblings";
  *
  * A component intended for placing things exclusively related to Agama.
  *
- * @param {object} props
- * @param {React.ReactElement} props.children
+ * @typedef {object} SidebarProps
+ * @property {boolean} [isOpen] - Whether the sidebar is open or not.
+ * @property {() => void} [onClose] - A callback to be called when sidebar is closed.
+ * @property {React.ReactNode} [props.children]
+ *
+ * @param {SidebarProps}
  */
-export default function Sidebar ({ children, isOpen, onClose = noop }) {
+export default function Sidebar ({ isOpen, onClose = noop, children }) {
   const asideRef = useRef(null);
   const closeButtonRef = useRef(null);
   const [addAttribute, removeAttribute] = useNodeSiblings(asideRef.current);

--- a/web/src/components/core/index.js
+++ b/web/src/components/core/index.js
@@ -39,6 +39,7 @@ export { default as InstallButton } from "./InstallButton";
 export { default as IssuesDialog } from "./IssuesDialog";
 export { default as SectionSkeleton } from "./SectionSkeleton";
 export { default as ListSearch } from "./ListSearch";
+export { default as LoginPage } from "./LoginPage";
 export { default as LogsButton } from "./LogsButton";
 export { default as FileViewer } from "./FileViewer";
 export { default as RowActions } from "./RowActions";

--- a/web/src/components/layout/Center.jsx
+++ b/web/src/components/layout/Center.jsx
@@ -19,6 +19,8 @@
  * find current contact information at www.suse.com.
  */
 
+// @ts-check
+
 import React from "react";
 
 /**
@@ -42,7 +44,8 @@ import React from "react";
  *     - https://www.w3.org/TR/selectors-4/#relational
  *     - https://ishadeed.com/article/css-has-parent-selector/
  *
- * @param {React.ReactNode} [props.children]
+ * @param {object} props
+ * @param {React.ReactNode} props.children
  */
 const Center = ({ children }) => (
   <div className="vertically-centered">

--- a/web/src/components/product/ProductSelectionPage.jsx
+++ b/web/src/components/product/ProductSelectionPage.jsx
@@ -31,7 +31,7 @@ import { useInstallerClient } from "~/context/installer";
 import { useProduct } from "~/context/product";
 
 function ProductSelectionPage() {
-  const { manager, software } = useInstallerClient();
+  const { manager, product } = useInstallerClient();
   const navigate = useNavigate();
   const { products, selectedProduct } = useProduct();
   const [newProductId, setNewProductId] = useState(selectedProduct?.id);
@@ -39,16 +39,17 @@ function ProductSelectionPage() {
   useEffect(() => {
     // TODO: display a notification in the UI to emphasizes that
     // selected product has changed
-    return software.product.onChange(() => navigate("/"));
-  }, [software, navigate]);
+    return product.onChange(() => navigate("/"));
+  }, [product, navigate]);
 
   const onSubmit = async (e) => {
     e.preventDefault();
 
     if (newProductId !== selectedProduct?.id) {
       // TODO: handle errors
-      await software.product.select(newProductId);
-      manager.startProbing();
+      await product.select(newProductId);
+      // FIXME: adapt to the new API
+      // manager.startProbing();
     }
 
     navigate("/");

--- a/web/src/context/app.jsx
+++ b/web/src/context/app.jsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// @ts-check
+
+import React from "react";
+import { InstallerL10nProvider } from "./installerL10n";
+import { L10nProvider } from "./l10n";
+import { ProductProvider } from "./product";
+
+/**
+ * Combines all application providers.
+ *
+ * @param {object} props
+ * @param {React.ReactNode} [props.children] - content to display within the provider.
+ */
+function AppProviders({ children }) {
+  return (
+    <InstallerL10nProvider>
+      <L10nProvider>
+        <ProductProvider>
+          {children}
+        </ProductProvider>
+      </L10nProvider>
+    </InstallerL10nProvider>
+  );
+}
+
+export {
+  AppProviders
+};

--- a/web/src/context/app.jsx
+++ b/web/src/context/app.jsx
@@ -22,6 +22,7 @@
 // @ts-check
 
 import React from "react";
+import { InstallerClientProvider } from "./installer";
 import { InstallerL10nProvider } from "./installerL10n";
 import { L10nProvider } from "./l10n";
 import { ProductProvider } from "./product";
@@ -34,16 +35,16 @@ import { ProductProvider } from "./product";
  */
 function AppProviders({ children }) {
   return (
-    <InstallerL10nProvider>
-      <L10nProvider>
-        <ProductProvider>
-          {children}
-        </ProductProvider>
-      </L10nProvider>
-    </InstallerL10nProvider>
+    <InstallerClientProvider>
+      <InstallerL10nProvider>
+        <L10nProvider>
+          <ProductProvider>
+            {children}
+          </ProductProvider>
+        </L10nProvider>
+      </InstallerL10nProvider>
+    </InstallerClientProvider>
   );
 }
 
-export {
-  AppProviders
-};
+export { AppProviders };

--- a/web/src/context/auth.jsx
+++ b/web/src/context/auth.jsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// @ts-check
+
+import React, { useCallback, useEffect, useState } from "react";
+
+const AuthContext = React.createContext(null);
+
+/**
+ * Returns the authentication functions
+ */
+function useAuth() {
+  const context = React.useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error("useAuth must be used within a AuthProvider");
+  }
+
+  return context;
+}
+
+/**
+ * @param {object} props
+ * @param {React.ReactNode} [props.children] - content to display within the provider
+ */
+function AuthProvider({ children }) {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  const login = useCallback(async (password) => {
+    const response = await fetch("/api/authenticate", {
+      method: "POST",
+      body: JSON.stringify({ password }),
+      headers: { "Content-Type": "application/json" },
+    });
+    setIsAuthenticated(response.status === 200);
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/authenticate", {
+      headers: { "Content-Type": "application/json" },
+    })
+      .then((response) => {
+        setIsAuthenticated(response.status === 200);
+      })
+      .catch(() => setIsAuthenticated(false));
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ login, isAuthenticated }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export { AuthProvider, useAuth };

--- a/web/src/context/auth.jsx
+++ b/web/src/context/auth.jsx
@@ -42,29 +42,36 @@ function useAuth() {
  * @param {React.ReactNode} [props.children] - content to display within the provider
  */
 function AuthProvider({ children }) {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   const login = useCallback(async (password) => {
-    const response = await fetch("/api/authenticate", {
+    const response = await fetch("/api/auth", {
       method: "POST",
       body: JSON.stringify({ password }),
       headers: { "Content-Type": "application/json" },
     });
-    setIsAuthenticated(response.status === 200);
+    setIsLoggedIn(response.status === 200);
+  }, []);
+
+  const logout = useCallback(async () => {
+    await fetch("/api/auth", {
+      method: "DELETE",
+    });
+    setIsLoggedIn(false);
   }, []);
 
   useEffect(() => {
-    fetch("/api/authenticate", {
+    fetch("/api/auth", {
       headers: { "Content-Type": "application/json" },
     })
       .then((response) => {
-        setIsAuthenticated(response.status === 200);
+        setIsLoggedIn(response.status === 200);
       })
-      .catch(() => setIsAuthenticated(false));
+      .catch(() => setIsLoggedIn(false));
   }, []);
 
   return (
-    <AuthContext.Provider value={{ login, isAuthenticated }}>
+    <AuthContext.Provider value={{ login, logout, isLoggedIn }}>
       {children}
     </AuthContext.Provider>
   );

--- a/web/src/context/installerL10n.jsx
+++ b/web/src/context/installerL10n.jsx
@@ -184,17 +184,6 @@ function reload(newLanguage) {
 }
 
 /**
- * Extracts the keymap from the `setxkbmap -query` output.
- *
- * @param {string} output
- * @returns {string|undefined}
- */
-function keymapFromX(output) {
-  const matcher = /^layout:\s+(\S.*)$/m;
-  return matcher.exec(output)?.at(1);
-}
-
-/**
  * This provider sets the installer locale. By default, it uses the URL "lang" query parameter or
  * the preferred locale from the browser and synchronizes the UI and the backend locales. To
  * activate a new locale it reloads the whole page.
@@ -258,13 +247,11 @@ function InstallerL10nProvider({ children }) {
   }, [storeInstallerLanguage, setLanguage]);
 
   const changeKeymap = useCallback(async (id) => {
+    if (!client) return;
+
     setKeymap(id);
-    // write the config to file (/etc/X11/xorg.conf.d/00-keyboard.conf),
-    // this also sets the console keyboard!
-    await cockpit.spawn(["localectl", "set-x11-keymap", id]);
-    // set the current X11 keyboard
-    await cockpit.spawn(["setxkbmap", id], { environ: ["DISPLAY=:0"] });
-  }, [setKeymap]);
+    client.l10n.setUIKeymap(id);
+  }, [setKeymap, client]);
 
   useEffect(() => {
     if (!language) changeLanguage();
@@ -278,8 +265,9 @@ function InstallerL10nProvider({ children }) {
   }, [client, language, backendPending, storeInstallerLanguage]);
 
   useEffect(() => {
-    cockpit.spawn(["setxkbmap", "-query"], { environ: ["DISPLAY=:0"] }).then(output => setKeymap(keymapFromX(output)));
-  }, [setKeymap]);
+    if (!client) return;
+    client.l10n.getUIKeymap().then(setKeymap);
+  }, [setKeymap, client]);
 
   const value = { language, changeLanguage, keymap, changeKeymap };
 

--- a/web/src/context/product.jsx
+++ b/web/src/context/product.jsx
@@ -39,13 +39,13 @@ function ProductProvider({ children }) {
 
   useEffect(() => {
     const load = async () => {
-      const productManager = client.software.product;
-      const available = await cancellablePromise(productManager.getAll());
-      const selected = await cancellablePromise(productManager.getSelected());
-      const registration = await cancellablePromise(productManager.getRegistration());
+      const productClient = client.product;
+      const available = await cancellablePromise(productClient.getAll());
+      const selected = await cancellablePromise(productClient.getSelected());
+      // const registration = await cancellablePromise(productManager.getRegistration());
       setProducts(available);
-      setSelectedId(selected?.id || null);
-      setRegistration(registration);
+      setSelectedId(selected);
+      // setRegistration(registration);
     };
 
     if (client) {
@@ -53,17 +53,17 @@ function ProductProvider({ children }) {
     }
   }, [client, setProducts, setSelectedId, setRegistration, cancellablePromise]);
 
-  useEffect(() => {
-    if (!client) return;
+  // useEffect(() => {
+  //   if (!client) return;
 
-    return client.software.product.onChange(setSelectedId);
-  }, [client, setSelectedId]);
+  //   return client.software.product.onChange(setSelectedId);
+  // }, [client, setSelectedId]);
 
-  useEffect(() => {
-    if (!client) return;
+  // useEffect(() => {
+  //   if (!client) return;
 
-    return client.software.product.onRegistrationChange(setRegistration);
-  }, [client, setRegistration]);
+  //   return client.software.product.onRegistrationChange(setRegistration);
+  // }, [client, setRegistration]);
 
   const value = { products, selectedId, registration };
   return <ProductContext.Provider value={value}>{children}</ProductContext.Provider>;

--- a/web/src/context/root.jsx
+++ b/web/src/context/root.jsx
@@ -22,7 +22,6 @@
 // @ts-check
 
 import React from "react";
-import { InstallerClientProvider } from "./installer";
 import { AuthProvider } from "./auth";
 
 /**
@@ -33,14 +32,10 @@ import { AuthProvider } from "./auth";
  */
 function RootProviders({ children }) {
   return (
-    <InstallerClientProvider>
-      <AuthProvider>
-        {children}
-      </AuthProvider>
-    </InstallerClientProvider>
+    <AuthProvider>
+      {children}
+    </AuthProvider>
   );
 }
 
-export {
-  RootProviders
-};
+export { RootProviders };

--- a/web/src/context/root.jsx
+++ b/web/src/context/root.jsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// @ts-check
+
+import React from "react";
+import { InstallerClientProvider } from "./installer";
+import { AuthProvider } from "./auth";
+
+/**
+ * Combines all application providers.
+ *
+ * @param {object} props
+ * @param {React.ReactNode} [props.children] - content to display within the provider.
+ */
+function RootProviders({ children }) {
+  return (
+    <InstallerClientProvider>
+      <AuthProvider>
+        {children}
+      </AuthProvider>
+    </InstallerClientProvider>
+  );
+}
+
+export {
+  RootProviders
+};

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -23,7 +23,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 
 import { HashRouter, Routes, Route } from "react-router-dom";
-import { AgamaProviders } from "~/context/agama";
+import { RootProviders } from "~/context/root";
 
 /**
  * Import PF base styles before any JSX since components coming from PF may
@@ -33,12 +33,14 @@ import "@patternfly/patternfly/patternfly-base.scss";
 
 import App from "~/App";
 import Main from "~/Main";
+import Protected from "~/Protected";
 import { OverviewPage } from "~/components/overview";
 import { ProductPage, ProductSelectionPage } from "~/components/product";
 import { SoftwarePage } from "~/components/software";
 import { ProposalPage as StoragePage, ISCSIPage, DASDPage, ZFCPPage } from "~/components/storage";
 import { UsersPage } from "~/components/users";
 import { L10nPage } from "~/components/l10n";
+import { LoginPage } from "./components/core";
 import { NetworkPage } from "~/components/network";
 
 /**
@@ -57,26 +59,29 @@ const container = document.getElementById("root");
 const root = createRoot(container);
 
 root.render(
-  <AgamaProviders>
+  <RootProviders>
     <HashRouter>
       <Routes>
-        <Route path="/" element={<App />}>
-          <Route path="/" element={<Main />}>
-            <Route index element={<OverviewPage />} />
-            <Route path="/overview" element={<OverviewPage />} />
-            <Route path="/product" element={<ProductPage />} />
-            <Route path="/l10n" element={<L10nPage />} />
-            <Route path="/software" element={<SoftwarePage />} />
-            <Route path="/storage" element={<StoragePage />} />
-            <Route path="/storage/iscsi" element={<ISCSIPage />} />
-            <Route path="/storage/dasd" element={<DASDPage />} />
-            <Route path="/storage/zfcp" element={<ZFCPPage />} />
-            <Route path="/network" element={<NetworkPage />} />
-            <Route path="/users" element={<UsersPage />} />
+        <Route path="/login" exact element={<LoginPage />} />
+        <Route path="/" element={<Protected />}>
+          <Route path="/" element={<App />}>
+            <Route path="/" element={<Main />}>
+              <Route index element={<OverviewPage />} />
+              <Route path="/overview" element={<OverviewPage />} />
+              <Route path="/product" element={<ProductPage />} />
+              <Route path="/l10n" element={<L10nPage />} />
+              <Route path="/software" element={<SoftwarePage />} />
+              <Route path="/storage" element={<StoragePage />} />
+              <Route path="/storage/iscsi" element={<ISCSIPage />} />
+              <Route path="/storage/dasd" element={<DASDPage />} />
+              <Route path="/storage/zfcp" element={<ZFCPPage />} />
+              <Route path="/network" element={<NetworkPage />} />
+              <Route path="/users" element={<UsersPage />} />
+            </Route>
+            <Route path="products" element={<ProductSelectionPage />} />
           </Route>
-          <Route path="products" element={<ProductSelectionPage />} />
         </Route>
       </Routes>
     </HashRouter>
-  </AgamaProviders>
+  </RootProviders>
 );

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -104,10 +104,15 @@ module.exports = {
       //   selfHandleResponse : true,
       //   onProxyRes: manifests_handler,
       // },
+      "/api/ws": {
+        target: agamaServer.replace(/^http/, "ws"),
+        ws: true,
+        secure: false,
+      },
       "/api": {
         target: agamaServer,
         secure: false,
-      }
+      },
     },
     server: "http",
     // hot replacement does not support wss:// transport when running over https://,


### PR DESCRIPTION
This pull request aims to adapt the web UI to start using the new `agama-server`.

The user should be able to:

* Log in the new `agama-server` (using the root password).
* Find the list of existing products and allow the user to select one.

To make it possible to reach the product selection list, several things need to be adapted.

## Screenshots

Although texts still need a review, you can get an idea of how it looks with the following screenshots.

![Screenshot 2024-03-08 at 06-18-09 Agama](https://github.com/openSUSE/agama/assets/15836/1e6d295f-8942-4986-9112-a07ebc6c0624)

![Screenshot 2024-03-08 at 06-17-39 Agama](https://github.com/openSUSE/agama/assets/15836/0bbf02f7-baaa-4d2c-b737-743a4be56054)
