### PR TITLE
Simplify server errors and drop some unused code

### DIFF
--- a/rust/agama-server/src/error.rs
+++ b/rust/agama-server/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     DBus(#[from] zbus::Error),
     #[error("Generic error: {0}")]
     Anyhow(String),
+    #[error("Agama service error: {0}")]
+    Service(#[from] ServiceError),
     #[error("Answers handling error: {0}")]
     Answers(QuestionsError),
 }
@@ -36,15 +38,7 @@ impl From<Error> for zbus::fdo::Error {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum ApiError {
-    #[error("Agama service error: {0}")]
-    Service(#[from] ServiceError),
-    #[error("D-Bus error: {0}")]
-    DBus(#[from] zbus::Error),
-}
-
-impl IntoResponse for ApiError {
+impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let body = json!({
             "error": self.to_string()

--- a/rust/agama-server/src/error.rs
+++ b/rust/agama-server/src/error.rs
@@ -5,14 +5,17 @@ use axum::{
     Json,
 };
 use serde_json::json;
-use zbus_macros::DBusError;
 
-#[derive(DBusError, Debug)]
-#[dbus_error(prefix = "org.opensuse.Agama1.Locale")]
+use crate::questions::QuestionsError;
+
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[dbus_error(zbus_error)]
-    ZBus(zbus::Error),
+    #[error("D-Bus error: {0}")]
+    DBus(#[from] zbus::Error),
+    #[error("Generic error: {0}")]
     Anyhow(String),
+    #[error("Answers handling error: {0}")]
+    Answers(QuestionsError),
 }
 
 // This would be nice, but using it for a return type
@@ -29,7 +32,7 @@ impl From<anyhow::Error> for Error {
 
 impl From<Error> for zbus::fdo::Error {
     fn from(value: Error) -> zbus::fdo::Error {
-        zbus::fdo::Error::Failed(format!("Localization error: {value}"))
+        zbus::fdo::Error::Failed(format!("D-Bus error: {value}"))
     }
 }
 

--- a/rust/agama-server/src/error.rs
+++ b/rust/agama-server/src/error.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use serde_json::json;
 
-use crate::questions::QuestionsError;
+use crate::{l10n::web::LocaleError, questions::QuestionsError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -16,8 +16,10 @@ pub enum Error {
     Anyhow(String),
     #[error("Agama service error: {0}")]
     Service(#[from] ServiceError),
-    #[error("Answers handling error: {0}")]
-    Answers(QuestionsError),
+    #[error("Questions service error: {0}")]
+    Questions(QuestionsError),
+    #[error("Software service error: {0}")]
+    Locale(#[from] LocaleError),
 }
 
 // This would be nice, but using it for a return type

--- a/rust/agama-server/src/manager/web.rs
+++ b/rust/agama-server/src/manager/web.rs
@@ -21,7 +21,7 @@ use serde::Serialize;
 use tokio_stream::{Stream, StreamExt};
 
 use crate::{
-    error::{ApiError, Error},
+    error::Error,
     web::{
         common::{progress_router, service_status_router},
         Event,
@@ -98,7 +98,7 @@ pub async fn manager_service(dbus: zbus::Connection) -> Result<Router, ServiceEr
 #[utoipa::path(get, path = "/api/manager/probe", responses(
   (status = 200, description = "The probing process was started.")
 ))]
-async fn probe_action(State(state): State<ManagerState<'_>>) -> Result<(), ApiError> {
+async fn probe_action(State(state): State<ManagerState<'_>>) -> Result<(), Error> {
     state.manager.probe().await?;
     Ok(())
 }
@@ -107,7 +107,7 @@ async fn probe_action(State(state): State<ManagerState<'_>>) -> Result<(), ApiEr
 #[utoipa::path(get, path = "/api/manager/install", responses(
   (status = 200, description = "The installation process was started.")
 ))]
-async fn install_action(State(state): State<ManagerState<'_>>) -> Result<(), ApiError> {
+async fn install_action(State(state): State<ManagerState<'_>>) -> Result<(), Error> {
     state.manager.install().await?;
     Ok(())
 }
@@ -116,7 +116,7 @@ async fn install_action(State(state): State<ManagerState<'_>>) -> Result<(), Api
 #[utoipa::path(get, path = "/api/manager/install", responses(
   (status = 200, description = "The installation tasks are executed.")
 ))]
-async fn finish_action(State(state): State<ManagerState<'_>>) -> Result<(), ApiError> {
+async fn finish_action(State(state): State<ManagerState<'_>>) -> Result<(), Error> {
     state.manager.finish().await?;
     Ok(())
 }
@@ -127,7 +127,7 @@ async fn finish_action(State(state): State<ManagerState<'_>>) -> Result<(), ApiE
 ))]
 async fn installer_status(
     State(state): State<ManagerState<'_>>,
-) -> Result<Json<InstallerStatus>, ApiError> {
+) -> Result<Json<InstallerStatus>, Error> {
     let status = InstallerStatus {
         phase: state.manager.current_installation_phase().await?,
         busy: state.manager.busy_services().await?,

--- a/rust/agama-server/src/questions.rs
+++ b/rust/agama-server/src/questions.rs
@@ -1,11 +1,18 @@
 use std::collections::HashMap;
 
-use crate::error::Error;
 use agama_lib::questions::{self, GenericQuestion, WithPassword};
 use log;
 use zbus::{dbus_interface, fdo::ObjectManager, zvariant::ObjectPath, Connection};
 
 mod answers;
+
+#[derive(thiserror::Error, Debug)]
+pub enum QuestionsError {
+    #[error("Could not read the answers file: {0}")]
+    IO(std::io::Error),
+    #[error("Could not deserialize the answers file: {0}")]
+    Deserialize(serde_yaml::Error),
+}
 
 #[derive(Clone, Debug)]
 struct GenericQuestionObject(questions::GenericQuestion);
@@ -48,7 +55,7 @@ impl GenericQuestionObject {
     }
 
     #[dbus_interface(property)]
-    pub fn set_answer(&mut self, value: &str) -> Result<(), zbus::fdo::Error> {
+    pub fn set_answer(&mut self, value: &str) -> zbus::fdo::Result<()> {
         // TODO verify if answer exists in options or if it is valid in other way
         self.0.answer = value.to_string();
 
@@ -143,7 +150,7 @@ impl Questions {
         options: Vec<&str>,
         default_option: &str,
         data: HashMap<String, String>,
-    ) -> Result<ObjectPath, zbus::fdo::Error> {
+    ) -> zbus::fdo::Result<ObjectPath> {
         log::info!("Creating new question with text: {}.", text);
         let id = self.last_id;
         self.last_id += 1; // TODO use some thread safety
@@ -176,7 +183,7 @@ impl Questions {
         options: Vec<&str>,
         default_option: &str,
         data: HashMap<String, String>,
-    ) -> Result<ObjectPath, zbus::fdo::Error> {
+    ) -> zbus::fdo::Result<ObjectPath> {
         log::info!("Creating new question with password with text: {}.", text);
         let id = self.last_id;
         self.last_id += 1; // TODO use some thread safety
@@ -213,7 +220,7 @@ impl Questions {
     }
 
     /// Removes question at given object path
-    async fn delete(&mut self, question: ObjectPath<'_>) -> Result<(), Error> {
+    async fn delete(&mut self, question: ObjectPath<'_>) -> zbus::fdo::Result<()> {
         // TODO: error checking
         let id: u32 = question.rsplit('/').next().unwrap().parse().unwrap();
         let qtype = self.questions.get(&id).unwrap();
@@ -266,16 +273,12 @@ impl Questions {
         }
     }
 
-    fn add_answer_file(&mut self, path: String) -> Result<(), Error> {
+    fn add_answer_file(&mut self, path: String) -> zbus::fdo::Result<()> {
         log::info!("Adding answer file {}", path);
-        let answers = answers::Answers::new_from_file(path.as_str());
-        match answers {
-            Ok(answers) => {
-                self.answer_strategies.push(Box::new(answers));
-                Ok(())
-            }
-            Err(e) => Err(e.into()),
-        }
+        let answers = answers::Answers::new_from_file(path.as_str())
+            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
+        self.answer_strategies.push(Box::new(answers));
+        Ok(())
     }
 }
 

--- a/rust/agama-server/src/questions/answers.rs
+++ b/rust/agama-server/src/questions/answers.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use agama_lib::questions::GenericQuestion;
-use anyhow::Context;
 use serde::{Deserialize, Serialize};
+
+use super::QuestionsError;
 
 /// Data structure for single yaml answer. For variables specification see
 /// corresponding [agama_lib::questions::GenericQuestion] fields.
@@ -60,10 +61,9 @@ pub struct Answers {
 }
 
 impl Answers {
-    pub fn new_from_file(path: &str) -> anyhow::Result<Self> {
-        let f = std::fs::File::open(path).context(format!("Failed to open {}", path))?;
-        let result: Self =
-            serde_yaml::from_reader(f).context(format!("Failed to parse values at {}", path))?;
+    pub fn new_from_file(path: &str) -> Result<Self, QuestionsError> {
+        let f = std::fs::File::open(path).map_err(QuestionsError::IO)?;
+        let result: Self = serde_yaml::from_reader(f).map_err(QuestionsError::Deserialize)?;
 
         Ok(result)
     }

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -6,7 +6,7 @@
 //! * `software_stream` which offers an stream that emits the software events coming from D-Bus.
 
 use crate::{
-    error::{ApiError, Error},
+    error::Error,
     web::{
         common::{progress_router, service_status_router},
         Event,
@@ -140,7 +140,7 @@ pub async fn software_service(dbus: zbus::Connection) -> Result<Router, ServiceE
     (status = 200, description = "List of known products", body = Vec<Product>),
     (status = 400, description = "The D-Bus service could not perform the action")
 ))]
-async fn products(State(state): State<SoftwareState<'_>>) -> Result<Json<Vec<Product>>, ApiError> {
+async fn products(State(state): State<SoftwareState<'_>>) -> Result<Json<Vec<Product>>, Error> {
     let products = state.product.products().await?;
     Ok(Json(products))
 }
@@ -164,7 +164,7 @@ pub struct PatternEntry {
 ))]
 async fn patterns(
     State(state): State<SoftwareState<'_>>,
-) -> Result<Json<Vec<PatternEntry>>, ApiError> {
+) -> Result<Json<Vec<PatternEntry>>, Error> {
     let patterns = state.software.patterns(true).await?;
     let selected = state.software.selected_patterns().await?;
     let items = patterns
@@ -195,7 +195,7 @@ async fn patterns(
 async fn set_config(
     State(state): State<SoftwareState<'_>>,
     Json(config): Json<SoftwareConfig>,
-) -> Result<(), ApiError> {
+) -> Result<(), Error> {
     if let Some(product) = config.product {
         state.product.select_product(&product).await?;
     }
@@ -214,9 +214,7 @@ async fn set_config(
     (status = 200, description = "Software configuration", body = SoftwareConfig),
     (status = 400, description = "The D-Bus service could not perform the action")
 ))]
-async fn get_config(
-    State(state): State<SoftwareState<'_>>,
-) -> Result<Json<SoftwareConfig>, ApiError> {
+async fn get_config(State(state): State<SoftwareState<'_>>) -> Result<Json<SoftwareConfig>, Error> {
     let product = state.product.product().await?;
     let product = if product.is_empty() {
         None
@@ -246,9 +244,7 @@ pub struct SoftwareProposal {
     get, path = "/software/proposal", responses(
         (status = 200, description = "Software proposal", body = SoftwareProposal)
 ))]
-async fn proposal(
-    State(state): State<SoftwareState<'_>>,
-) -> Result<Json<SoftwareProposal>, ApiError> {
+async fn proposal(State(state): State<SoftwareState<'_>>) -> Result<Json<SoftwareProposal>, Error> {
     let size = state.software.used_disk_space().await?;
     let proposal = SoftwareProposal { size };
     Ok(Json(proposal))
@@ -263,7 +259,7 @@ async fn proposal(
         (status = 400, description = "The D-Bus service could not perform the action
 ")
 ))]
-async fn probe(State(state): State<SoftwareState<'_>>) -> Result<Json<()>, ApiError> {
+async fn probe(State(state): State<SoftwareState<'_>>) -> Result<Json<()>, Error> {
     state.software.probe().await?;
     Ok(Json(()))
 }

--- a/rust/agama-server/src/web/common.rs
+++ b/rust/agama-server/src/web/common.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use tokio_stream::{Stream, StreamExt};
 use zbus::PropertyStream;
 
-use crate::error::{ApiError, Error};
+use crate::error::Error;
 
 use super::Event;
 
@@ -163,7 +163,7 @@ struct ProgressState<'a> {
     proxy: ProgressProxy<'a>,
 }
 
-async fn progress(State(state): State<ProgressState<'_>>) -> Result<Json<Progress>, ApiError> {
+async fn progress(State(state): State<ProgressState<'_>>) -> Result<Json<Progress>, Error> {
     let proxy = state.proxy;
     let progress = Progress::from_proxy(&proxy).await?;
     Ok(Json(progress))


### PR DESCRIPTION
* Simplify the error handling in the `agama-server` crate, unifying many.
* Remove some functions from the `Locale` D-Bus API that are irrelevant for inter-process communication.
* +88/-215 lines and removed some redundant `IntoResponse` implementations.