### PR TITLE
Disable adjust_by_ram for swap at TW since it is not fully implemented

### DIFF
--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -165,12 +165,10 @@ storage:
     - mount_path: "swap"
       filesystem: swap
       size:
-        auto: true
+        auto: false
+        min: 1 GiB
+        max: 2 GiB
       outline:
-        auto_size:
-          base_min: 1 GiB
-          base_max: 2 GiB
-          adjust_by_ram: true
         required: false
         filesystems:
           - swap


### PR DESCRIPTION
## Problem

As part of #1081, we enabled at the Tumbleweed configuration the parameter `adjust_by_ram` for the outline of the swap volume.

But the feature is not really implemented yet because we have not defined all the details of how we want it to work and how distribute the logic between Agama itself and yast2-storage-ng (more details at this [non-public Trello card](https://trello.com/c/cki2gJ3b/366-agama-dynamic-sizes-based-on-ram)). `AdjustByRam` was added to the definition of the outlines only as a preliminary step, but we never went further and at this point in time the user cannot actually adjust the size if "auto" is not wanted.

## Solution

Revert commit 9f537c65cfd08cba670fcea809b5f454bdc60228 until we implement the feature in a more final (at least complete) way.