### PR TITLE
Show size before resizing

### DIFF
--- a/web/src/components/storage/ProposalResultSection.jsx
+++ b/web/src/components/storage/ProposalResultSection.jsx
@@ -162,12 +162,14 @@ const DevicesTreeTable = ({ devicesManager }) => {
   const renderResizedLabel = (item) => {
     if (!item.sid || !devicesManager.isShrunk(item)) return;
 
+    const sizeBefore = devicesManager.systemDevice(item.sid).size;
+
     return (
       <Tag variant="orange">
         {
-          // TRANSLATORS: a label to show how much a device was resized. %s will be
-          // replaced with such a size, including the unit. E.g., 508 MiB
-          sprintf(_("Resized %s"), deviceSize(devicesManager.shrinkSize(item)))
+          // TRANSLATORS: Label to indicate the device size before resizing, where %s is replaced by
+          // the original size (e.g., 3.00 GiB).
+          sprintf(_("Before %s"), deviceSize(sizeBefore))
         }
       </Tag>
     );

--- a/web/src/components/storage/ProposalResultSection.test.jsx
+++ b/web/src/components/storage/ProposalResultSection.test.jsx
@@ -96,7 +96,7 @@ describe("ProposalResultSection", () => {
        * "Unused space 3.49 GiB"
        * "vdc2 openSUSE Leap 15.2, Fedora 10.30 5 GiB"
        * "Unused space 1 GiB"
-       * "vdc4 Linux Resized 514 MiB 1.5 GiB"
+       * "vdc4 Linux Before 2 GiB 1.5 GiB"
        * "vdc5 / New Btrfs Partition 17.5 GiB"
        *
        * Device      Mount point      Details                                 Size
@@ -107,7 +107,7 @@ describe("ProposalResultSection", () => {
        *                              Unused space                        3.49 GiB
        *     vdc2                     openSUSE Leap 15.2, Fedora 10.30       5 GiB
        *                              Unused space                           1 GiB
-       *     vdc4                     Linux                Resized 514 MiB 1.5 GiB
+       *     vdc4                     Linux                   Before 2 GiB 1.5 GiB
        *     vdc5    /            New Btrfs Partition                     17.5 GiB
        * -------------------------------------------------------------------------
        */
@@ -117,7 +117,7 @@ describe("ProposalResultSection", () => {
       within(treegrid).getByRole("row", { name: "Unused space 3.49 GiB" });
       within(treegrid).getByRole("row", { name: "vdc2 openSUSE Leap 15.2, Fedora 10.30 5 GiB" });
       within(treegrid).getByRole("row", { name: "Unused space 1 GiB" });
-      within(treegrid).getByRole("row", { name: "vdc4 Linux Resized 514 MiB 1.5 GiB" });
+      within(treegrid).getByRole("row", { name: "vdc4 Linux Before 2 GiB 1.5 GiB" });
       within(treegrid).getByRole("row", { name: "vdc5 / New Btrfs Partition 17.5 GiB" });
     });
 


### PR DESCRIPTION
## Problem

After presenting the new storage result, it was suggested to replace the label indicating the amount of shrunk size by a label indicating the orignal size before resizing.

## Solution

Replace the label.

## Testing

* Test adapted.
* Tested manually

## Screenshots

![Screenshot from 2024-03-18 10-43-19](https://github.com/openSUSE/agama/assets/1112304/3dfbceea-9a11-4845-b91c-1484c128960b)
