### PR TITLE
Skip the IRC notification if the integration test is started manually

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -101,8 +101,8 @@ jobs:
     - name: IRC notification
       # see https://github.com/marketplace/actions/irc-message-action
       uses: Gottox/irc-message-action@v2
-      # never run in forks
-      if: failure() && github.repository_owner == 'openSUSE'
+      # never run in forks or when triggered manually
+      if: failure() && github.repository_owner == 'openSUSE' && github.event_name != 'workflow_dispatch'
       with:
         channel: "#yast"
         nickname: github-action


### PR DESCRIPTION
## Problem

- When debugging a failing integration test you have to trigger it manually
- If the test fails it sends notification to IRC
- If you need to run the test several times to find the problem then you are spamming the IRC channel

## Solution

- Skip the IRC notification if the integration test is started manually

## Rationale

- If you run the test manually you are very likely watching the result, it should send the IRC notification only when started automatically via the cron setting.
