### PR TITLE
Expose the manager service through the HTTP/JSON API

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-test",
  "tower",
  "tower-http",
  "tracing",
@@ -383,6 +384,28 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3036,6 +3059,19 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89b3cbabd3ae862100094ae433e1def582cf86451b4e9bf83aa7ac1d8a7d719"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/rust/agama-lib/src/error.rs
+++ b/rust/agama-lib/src/error.rs
@@ -22,6 +22,8 @@ pub enum ServiceError {
     UnknownPatterns(Vec<String>),
     #[error("Could not perform action '{0}'")]
     UnsuccessfulAction(String),
+    #[error("Unknown installation phase: '{0}")]
+    UnknownInstallationPhase(u32),
 }
 
 #[derive(Error, Debug)]

--- a/rust/agama-lib/src/manager.rs
+++ b/rust/agama-lib/src/manager.rs
@@ -83,6 +83,11 @@ impl<'a> ManagerClient<'a> {
         Ok(self.manager_proxy.can_install().await?)
     }
 
+    /// Determines whether the installer is running on Iguana.
+    pub async fn use_iguana(&self) -> Result<bool, ServiceError> {
+        Ok(self.manager_proxy.iguana_backend().await?)
+    }
+
     /// Returns the current progress.
     pub async fn progress(&self) -> zbus::Result<Progress> {
         Progress::from_proxy(&self.progress_proxy).await

--- a/rust/agama-lib/src/manager.rs
+++ b/rust/agama-lib/src/manager.rs
@@ -23,23 +23,28 @@ impl<'a> ManagerClient<'a> {
         })
     }
 
+    /// Returns the list of busy services.
     pub async fn busy_services(&self) -> Result<Vec<String>, ServiceError> {
         Ok(self.manager_proxy.busy_services().await?)
     }
 
+    /// Starts the probing process.
     pub async fn probe(&self) -> Result<(), ServiceError> {
         self.wait().await?;
         Ok(self.manager_proxy.probe().await?)
     }
 
+    /// Starts the installation.
     pub async fn install(&self) -> Result<(), ServiceError> {
         Ok(self.manager_proxy.commit().await?)
     }
 
+    /// Determines whether it is possible to start the installation.
     pub async fn can_install(&self) -> Result<bool, ServiceError> {
         Ok(self.manager_proxy.can_install().await?)
     }
 
+    /// Returns the current progress.
     pub async fn progress(&self) -> zbus::Result<Progress> {
         Progress::from_proxy(&self.progress_proxy).await
     }

--- a/rust/agama-lib/src/manager.rs
+++ b/rust/agama-lib/src/manager.rs
@@ -1,3 +1,5 @@
+//! This module implements the web API for the manager module.
+
 use crate::error::ServiceError;
 use crate::proxies::ServiceStatusProxy;
 use crate::{
@@ -17,7 +19,7 @@ pub struct ManagerClient<'a> {
 }
 
 /// Represents the installation phase.
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub enum InstallationPhase {
     /// Start up phase.
     Startup,

--- a/rust/agama-lib/src/manager.rs
+++ b/rust/agama-lib/src/manager.rs
@@ -4,7 +4,7 @@ use crate::error::ServiceError;
 use crate::proxies::ServiceStatusProxy;
 use crate::{
     progress::Progress,
-    proxies::{ManagerProxy, ProgressProxy},
+    proxies::{Manager1Proxy, ProgressProxy},
 };
 use serde::Serialize;
 use tokio_stream::StreamExt;
@@ -13,7 +13,7 @@ use zbus::Connection;
 /// D-Bus client for the manager service
 #[derive(Clone)]
 pub struct ManagerClient<'a> {
-    manager_proxy: ManagerProxy<'a>,
+    manager_proxy: Manager1Proxy<'a>,
     progress_proxy: ProgressProxy<'a>,
     status_proxy: ServiceStatusProxy<'a>,
 }
@@ -45,7 +45,7 @@ impl TryFrom<u32> for InstallationPhase {
 impl<'a> ManagerClient<'a> {
     pub async fn new(connection: Connection) -> zbus::Result<ManagerClient<'a>> {
         Ok(Self {
-            manager_proxy: ManagerProxy::new(&connection).await?,
+            manager_proxy: Manager1Proxy::new(&connection).await?,
             progress_proxy: ProgressProxy::new(&connection).await?,
             status_proxy: ServiceStatusProxy::new(&connection).await?,
         })

--- a/rust/agama-lib/src/manager.rs
+++ b/rust/agama-lib/src/manager.rs
@@ -19,7 +19,7 @@ pub struct ManagerClient<'a> {
 }
 
 /// Represents the installation phase.
-#[derive(Serialize, utoipa::ToSchema)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, utoipa::ToSchema)]
 pub enum InstallationPhase {
     /// Start up phase.
     Startup,

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -47,12 +47,12 @@ trait ServiceStatus {
     default_service = "org.opensuse.Agama.Manager1",
     default_path = "/org/opensuse/Agama/Manager1"
 )]
-trait Manager {
+trait Manager1 {
     /// CanInstall method
     fn can_install(&self) -> zbus::Result<bool>;
 
     /// CollectLogs method
-    fn collect_logs(&self, user: &str) -> zbus::Result<String>;
+    fn collect_logs(&self) -> zbus::Result<String>;
 
     /// Commit method
     fn commit(&self) -> zbus::Result<()>;
@@ -70,6 +70,10 @@ trait Manager {
     /// CurrentInstallationPhase property
     #[dbus_proxy(property)]
     fn current_installation_phase(&self) -> zbus::Result<u32>;
+
+    /// IguanaBackend property
+    #[dbus_proxy(property)]
+    fn iguana_backend(&self) -> zbus::Result<bool>;
 
     /// InstallationPhases property
     #[dbus_proxy(property)]

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -57,6 +57,9 @@ trait Manager {
     /// Commit method
     fn commit(&self) -> zbus::Result<()>;
 
+    /// Finish method
+    fn finish(&self) -> zbus::Result<()>;
+
     /// Probe method
     fn probe(&self) -> zbus::Result<()>;
 

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -59,3 +59,4 @@ path = "src/agama-web-server.rs"
 
 [dev-dependencies]
 http-body-util = "0.1.0"
+tokio-test = "0.4.3"

--- a/rust/agama-server/src/l10n/web.rs
+++ b/rust/agama-server/src/l10n/web.rs
@@ -79,7 +79,7 @@ async fn locales(State(state): State<LocaleState>) -> Json<Vec<LocaleEntry>> {
     Json(locales)
 }
 
-#[derive(Clone, Default, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct LocaleConfig {
     /// Locales to install in the target system
     locales: Option<Vec<String>>,

--- a/rust/agama-server/src/lib.rs
+++ b/rust/agama-server/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod l10n;
+pub mod manager;
 pub mod network;
 pub mod questions;
 pub mod software;

--- a/rust/agama-server/src/manager.rs
+++ b/rust/agama-server/src/manager.rs
@@ -1,0 +1,2 @@
+pub mod web;
+pub use web::manager_service;

--- a/rust/agama-server/src/manager/web.rs
+++ b/rust/agama-server/src/manager/web.rs
@@ -8,7 +8,7 @@
 use agama_lib::{
     error::ServiceError,
     manager::{InstallationPhase, ManagerClient},
-    proxies::ManagerProxy,
+    proxies::Manager1Proxy,
 };
 use axum::{
     extract::State,
@@ -66,7 +66,7 @@ pub async fn manager_stream(dbus: zbus::Connection) -> Result<impl Stream<Item =
 pub async fn busy_services_changed_stream(
     dbus: zbus::Connection,
 ) -> Result<impl Stream<Item = Event>, Error> {
-    let proxy = ManagerProxy::new(&dbus).await?;
+    let proxy = Manager1Proxy::new(&dbus).await?;
     let stream = proxy
         .receive_busy_services_changed()
         .await
@@ -86,7 +86,7 @@ pub async fn busy_services_changed_stream(
 pub async fn installation_phase_changed_stream(
     dbus: zbus::Connection,
 ) -> Result<impl Stream<Item = Event>, Error> {
-    let proxy = ManagerProxy::new(&dbus).await?;
+    let proxy = Manager1Proxy::new(&dbus).await?;
     let stream = proxy
         .receive_current_installation_phase_changed()
         .await

--- a/rust/agama-server/src/manager/web.rs
+++ b/rust/agama-server/src/manager/web.rs
@@ -1,0 +1,94 @@
+use agama_lib::{
+    error::ServiceError,
+    manager::{InstallationPhase, ManagerClient},
+};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use serde::Serialize;
+use serde_json::json;
+use thiserror::Error;
+
+#[derive(Clone)]
+pub struct ManagerState<'a> {
+    manager: ManagerClient<'a>,
+}
+
+#[derive(Error, Debug)]
+pub enum ManagerError {
+    #[error("Manager service error: {0}")]
+    Error(#[from] ServiceError),
+}
+
+impl IntoResponse for ManagerError {
+    fn into_response(self) -> Response {
+        let body = json!({});
+        (StatusCode::BAD_REQUEST, Json(body)).into_response()
+    }
+}
+
+/// Holds information about the manager's status.
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct ManagerStatus {
+    /// Current installation phase.
+    phase: InstallationPhase,
+    /// List of busy services.
+    busy: Vec<String>,
+}
+
+/// Sets up and returns the axum service for the manager module
+pub async fn manager_service(dbus: zbus::Connection) -> Result<Router, ServiceError> {
+    let manager = ManagerClient::new(dbus).await?;
+    let state = ManagerState { manager };
+    Ok(Router::new()
+        .route("/probe", post(probe_action))
+        .route("/install", post(install_action))
+        .route("/finish", post(finish_action))
+        .route("/status", get(status))
+        .with_state(state))
+}
+
+/// Starts the probing process.
+#[utoipa::path(get, path = "/api/manager/probe", responses(
+  (status = 200, description = "The probing process was started.")
+))]
+async fn probe_action(State(state): State<ManagerState<'_>>) -> Result<(), ManagerError> {
+    state.manager.probe().await?;
+    Ok(())
+}
+
+/// Starts the probing process.
+#[utoipa::path(get, path = "/api/manager/install", responses(
+  (status = 200, description = "The installation process was started.")
+))]
+async fn install_action(State(state): State<ManagerState<'_>>) -> Result<(), ManagerError> {
+    state.manager.install().await?;
+    Ok(())
+}
+
+/// Executes the post installation tasks (e.g., rebooting the system).
+#[utoipa::path(get, path = "/api/manager/install", responses(
+  (status = 200, description = "The installation tasks are executed.")
+))]
+async fn finish_action(State(state): State<ManagerState<'_>>) -> Result<(), ManagerError> {
+    state.manager.finish().await?;
+    Ok(())
+}
+
+/// Returns the manager status.
+#[utoipa::path(get, path = "/api/manager/status", responses(
+  (status = 200, description = "Manager status.", body = ManagerStatus)
+))]
+async fn status(
+    State(state): State<ManagerState<'_>>,
+) -> Result<Json<ManagerStatus>, ManagerError> {
+    let status = ManagerStatus {
+        phase: state.manager.current_installation_phase().await?,
+        busy: state.manager.busy_services().await?,
+    };
+    Ok(Json(status))
+}

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -1,4 +1,4 @@
-//! This module implements the web API for the software module.
+//! This module implements the web API for the software service.
 //!
 //! The module offers two public functions:
 //!
@@ -55,6 +55,8 @@ impl IntoResponse for SoftwareError {
 }
 
 /// Returns an stream that emits software related events coming from D-Bus.
+///
+/// It emits the Event::ProductChanged and Event::PatternsChanged events.
 ///
 /// * `connection`: D-Bus connection to listen for events.
 pub async fn software_stream(dbus: zbus::Connection) -> Result<impl Stream<Item = Event>, Error> {

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -8,6 +8,7 @@ use self::progress::EventsProgressPresenter;
 use crate::{
     error::Error,
     l10n::web::l10n_service,
+    manager::web::manager_service,
     software::web::{software_service, software_stream},
 };
 use axum::Router;
@@ -48,6 +49,7 @@ where
 {
     let router = MainServiceBuilder::new(events.clone(), web_ui_dir)
         .add_service("/l10n", l10n_service(events.clone()))
+        .add_service("/manager", manager_service(dbus.clone()).await?)
         .add_service("/software", software_service(dbus).await?)
         .with_config(config)
         .build();

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -14,6 +14,7 @@ use crate::{
 use axum::Router;
 
 mod auth;
+pub mod common;
 mod config;
 mod docs;
 mod event;

--- a/rust/agama-server/src/web/common.rs
+++ b/rust/agama-server/src/web/common.rs
@@ -1,0 +1,103 @@
+//! This module defines functions to be used accross all services.
+
+use agama_lib::{error::ServiceError, proxies::ServiceStatusProxy};
+use axum::{extract::State, routing::get, Json, Router};
+use serde::Serialize;
+use tokio_stream::{Stream, StreamExt};
+
+use crate::error::Error;
+
+use super::Event;
+
+/// Builds a router to the `org.opensuse.Agama1.ServiceStatus`
+/// interface of the given D-Bus object.
+///
+/// ```no_run
+/// # use axum::{extract::State, routing::get, Json, Router};
+/// # use agama_lib::connection;
+/// # use agama_server::web::common::service_status_router;
+/// # use tokio_test;
+///
+/// # tokio_test::block_on(async {
+/// async fn hello(state: State<HelloWorldState>) {};
+///
+/// #[derive(Clone)]
+/// struct HelloWorldState {};
+///
+/// let dbus = connection().await.unwrap();
+/// let status_router = service_status_router(
+///   &dbus, "org.opensuse.HelloWorld", "/org/opensuse/hello"
+/// ).await.unwrap();
+/// let router: Router<HelloWorldState> = Router::new()
+///   .route("/hello", get(hello))
+///   .merge(status_router)
+///   .with_state(HelloWorldState {});
+/// });
+/// ```
+///
+/// * `dbus`: D-Bus connection.
+/// * `destination`: D-Bus service name.
+/// * `path`: D-Bus object path.
+pub async fn service_status_router<T>(
+    dbus: &zbus::Connection,
+    destination: &str,
+    path: &str,
+) -> Result<Router<T>, ServiceError> {
+    let proxy = build_service_status_proxy(dbus, destination, path).await?;
+    let state = ServiceStatusState { proxy };
+    Ok(Router::new()
+        .route("/status", get(service_status))
+        .with_state(state))
+}
+
+async fn service_status(State(state): State<ServiceStatusState<'_>>) -> Json<ServiceStatus> {
+    Json(ServiceStatus {
+        current: state.proxy.current().await.unwrap(),
+    })
+}
+
+#[derive(Clone)]
+struct ServiceStatusState<'a> {
+    proxy: ServiceStatusProxy<'a>,
+}
+
+#[derive(Clone, Serialize)]
+struct ServiceStatus {
+    /// Current service status.
+    current: u32,
+}
+
+/// Builds a stream of the changes in the the `org.opensuse.Agama1.ServiceStatus`
+/// interface of the given D-Bus object.
+pub async fn service_status_stream(
+    dbus: zbus::Connection,
+    destination: &str,
+    path: &str,
+) -> Result<impl Stream<Item = Event>, Error> {
+    let proxy = build_service_status_proxy(&dbus, destination, path).await?;
+    let stream = proxy
+        .receive_current_changed()
+        .await
+        .then(|change| async move {
+            if let Ok(status) = change.get().await {
+                Some(Event::StatusChanged { status })
+            } else {
+                None
+            }
+        })
+        .filter_map(|e| e);
+    Ok(stream)
+}
+
+async fn build_service_status_proxy<'a>(
+    dbus: &zbus::Connection,
+    destination: &str,
+    path: &str,
+) -> Result<ServiceStatusProxy<'a>, zbus::Error> {
+    let proxy = ServiceStatusProxy::builder(&dbus)
+        .destination(destination.to_string())?
+        .path(path.to_string())?
+        .build()
+        .await?;
+    Ok(proxy)
+}

--- a/rust/agama-server/src/web/docs.rs
+++ b/rust/agama-server/src/web/docs.rs
@@ -13,11 +13,13 @@ use utoipa::OpenApi;
         crate::software::web::patterns,
         crate::software::web::patterns,
         crate::software::web::set_config,
+        crate::manager::web::probe_action,
         super::http::ping,
     ),
     components(
         schemas(agama_lib::product::Product),
         schemas(agama_lib::software::Pattern),
+        schemas(agama_lib::manager::InstallationPhase),
         schemas(crate::l10n::Keymap),
         schemas(crate::l10n::LocaleEntry),
         schemas(crate::l10n::TimezoneEntry),
@@ -25,6 +27,7 @@ use utoipa::OpenApi;
         schemas(crate::software::web::PatternEntry),
         schemas(crate::software::web::SoftwareConfig),
         schemas(crate::software::web::SoftwareProposal),
+        schemas(crate::manager::web::ManagerStatus),
         schemas(super::http::PingResponse),
     )
 )]

--- a/rust/agama-server/src/web/docs.rs
+++ b/rust/agama-server/src/web/docs.rs
@@ -15,7 +15,7 @@ use utoipa::OpenApi;
         crate::manager::web::probe_action,
         crate::manager::web::install_action,
         crate::manager::web::finish_action,
-        crate::manager::web::status,
+        crate::manager::web::installer_status,
         super::http::ping,
     ),
     components(

--- a/rust/agama-server/src/web/docs.rs
+++ b/rust/agama-server/src/web/docs.rs
@@ -14,6 +14,9 @@ use utoipa::OpenApi;
         crate::software::web::patterns,
         crate::software::web::set_config,
         crate::manager::web::probe_action,
+        crate::manager::web::install_action,
+        crate::manager::web::finish_action,
+        crate::manager::web::status,
         super::http::ping,
     ),
     components(

--- a/rust/agama-server/src/web/docs.rs
+++ b/rust/agama-server/src/web/docs.rs
@@ -30,7 +30,7 @@ use utoipa::OpenApi;
         schemas(crate::software::web::PatternEntry),
         schemas(crate::software::web::SoftwareConfig),
         schemas(crate::software::web::SoftwareProposal),
-        schemas(crate::manager::web::ManagerStatus),
+        schemas(crate::manager::web::InstallerStatus),
         schemas(super::http::PingResponse),
     )
 )]

--- a/rust/agama-server/src/web/docs.rs
+++ b/rust/agama-server/src/web/docs.rs
@@ -1,5 +1,4 @@
 use utoipa::OpenApi;
-
 #[derive(OpenApi)]
 #[openapi(
     info(description = "Agama web API description"),

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -14,6 +14,7 @@ pub enum Event {
     PatternsChanged(HashMap<String, SelectedBy>),
     InstallationPhaseChanged { phase: InstallationPhase },
     BusyServicesChanged { services: Vec<String> },
+    StatusChanged { status: u32 },
 }
 
 pub type EventsSender = Sender<Event>;

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -1,10 +1,10 @@
 use crate::l10n::web::LocaleConfig;
-use agama_lib::{progress::Progress, software::SelectedBy};
+use agama_lib::{manager::InstallationPhase, progress::Progress, software::SelectedBy};
 use serde::Serialize;
 use std::collections::HashMap;
 use tokio::sync::broadcast::{Receiver, Sender};
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(tag = "type")]
 pub enum Event {
     L10nConfigChanged(LocaleConfig),
@@ -12,6 +12,8 @@ pub enum Event {
     Progress(Progress),
     ProductChanged { id: String },
     PatternsChanged(HashMap<String, SelectedBy>),
+    InstallationPhaseChanged { phase: InstallationPhase },
+    BusyServicesChanged { services: Vec<String> },
 }
 
 pub type EventsSender = Sender<Event>;

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -14,7 +14,7 @@ pub enum Event {
     PatternsChanged(HashMap<String, SelectedBy>),
     InstallationPhaseChanged { phase: InstallationPhase },
     BusyServicesChanged { services: Vec<String> },
-    StatusChanged { status: u32 },
+    ServiceStatusChanged { service: String, status: u32 },
 }
 
 pub type EventsSender = Sender<Event>;


### PR DESCRIPTION
Trello: https://trello.com/c/Ff8n3NVZ/3563-5-expose-the-manager-api-over-http

This PR exposes most of the Manager API[^1] through the interface. It includes:

* `api/manager/probe`: starts the probing.
* `api/manager/install`: starts the installation.
* `api/manager/finish`: executes the post-install tasks.
* `api/manager/status`: expose the manager status`

```rust
{
  "phase": "Config",
  "busy": [
    "org.opensuse.Agama.Storage1"
  ]
}
```

Additionally, it emits two events: `BusyServicesChanged` and `InstallationPhaseChanged`.

[^1]: The part of the D-Bus API used by the web UI.

## To do

- [x] Before proceeding, we need to merge #1080.
- [ ] ~~Add a mechanism to get the logs~~ (postponed).
- [x] Add a `CanInstall` boolean to the manager status.