### PR TITLE
Adapt product selection and handling ofl10n settings with the HTTP/JSON server

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -64,6 +64,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "serde_repr",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2647,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
+checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -16,6 +16,7 @@ jsonschema = { version = "0.16.1", default-features = false }
 log = "0.4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.94"
+serde_repr = "0.1.18"
 tempfile = "3.4.0"
 thiserror = "1.0.39"
 tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }

--- a/rust/agama-lib/src/manager.rs
+++ b/rust/agama-lib/src/manager.rs
@@ -6,7 +6,7 @@ use crate::{
     progress::Progress,
     proxies::{Manager1Proxy, ProgressProxy},
 };
-use serde::Serialize;
+use serde_repr::Serialize_repr;
 use tokio_stream::StreamExt;
 use zbus::Connection;
 
@@ -19,7 +19,9 @@ pub struct ManagerClient<'a> {
 }
 
 /// Represents the installation phase.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, utoipa::ToSchema)]
+/// NOTE: does this conversion have any value?
+#[derive(Clone, Copy, Debug, PartialEq, Serialize_repr, utoipa::ToSchema)]
+#[repr(u32)]
 pub enum InstallationPhase {
     /// Start up phase.
     Startup,

--- a/rust/agama-locale-data/src/lib.rs
+++ b/rust/agama-locale-data/src/lib.rs
@@ -19,7 +19,7 @@ pub mod timezone_part;
 
 use keyboard::xkeyboard;
 
-pub use locale::{InvalidKeymap, InvalidLocaleCode, KeymapId, LocaleCode};
+pub use locale::{InvalidKeymap, InvalidLocaleCode, KeymapId, LocaleId};
 
 fn file_reader(file_path: &str) -> anyhow::Result<impl BufRead> {
     let file = File::open(file_path)

--- a/rust/agama-locale-data/src/locale.rs
+++ b/rust/agama-locale-data/src/locale.rs
@@ -7,7 +7,7 @@ use std::{fmt::Display, str::FromStr};
 use thiserror::Error;
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
-pub struct LocaleCode {
+pub struct LocaleId {
     // ISO-639
     pub language: String,
     // ISO-3166
@@ -15,7 +15,7 @@ pub struct LocaleCode {
     pub encoding: String,
 }
 
-impl Display for LocaleCode {
+impl Display for LocaleId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -25,7 +25,7 @@ impl Display for LocaleCode {
     }
 }
 
-impl Default for LocaleCode {
+impl Default for LocaleId {
     fn default() -> Self {
         Self {
             language: "en".to_string(),
@@ -39,7 +39,7 @@ impl Default for LocaleCode {
 #[error("Not a valid locale string: {0}")]
 pub struct InvalidLocaleCode(String);
 
-impl TryFrom<&str> for LocaleCode {
+impl TryFrom<&str> for LocaleId {
     type Error = InvalidLocaleCode;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {

--- a/rust/agama-server/src/l10n/helpers.rs
+++ b/rust/agama-server/src/l10n/helpers.rs
@@ -2,16 +2,16 @@
 //!
 //! FIXME: find a better place for the localization function
 
-use agama_locale_data::LocaleCode;
+use agama_locale_data::LocaleId;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use std::env;
 
 /// Initializes the service locale.
 ///
 /// It returns the used locale. Defaults to `en_US.UTF-8`.
-pub fn init_locale() -> Result<LocaleCode, Box<dyn std::error::Error>> {
+pub fn init_locale() -> Result<LocaleId, Box<dyn std::error::Error>> {
     let lang = env::var("LANG").unwrap_or("en_US.UTF-8".to_string());
-    let locale: LocaleCode = lang.as_str().try_into().unwrap_or_default();
+    let locale: LocaleId = lang.as_str().try_into().unwrap_or_default();
 
     set_service_locale(&locale);
     textdomain("xkeyboard-config")?;
@@ -21,7 +21,7 @@ pub fn init_locale() -> Result<LocaleCode, Box<dyn std::error::Error>> {
 
 /// Sets the service locale.
 ///
-pub fn set_service_locale(locale: &LocaleCode) {
+pub fn set_service_locale(locale: &LocaleId) {
     if setlocale(LocaleCategory::LcAll, locale.to_string()).is_none() {
         log::warn!("Could not set the locale");
     }

--- a/rust/agama-server/src/l10n/keyboard.rs
+++ b/rust/agama-server/src/l10n/keyboard.rs
@@ -1,12 +1,15 @@
 use agama_locale_data::{get_localectl_keymaps, keyboard::XkbConfigRegistry, KeymapId};
 use gettextrs::*;
 use serde::Serialize;
+use serde_with::{serde_as, DisplayFromStr};
 use std::collections::HashMap;
 
+#[serde_as]
 // Minimal representation of a keymap
 #[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
 pub struct Keymap {
     /// Keymap identifier (e.g., "us")
+    #[serde_as(as = "DisplayFromStr")]
     pub id: KeymapId,
     /// Keymap description
     description: String,

--- a/rust/agama-server/src/l10n/web.rs
+++ b/rust/agama-server/src/l10n/web.rs
@@ -6,7 +6,7 @@ use crate::{
     l10n::helpers,
     web::{Event, EventsSender},
 };
-use agama_locale_data::{InvalidKeymap, LocaleCode};
+use agama_locale_data::{InvalidKeymap, LocaleId};
 use axum::{
     extract::State,
     http::StatusCode,
@@ -55,8 +55,8 @@ struct LocaleState {
 ///
 /// * `events`: channel to send the events to the main service.
 pub fn l10n_service(events: EventsSender) -> Router {
-    let code = LocaleCode::default();
-    let locale = Locale::new_with_locale(&code).unwrap();
+    let id = LocaleId::default();
+    let locale = Locale::new_with_locale(&id).unwrap();
     let state = LocaleState {
         locale: Arc::new(RwLock::new(locale)),
         events,
@@ -147,7 +147,7 @@ async fn set_config(
     }
 
     if let Some(ui_locale) = &value.ui_locale {
-        let locale: LocaleCode = ui_locale
+        let locale: LocaleId = ui_locale
             .as_str()
             .try_into()
             .map_err(|_e| LocaleError::UnknownLocale(ui_locale.to_string()))?;
@@ -193,13 +193,13 @@ async fn get_config(State(state): State<LocaleState>) -> Json<LocaleConfig> {
 #[cfg(test)]
 mod tests {
     use crate::l10n::{web::LocaleState, Locale};
-    use agama_locale_data::{KeymapId, LocaleCode};
+    use agama_locale_data::{KeymapId, LocaleId};
     use std::sync::{Arc, RwLock};
     use tokio::{sync::broadcast::channel, test};
 
     fn build_state() -> LocaleState {
         let (tx, _) = channel(16);
-        let default_code = LocaleCode::default();
+        let default_code = LocaleId::default();
         let locale = Locale::new_with_locale(&default_code).unwrap();
         LocaleState {
             locale: Arc::new(RwLock::new(locale)),
@@ -211,8 +211,8 @@ mod tests {
     async fn test_locales() {
         let state = build_state();
         let response = super::locales(axum::extract::State(state)).await;
-        let default = LocaleCode::default();
-        let found = response.iter().find(|l| l.code == default);
+        let default = LocaleId::default();
+        let found = response.iter().find(|l| l.id == default);
         assert!(found.is_some());
     }
 

--- a/rust/agama-server/tests/l10n.rs
+++ b/rust/agama-server/tests/l10n.rs
@@ -49,7 +49,7 @@ async fn test_keymaps() {
     let response = service.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_to_string(response.into_body()).await;
-    assert!(body.contains(r#""layout":"us""#));
+    assert!(body.contains(r#""id":"us""#));
 }
 
 #[test]

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -24,8 +24,8 @@ import { Outlet } from "react-router-dom";
 
 import { useInstallerClient, useInstallerClientStatus } from "~/context/installer";
 import { useProduct } from "./context/product";
-import { CONFIG, INSTALL, STARTUP } from "~/client/phase";
-import { BUSY, IDLE } from "~/client/status";
+import { INSTALL, STARTUP } from "~/client/phase";
+import { BUSY } from "~/client/status";
 
 import { DBusError, If, Installation } from "~/components/core";
 import { Loading } from "./components/layout";
@@ -51,29 +51,22 @@ function App() {
 
   useEffect(() => {
     if (client) {
-      // FIXME: adapt to the new API
-      // return client.manager.onPhaseChange(setPhase);
-      setPhase(CONFIG);
+      return client.manager.onPhaseChange(setPhase);
     }
   }, [client, setPhase]);
 
   useEffect(() => {
     if (client) {
-      setStatus(IDLE);
-      // FIXME: adapt to the new API
-      // return client.manager.onStatusChange(setStatus);
+      return client.manager.onStatusChange(setStatus);
     }
   }, [client, setStatus]);
 
   useEffect(() => {
     const loadPhase = async () => {
-      setPhase(CONFIG);
-      setStatus(IDLE);
-      // FIXME: adapt to the new API
-      // const phase = await client.manager.getPhase();
-      // const status = await client.manager.getStatus();
-      // setPhase(phase);
-      // setStatus(status);
+      const phase = await client.manager.getPhase();
+      const status = await client.manager.getStatus();
+      setPhase(phase);
+      setStatus(status);
     };
 
     if (client) {

--- a/web/src/client/http.js
+++ b/web/src/client/http.js
@@ -119,7 +119,13 @@ class HTTPClient {
         "Content-Type": "application/json",
       },
     });
-    return await response.json();
+
+    try {
+      return await response.json();
+    } catch (e) {
+      console.warn("Expecting a JSON response", e);
+      return response.status === 200;
+    }
   }
 
   /**
@@ -135,7 +141,13 @@ class HTTPClient {
         "Content-Type": "application/json",
       },
     });
-    return await response.json();
+
+    try {
+      return await response.json();
+    } catch (e) {
+      console.warn("Expecting a JSON response", e);
+      return response.status === 200;
+    }
   }
 
   /**

--- a/web/src/client/index.js
+++ b/web/src/client/index.js
@@ -75,7 +75,7 @@ const createClient = (url) => {
   const l10n = new L10nClient(client);
   // TODO: unify with the manager client
   const product = new ProductClient(client);
-  // const manager = new ManagerClient(address);
+  const manager = new ManagerClient(client);
   // const monitor = new Monitor(address, MANAGER_SERVICE);
   // const network = new NetworkClient(address);
   // const software = new SoftwareClient(address);
@@ -136,7 +136,7 @@ const createClient = (url) => {
   return {
     l10n,
     product,
-    // manager,
+    manager,
     // monitor,
     // network,
     // software,

--- a/web/src/client/l10n.js
+++ b/web/src/client/l10n.js
@@ -276,13 +276,13 @@ class L10nClient {
    * @private
    *
    * @param {object} locale - Locale data.
-   * @param {string} locale.code - Identifier.
-   * @param {string} locale.name - Name.
+   * @param {string} locale.id - Identifier.
+   * @param {string} locale.language - Name.
    * @param {string} locale.territory - Territory.
    * @return {Locale}
    */
-  buildLocale({ code, name, territory }) {
-    return ({ id: code, name, territory });
+  buildLocale({ id, language, territory }) {
+    return ({ id, name: language, territory });
   }
 
   /**

--- a/web/src/client/manager.js
+++ b/web/src/client/manager.js
@@ -22,7 +22,7 @@
 // @ts-check
 
 import DBusClient from "./dbus";
-import { WithStatus, WithProgress } from "./mixins";
+import { WithProgress, WithStatus } from "./mixins";
 import cockpit from "../lib/cockpit";
 
 const MANAGER_SERVICE = "org.opensuse.Agama.Manager1";
@@ -36,10 +36,10 @@ const MANAGER_PATH = "/org/opensuse/Agama/Manager1";
  */
 class ManagerBaseClient {
   /**
-   * @param {string|undefined} address - D-Bus address; if it is undefined, it uses the system bus.
+   * @param {import("./http").HTTPClient} client - HTTP client.
    */
-  constructor(address = undefined) {
-    this.client = new DBusClient(MANAGER_SERVICE, address);
+  constructor(client) {
+    this.client = client;
   }
 
   /**
@@ -49,9 +49,8 @@ class ManagerBaseClient {
    *
    * @return {Promise<void>}
    */
-  async startProbing() {
-    const proxy = await this.client.proxy(MANAGER_IFACE);
-    return proxy.Probe();
+  startProbing() {
+    return this.client.post("/manager/probe");
   }
 
   /**
@@ -61,9 +60,8 @@ class ManagerBaseClient {
    *
    * @return {Promise}
    */
-  async startInstallation() {
-    const proxy = await this.client.proxy(MANAGER_IFACE);
-    return proxy.Commit();
+  startInstallation() {
+    return this.client.post("/manager/install");
   }
 
   /**
@@ -75,20 +73,18 @@ class ManagerBaseClient {
    * @return {Promise<boolean>}
    */
   async canInstall() {
-    const proxy = await this.client.proxy(MANAGER_IFACE);
-    return proxy.CanInstall();
+    const installer = await this.client.get("/manager/installer");
+    return installer.can_install;
   }
 
   /**
    * Returns the binary content of the YaST logs file
    *
-   * @return {Promise<Uint8Array>}
+   * @todo Implement a mechanism to get the logs.
+   * @return {Promise<void>}
    */
   async fetchLogs() {
-    const proxy = await this.client.proxy(MANAGER_IFACE);
-    const path = await proxy.CollectLogs();
-    const file = cockpit.file(path, { binary: true });
-    return file.read();
+    // TODO
   }
 
   /**
@@ -97,8 +93,8 @@ class ManagerBaseClient {
    * @return {Promise<number>}
    */
   async getPhase() {
-    const proxy = await this.client.proxy(MANAGER_IFACE);
-    return proxy.CurrentInstallationPhase;
+    const installer = await this.client.get("/manager/installer");
+    return installer.phase;
   }
 
   /**
@@ -108,9 +104,9 @@ class ManagerBaseClient {
    * @return {import ("./dbus").RemoveFn} function to disable the callback
    */
   onPhaseChange(handler) {
-    return this.client.onObjectChanged(MANAGER_PATH, MANAGER_IFACE, (changes) => {
-      if ("CurrentInstallationPhase" in changes) {
-        handler(changes.CurrentInstallationPhase.v);
+    return this.client.onEvent("InstallationPhaseChanged", ({ phase }) => {
+      if (phase) {
+        handler(phase);
       }
     });
   }
@@ -118,23 +114,27 @@ class ManagerBaseClient {
   /**
    * Runs cleanup when installation is done
    */
-  async finishInstallation() {
-    const proxy = await this.client.proxy(MANAGER_IFACE);
-    return proxy.Finish();
+  finishInstallation() {
+    return this.client.post("/manager/install");
   }
 
   /**
    * Returns whether Iguana is used on the system
+   *
+   * @return {Promise<boolean>}
    */
   async useIguana() {
-    const proxy = await this.client.proxy(MANAGER_IFACE);
-    return proxy.IguanaBackend;
+    const installer = await this.client.get("/manager/installer");
+    return installer.iguana;
   }
 }
 
 /**
-  * Client to interact with the Agama manager service
-  */
-class ManagerClient extends WithProgress(WithStatus(ManagerBaseClient, MANAGER_PATH), MANAGER_PATH) { }
+ * Client to interact with the Agama manager service
+ */
+class ManagerClient extends WithProgress(
+  WithStatus(ManagerBaseClient, "/manager/status", "org.opensuse.Agama.Manager1"),
+  MANAGER_PATH,
+) {}
 
 export { ManagerClient };

--- a/web/src/client/manager.js
+++ b/web/src/client/manager.js
@@ -21,12 +21,8 @@
 
 // @ts-check
 
-import DBusClient from "./dbus";
 import { WithProgress, WithStatus } from "./mixins";
-import cockpit from "../lib/cockpit";
 
-const MANAGER_SERVICE = "org.opensuse.Agama.Manager1";
-const MANAGER_IFACE = "org.opensuse.Agama.Manager1";
 const MANAGER_PATH = "/org/opensuse/Agama/Manager1";
 
 /**

--- a/web/src/client/manager.js
+++ b/web/src/client/manager.js
@@ -24,6 +24,7 @@
 import { WithProgress, WithStatus } from "./mixins";
 
 const MANAGER_PATH = "/org/opensuse/Agama/Manager1";
+const MANAGER_SERVICE = "org.opensuse.Agama.Manager1";
 
 /**
  * Manager base client
@@ -129,7 +130,7 @@ class ManagerBaseClient {
  * Client to interact with the Agama manager service
  */
 class ManagerClient extends WithProgress(
-  WithStatus(ManagerBaseClient, "/manager/status", "org.opensuse.Agama.Manager1"),
+  WithStatus(ManagerBaseClient, "/manager/status", MANAGER_SERVICE),
   MANAGER_PATH,
 ) {}
 

--- a/web/src/client/mixins.js
+++ b/web/src/client/mixins.js
@@ -36,11 +36,20 @@ const VALIDATION_IFACE = "org.opensuse.Agama1.Validation";
  */
 
 /**
+ * @typedef {GConstructor<{ client: import("./http").HTTPClient }>} WithHTTPClient
+ */
+
+/**
  * @typedef {GConstructor<{ client: import("./dbus").default, proxies: Object }>} WithDBusProxies
  */
 
 /**
  * @typedef {[string, string, number, number]} DBusIssue
+ */
+
+/**
+ * @typedef {object} StatusResource
+ * @property {number} current - current status.
  */
 
 /**
@@ -136,35 +145,37 @@ const WithIssues = (superclass, object_path) => class extends superclass {
 /**
  * Extends the given class with methods to get and track the progress over D-Bus
  *
- * @template {!WithDBusClient} T
- * @param {string} object_path - object path
+ * @template {!WithHTTPClient} T
+ * @param {string} status_path - status resource path (e.g., "/manager/status").
+ * @param {string} service_name - service name (e.g., "org.opensuse.Agama.Manager1").
  * @param {T} superclass - superclass to extend
  */
-const WithStatus = (superclass, object_path) => class extends superclass {
-  /**
-   * Returns the service status
-   *
-   * @return {Promise<number>} 0 for idle, 1 for busy
-   */
-  async getStatus() {
-    const proxy = await this.client.proxy(STATUS_IFACE, object_path);
-    return proxy.Current;
-  }
+const WithStatus = (superclass, status_path, service_name) =>
+  class extends superclass {
+    /**
+     * Returns the service status
+     *
+     * @return {Promise<number>} 0 for idle, 1 for busy
+     */
+    async getStatus() {
+      const status = await this.client.get(status_path);
+      return status.current;
+    }
 
-  /**
-   * Register a callback to run when the "CurrentInstallationPhase" changes
-   *
-   * @param {function} handler - callback function
-   * @return {function} function to disable the callback
-   */
-  onStatusChange(handler) {
-    return this.client.onObjectChanged(object_path, STATUS_IFACE, (changes) => {
-      if ("Current" in changes) {
-        handler(changes.Current.v);
-      }
-    });
-  }
-};
+    /**
+     * Register a callback to run when the "CurrentInstallationPhase" changes
+     *
+     * @param {function} handler - callback function
+     * @return {function} function to disable the callback
+     */
+    onStatusChange(handler) {
+      return this.client.onEvent("StatusChanged", ({ status, service }) => {
+        if (service === service_name && status) {
+          handler(status);
+        }
+      });
+    }
+  };
 
 /**
  * @typedef {object} Progress
@@ -186,40 +197,41 @@ const WithStatus = (superclass, object_path) => class extends superclass {
  * @param {T} superclass - superclass to extend
  * @template {!WithDBusClient} T
  */
-const WithProgress = (superclass, object_path) => class extends superclass {
-  /**
-   * Returns the service progress
-   *
-   * @return {Promise<Progress>} an object containing the total steps,
-   *   the current step and whether the service finished or not.
-   */
-  async getProgress() {
-    const proxy = await this.client.proxy(PROGRESS_IFACE, object_path);
-    return {
-      total: proxy.TotalSteps,
-      current: proxy.CurrentStep[0],
-      message: proxy.CurrentStep[1],
-      finished: proxy.Finished
-    };
-  }
+const WithProgress = (superclass, object_path) =>
+  class extends superclass {
+    /**
+     * Returns the service progress
+     *
+     * @return {Promise<Progress>} an object containing the total steps,
+     *   the current step and whether the service finished or not.
+     */
+    async getProgress() {
+      const proxy = await this.client.proxy(PROGRESS_IFACE, object_path);
+      return {
+        total: proxy.TotalSteps,
+        current: proxy.CurrentStep[0],
+        message: proxy.CurrentStep[1],
+        finished: proxy.Finished,
+      };
+    }
 
-  /**
-   * Register a callback to run when the progress changes
-   *
-   * @param {ProgressHandler} handler - callback function
-   * @return {import ("./dbus").RemoveFn} function to disable the callback
-   */
-  onProgressChange(handler) {
-    return this.client.onObjectChanged(object_path, PROGRESS_IFACE, (changes) => {
-      const { TotalSteps, CurrentStep, Finished } = changes;
-      if (TotalSteps === undefined && CurrentStep === undefined && Finished === undefined) {
-        return;
-      }
+    /**
+     * Register a callback to run when the progress changes
+     *
+     * @param {ProgressHandler} handler - callback function
+     * @return {import ("./dbus").RemoveFn} function to disable the callback
+     */
+    onProgressChange(handler) {
+      return this.client.onObjectChanged(object_path, PROGRESS_IFACE, (changes) => {
+        const { TotalSteps, CurrentStep, Finished } = changes;
+        if (TotalSteps === undefined && CurrentStep === undefined && Finished === undefined) {
+          return;
+        }
 
-      this.getProgress().then(handler);
-    });
-  }
-};
+        this.getProgress().then(handler);
+      });
+    }
+  };
 
 /**
  * @typedef {object} ValidationError

--- a/web/src/components/core/LoginPage.jsx
+++ b/web/src/components/core/LoginPage.jsx
@@ -64,8 +64,8 @@ export default function LoginPage() {
           <p
             dangerouslySetInnerHTML={{
               __html: sprintf(
-               // TRANSLATORS: An explanation about required privileges for login into the installer. %s
-               // will be replaced by "root"
+                // TRANSLATORS: An explanation about required privileges for login into the installer. %s
+                // will be replaced by "root"
                 _("The installer requires %s user privileges. Please, provide its password to log into the system."),
                 "<b>root</b>"
               )

--- a/web/src/components/overview/L10nSection.jsx
+++ b/web/src/components/overview/L10nSection.jsx
@@ -35,7 +35,7 @@ const Content = ({ locales }) => {
 
   return (
     <Text>
-      {msg1}<Em>{`${locale.name} (${locale.territory})`}</Em>{msg2}
+      {msg1}<Em>{`${locale.id} (${locale.territory})`}</Em>{msg2}
     </Text>
   );
 };

--- a/web/src/components/overview/OverviewPage.jsx
+++ b/web/src/components/overview/OverviewPage.jsx
@@ -41,6 +41,25 @@ export default function OverviewPage() {
     return <Navigate to="/products" />;
   }
 
+  // return (
+  //   <Page
+  //     icon="list_alt"
+  //     // TRANSLATORS: page title
+  //     title={_("Installation Summary")}
+  //   >
+  //     <ProductSection />
+  //     <L10nSection />
+  //     <NetworkSection />
+  //     <StorageSection showErrors />
+  //     <SoftwareSection showErrors />
+  //     <UsersSection showErrors={showErrors} />
+
+  //     <Page.Actions>
+  //       <InstallButton onClick={() => setShowErrors(true)} />
+  //     </Page.Actions>
+  //   </Page>
+  // );
+
   return (
     <Page
       icon="list_alt"
@@ -49,14 +68,6 @@ export default function OverviewPage() {
     >
       <ProductSection />
       <L10nSection />
-      <NetworkSection />
-      <StorageSection showErrors />
-      <SoftwareSection showErrors />
-      <UsersSection showErrors={showErrors} />
-
-      <Page.Actions>
-        <InstallButton onClick={() => setShowErrors(true)} />
-      </Page.Actions>
     </Page>
   );
 }

--- a/web/src/components/overview/ProductSection.jsx
+++ b/web/src/components/overview/ProductSection.jsx
@@ -57,8 +57,8 @@ export default function ProductSection() {
   const { cancellablePromise } = useCancellablePromise();
 
   useEffect(() => {
-    cancellablePromise(software.product.getIssues()).then(setIssues);
-    return software.product.onIssuesChange(setIssues);
+    // cancellablePromise(software.product.getIssues()).then(setIssues);
+    // return software.product.onIssuesChange(setIssues);
   }, [cancellablePromise, setIssues, software]);
 
   const isLoading = !selectedProduct;

--- a/web/src/components/product/ProductSelectionPage.jsx
+++ b/web/src/components/product/ProductSelectionPage.jsx
@@ -48,8 +48,7 @@ function ProductSelectionPage() {
     if (newProductId !== selectedProduct?.id) {
       // TODO: handle errors
       await product.select(newProductId);
-      // FIXME: adapt to the new API
-      // manager.startProbing();
+      manager.startProbing();
     }
 
     navigate("/");

--- a/web/src/context/product.jsx
+++ b/web/src/context/product.jsx
@@ -53,17 +53,17 @@ function ProductProvider({ children }) {
     }
   }, [client, setProducts, setSelectedId, setRegistration, cancellablePromise]);
 
-  // useEffect(() => {
-  //   if (!client) return;
+  useEffect(() => {
+    if (!client) return;
 
-  //   return client.software.product.onChange(setSelectedId);
-  // }, [client, setSelectedId]);
+    return client.product.onChange(setSelectedId);
+  }, [client, setSelectedId]);
 
-  // useEffect(() => {
-  //   if (!client) return;
+  useEffect(() => {
+    if (!client) return;
 
-  //   return client.software.product.onRegistrationChange(setRegistration);
-  // }, [client, setRegistration]);
+    // return client.product.onRegistrationChange(setRegistration);
+  }, [client, setRegistration]);
 
   const value = { products, selectedId, registration };
   return <ProductContext.Provider value={value}>{children}</ProductContext.Provider>;

--- a/web/src/context/product.jsx
+++ b/web/src/context/product.jsx
@@ -60,7 +60,7 @@ function ProductProvider({ children }) {
   }, [client, setSelectedId]);
 
   useEffect(() => {
-    if (!client) return;
+    // if (!client) return;
 
     // return client.product.onRegistrationChange(setRegistration);
   }, [client, setRegistration]);


### PR DESCRIPTION
Although the new HTTP/JSON interface is not ready yet, we have started adapting part of the JavaScript code. This pull request introduces quite some changes to move from the login page to the overview, although most of the sections are disabled.

<details>
<summary>Login, selecting a product and changing l10n settings</summary>

![overview](https://github.com/openSUSE/agama/assets/15836/9d11627f-6d7d-4643-b8c1-d9cadaffb038)
</summary>
</details>

## Changes

* Synchronize the l10n models we use in the backend and the frontend.
* Adapt the ManagerClient to the HTTP/JSON API and uncomment the related code (e.g., start probing after selecting a product).
* Adjust the L10nClient to recent changes.
* Adapt the L10nSection and L10nPage components.