### PR TITLE
Synchronize HTTP and D-Bus localization interfaces

### DIFF
--- a/rust/agama-lib/src/localization.rs
+++ b/rust/agama-lib/src/localization.rs
@@ -6,5 +6,6 @@ mod settings;
 mod store;
 
 pub use client::LocalizationClient;
+pub use proxies::LocaleProxy;
 pub use settings::LocalizationSettings;
 pub use store::LocalizationStore;

--- a/rust/agama-lib/src/localization/client.rs
+++ b/rust/agama-lib/src/localization/client.rs
@@ -3,6 +3,7 @@ use crate::error::ServiceError;
 use zbus::Connection;
 
 /// D-Bus client for the software service
+#[derive(Clone)]
 pub struct LocalizationClient<'a> {
     localization_proxy: LocaleProxy<'a>,
 }
@@ -22,6 +23,10 @@ impl<'a> LocalizationClient<'a> {
         Ok(first)
     }
 
+    pub async fn locales(&self) -> zbus::Result<Vec<String>> {
+        self.localization_proxy.locales().await
+    }
+
     pub async fn keyboard(&self) -> Result<String, ServiceError> {
         Ok(self.localization_proxy.keymap().await?)
     }
@@ -33,6 +38,10 @@ impl<'a> LocalizationClient<'a> {
     pub async fn set_language(&self, language: &str) -> zbus::Result<()> {
         let locales = [language];
         self.localization_proxy.set_locales(&locales).await
+    }
+
+    pub async fn set_locales(&self, locales: &[&str]) -> zbus::Result<()> {
+        self.localization_proxy.set_locales(locales).await
     }
 
     pub async fn set_keyboard(&self, keyboard: &str) -> zbus::Result<()> {

--- a/rust/agama-lib/src/localization/proxies.rs
+++ b/rust/agama-lib/src/localization/proxies.rs
@@ -39,6 +39,6 @@ trait Locale {
     /// UILocale property
     #[dbus_proxy(property, name = "UILocale")]
     fn uilocale(&self) -> zbus::Result<String>;
-    #[dbus_proxy(property)]
+    #[dbus_proxy(property, name = "UILocale")]
     fn set_uilocale(&self, value: &str) -> zbus::Result<()>;
 }

--- a/rust/agama-server/src/error.rs
+++ b/rust/agama-server/src/error.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use serde_json::json;
 
-use crate::{l10n::web::LocaleError, questions::QuestionsError};
+use crate::{l10n::LocaleError, questions::QuestionsError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/rust/agama-server/src/l10n.rs
+++ b/rust/agama-server/src/l10n.rs
@@ -1,4 +1,5 @@
 mod dbus;
+pub mod error;
 pub mod helpers;
 mod keyboard;
 pub mod l10n;
@@ -7,6 +8,7 @@ mod timezone;
 pub mod web;
 
 pub use dbus::export_dbus_objects;
+pub use error::LocaleError;
 pub use keyboard::Keymap;
 pub use l10n::L10n;
 pub use locale::LocaleEntry;

--- a/rust/agama-server/src/l10n.rs
+++ b/rust/agama-server/src/l10n.rs
@@ -1,3 +1,4 @@
+mod dbus;
 pub mod helpers;
 mod keyboard;
 mod locale;
@@ -12,8 +13,8 @@ use locale::LocalesDatabase;
 use regex::Regex;
 use std::{io, process::Command};
 use timezone::TimezonesDatabase;
-use zbus::{dbus_interface, Connection};
 
+pub use dbus::export_dbus_objects;
 pub use keyboard::Keymap;
 pub use locale::LocaleEntry;
 pub use timezone::TimezoneEntry;
@@ -28,107 +29,6 @@ pub struct Locale {
     keymaps_db: KeymapsDatabase,
     ui_locale: LocaleId,
     pub ui_keymap: KeymapId,
-}
-
-#[dbus_interface(name = "org.opensuse.Agama1.Locale")]
-impl Locale {
-    #[dbus_interface(property)]
-    fn locales(&self) -> Vec<String> {
-        self.locales.to_owned()
-    }
-
-    #[dbus_interface(property)]
-    fn set_locales(&mut self, locales: Vec<String>) -> zbus::fdo::Result<()> {
-        if locales.is_empty() {
-            return Err(zbus::fdo::Error::Failed(
-                "The locales list cannot be empty".to_string(),
-            ));
-        }
-        for loc in &locales {
-            if !self.locales_db.exists(loc.as_str()) {
-                return Err(zbus::fdo::Error::Failed(format!(
-                    "Unsupported locale value '{loc}'"
-                )));
-            }
-        }
-        self.locales = locales;
-        Ok(())
-    }
-
-    #[dbus_interface(property, name = "UILocale")]
-    fn ui_locale(&self) -> String {
-        self.ui_locale.to_string()
-    }
-
-    #[dbus_interface(property, name = "UILocale")]
-    fn set_ui_locale(&mut self, locale: &str) -> zbus::fdo::Result<()> {
-        let locale: LocaleId = locale
-            .try_into()
-            .map_err(|_e| zbus::fdo::Error::Failed(format!("Invalid locale value '{locale}'")))?;
-        helpers::set_service_locale(&locale);
-        Ok(self.translate(&locale)?)
-    }
-
-    #[dbus_interface(property)]
-    fn keymap(&self) -> String {
-        self.keymap.to_string()
-    }
-
-    #[dbus_interface(property)]
-    fn set_keymap(&mut self, keymap_id: &str) -> Result<(), zbus::fdo::Error> {
-        let keymap_id: KeymapId = keymap_id
-            .parse()
-            .map_err(|_e| zbus::fdo::Error::InvalidArgs("Cannot parse keymap ID".to_string()))?;
-
-        if !self.keymaps_db.exists(&keymap_id) {
-            return Err(zbus::fdo::Error::Failed(
-                "Cannot find this keymap".to_string(),
-            ));
-        }
-        self.keymap = keymap_id;
-        Ok(())
-    }
-
-    #[dbus_interface(property)]
-    fn timezone(&self) -> &str {
-        self.timezone.as_str()
-    }
-
-    #[dbus_interface(property)]
-    fn set_timezone(&mut self, timezone: &str) -> Result<(), zbus::fdo::Error> {
-        let timezone = timezone.to_string();
-        if !self.timezones_db.exists(&timezone) {
-            return Err(zbus::fdo::Error::Failed(format!(
-                "Unsupported timezone value '{timezone}'"
-            )));
-        }
-        self.timezone = timezone;
-        Ok(())
-    }
-
-    // TODO: what should be returned value for commit?
-    fn commit(&mut self) -> zbus::fdo::Result<()> {
-        const ROOT: &str = "/mnt";
-
-        Command::new("/usr/bin/systemd-firstboot")
-            .args([
-                "--root",
-                ROOT,
-                "--force",
-                "--locale",
-                self.locales.first().unwrap_or(&"en_US.UTF-8".to_string()),
-                "--keymap",
-                &self.keymap.to_string(),
-                "--timezone",
-                &self.timezone,
-            ])
-            .status()
-            .map_err(|e| {
-                zbus::fdo::Error::Failed(format!("Could not apply the l10n configuration: {e}"))
-            })?;
-
-        Ok(())
-    }
 }
 
 impl Locale {
@@ -196,17 +96,4 @@ impl Locale {
 
         Ok(keymap)
     }
-}
-
-pub async fn export_dbus_objects(
-    connection: &Connection,
-    locale: &LocaleId,
-) -> Result<(), Box<dyn std::error::Error>> {
-    const PATH: &str = "/org/opensuse/Agama1/Locale";
-
-    // When serving, request the service name _after_ exposing the main object
-    let locale_iface = Locale::new_with_locale(locale)?;
-    connection.object_server().at(PATH, locale_iface).await?;
-
-    Ok(())
 }

--- a/rust/agama-server/src/l10n.rs
+++ b/rust/agama-server/src/l10n.rs
@@ -1,99 +1,14 @@
 mod dbus;
 pub mod helpers;
 mod keyboard;
+pub mod l10n;
 mod locale;
 mod timezone;
 pub mod web;
 
-use crate::error::Error;
-use agama_locale_data::{KeymapId, LocaleId};
-
-use keyboard::KeymapsDatabase;
-use locale::LocalesDatabase;
-use regex::Regex;
-use std::{io, process::Command};
-use timezone::TimezonesDatabase;
-
 pub use dbus::export_dbus_objects;
 pub use keyboard::Keymap;
+pub use l10n::L10n;
 pub use locale::LocaleEntry;
 pub use timezone::TimezoneEntry;
 pub use web::LocaleConfig;
-
-pub struct Locale {
-    timezone: String,
-    timezones_db: TimezonesDatabase,
-    locales: Vec<String>,
-    pub locales_db: LocalesDatabase,
-    keymap: KeymapId,
-    keymaps_db: KeymapsDatabase,
-    ui_locale: LocaleId,
-    pub ui_keymap: KeymapId,
-}
-
-impl Locale {
-    pub fn new_with_locale(ui_locale: &LocaleId) -> Result<Self, Error> {
-        const DEFAULT_TIMEZONE: &str = "Europe/Berlin";
-
-        let locale = ui_locale.to_string();
-        let mut locales_db = LocalesDatabase::new();
-        locales_db.read(&locale)?;
-
-        let mut default_locale = ui_locale.to_string();
-        if !locales_db.exists(locale.as_str()) {
-            // TODO: handle the case where the database is empty (not expected!)
-            default_locale = locales_db.entries().first().unwrap().id.to_string();
-        };
-
-        let mut timezones_db = TimezonesDatabase::new();
-        timezones_db.read(&ui_locale.language)?;
-
-        let mut default_timezone = DEFAULT_TIMEZONE.to_string();
-        if !timezones_db.exists(&default_timezone) {
-            default_timezone = timezones_db.entries().first().unwrap().code.to_string();
-        };
-
-        let mut keymaps_db = KeymapsDatabase::new();
-        keymaps_db.read()?;
-
-        let ui_keymap = Self::x11_keymap().unwrap_or("us".to_string());
-
-        let locale = Self {
-            keymap: "us".parse().unwrap(),
-            timezone: default_timezone,
-            locales: vec![default_locale],
-            locales_db,
-            timezones_db,
-            keymaps_db,
-            ui_locale: ui_locale.clone(),
-            ui_keymap: ui_keymap.parse().unwrap_or_default(),
-        };
-
-        Ok(locale)
-    }
-
-    pub fn translate(&mut self, locale: &LocaleId) -> Result<(), Error> {
-        self.timezones_db.read(&locale.language)?;
-        self.locales_db.read(&locale.language)?;
-        self.ui_locale = locale.clone();
-        Ok(())
-    }
-
-    fn x11_keymap() -> Result<String, io::Error> {
-        let output = Command::new("setxkbmap")
-            .arg("-query")
-            .env("DISPLAY", ":0")
-            .output()?;
-        let output = String::from_utf8(output.stdout)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
-
-        let keymap_regexp = Regex::new(r"(?m)^layout: (.+)$").unwrap();
-        let captures = keymap_regexp.captures(&output);
-        let keymap = captures
-            .and_then(|c| c.get(1).map(|e| e.as_str()))
-            .unwrap_or("us")
-            .to_string();
-
-        Ok(keymap)
-    }
-}

--- a/rust/agama-server/src/l10n/dbus.rs
+++ b/rust/agama-server/src/l10n/dbus.rs
@@ -1,107 +1,94 @@
-use std::process::Command;
+use std::sync::{Arc, RwLock};
 
 use agama_locale_data::{KeymapId, LocaleId};
 use zbus::{dbus_interface, Connection};
 
-use super::{helpers, L10n};
+use super::L10n;
+
+struct L10nInterface {
+    backend: Arc<RwLock<L10n>>,
+}
 
 #[dbus_interface(name = "org.opensuse.Agama1.Locale")]
-impl L10n {
+impl L10nInterface {
     #[dbus_interface(property)]
     pub fn locales(&self) -> Vec<String> {
-        self.locales.to_owned()
+        let backend = self.backend.read().unwrap();
+        backend.locales.to_owned()
     }
 
     #[dbus_interface(property)]
     pub fn set_locales(&mut self, locales: Vec<String>) -> zbus::fdo::Result<()> {
+        let mut backend = self.backend.write().unwrap();
         if locales.is_empty() {
             return Err(zbus::fdo::Error::Failed(
                 "The locales list cannot be empty".to_string(),
             ));
         }
-        for loc in &locales {
-            if !self.locales_db.exists(loc.as_str()) {
-                return Err(zbus::fdo::Error::Failed(format!(
-                    "Unsupported locale value '{loc}'"
-                )));
-            }
-        }
-        self.locales = locales;
+        backend.set_locales(&locales).map_err(|e| {
+            zbus::fdo::Error::Failed(format!("Could not set the locales: {}", e.to_string()))
+        })?;
         Ok(())
     }
 
     #[dbus_interface(property, name = "UILocale")]
     pub fn ui_locale(&self) -> String {
-        self.ui_locale.to_string()
+        let backend = self.backend.read().unwrap();
+        backend.ui_locale.to_string()
     }
 
     #[dbus_interface(property, name = "UILocale")]
     pub fn set_ui_locale(&mut self, locale: &str) -> zbus::fdo::Result<()> {
+        let mut backend = self.backend.write().unwrap();
         let locale: LocaleId = locale
             .try_into()
             .map_err(|_e| zbus::fdo::Error::Failed(format!("Invalid locale value '{locale}'")))?;
-        helpers::set_service_locale(&locale);
-        Ok(self.translate(&locale)?)
+        Ok(backend.translate(&locale)?)
     }
 
     #[dbus_interface(property)]
     pub fn keymap(&self) -> String {
-        self.keymap.to_string()
+        let backend = self.backend.read().unwrap();
+        backend.keymap.to_string()
     }
 
     #[dbus_interface(property)]
     fn set_keymap(&mut self, keymap_id: &str) -> Result<(), zbus::fdo::Error> {
+        let mut backend = self.backend.write().unwrap();
         let keymap_id: KeymapId = keymap_id
             .parse()
             .map_err(|_e| zbus::fdo::Error::InvalidArgs("Cannot parse keymap ID".to_string()))?;
 
-        if !self.keymaps_db.exists(&keymap_id) {
-            return Err(zbus::fdo::Error::Failed(
-                "Cannot find this keymap".to_string(),
-            ));
-        }
-        self.keymap = keymap_id;
+        backend.set_keymap(keymap_id).map_err(|e| {
+            zbus::fdo::Error::Failed(format!("Could not set the keymap: {}", e.to_string()))
+        })?;
+
         Ok(())
     }
 
     #[dbus_interface(property)]
-    pub fn timezone(&self) -> &str {
-        self.timezone.as_str()
+    pub fn timezone(&self) -> String {
+        let backend = self.backend.read().unwrap();
+        backend.timezone.clone()
     }
 
     #[dbus_interface(property)]
     pub fn set_timezone(&mut self, timezone: &str) -> Result<(), zbus::fdo::Error> {
-        let timezone = timezone.to_string();
-        if !self.timezones_db.exists(&timezone) {
-            return Err(zbus::fdo::Error::Failed(format!(
-                "Unsupported timezone value '{timezone}'"
-            )));
-        }
-        self.timezone = timezone;
+        let mut backend = self.backend.write().unwrap();
+
+        backend.set_timezone(timezone).map_err(|e| {
+            zbus::fdo::Error::Failed(format!("Could not set the timezone: {}", e.to_string()))
+        })?;
         Ok(())
     }
 
     // TODO: what should be returned value for commit?
     pub fn commit(&mut self) -> zbus::fdo::Result<()> {
-        const ROOT: &str = "/mnt";
+        let backend = self.backend.read().unwrap();
 
-        Command::new("/usr/bin/systemd-firstboot")
-            .args([
-                "--root",
-                ROOT,
-                "--force",
-                "--locale",
-                self.locales.first().unwrap_or(&"en_US.UTF-8".to_string()),
-                "--keymap",
-                &self.keymap.to_string(),
-                "--timezone",
-                &self.timezone,
-            ])
-            .status()
-            .map_err(|e| {
-                zbus::fdo::Error::Failed(format!("Could not apply the l10n configuration: {e}"))
-            })?;
-
+        backend.commit().map_err(|e| {
+            zbus::fdo::Error::Failed(format!("Could not apply the l10n configuration: {e}"))
+        })?;
         Ok(())
     }
 }
@@ -113,7 +100,10 @@ pub async fn export_dbus_objects(
     const PATH: &str = "/org/opensuse/Agama1/Locale";
 
     // When serving, request the service name _after_ exposing the main object
-    let locale_iface = L10n::new_with_locale(locale)?;
+    let backend = L10n::new_with_locale(locale)?;
+    let locale_iface = L10nInterface {
+        backend: Arc::new(RwLock::new(backend)),
+    };
     connection.object_server().at(PATH, locale_iface).await?;
 
     Ok(())

--- a/rust/agama-server/src/l10n/dbus.rs
+++ b/rust/agama-server/src/l10n/dbus.rs
@@ -1,0 +1,120 @@
+use std::process::Command;
+
+use agama_locale_data::{KeymapId, LocaleId};
+use zbus::{dbus_interface, Connection};
+
+use super::{helpers, Locale};
+
+#[dbus_interface(name = "org.opensuse.Agama1.Locale")]
+impl Locale {
+    #[dbus_interface(property)]
+    pub fn locales(&self) -> Vec<String> {
+        self.locales.to_owned()
+    }
+
+    #[dbus_interface(property)]
+    pub fn set_locales(&mut self, locales: Vec<String>) -> zbus::fdo::Result<()> {
+        if locales.is_empty() {
+            return Err(zbus::fdo::Error::Failed(
+                "The locales list cannot be empty".to_string(),
+            ));
+        }
+        for loc in &locales {
+            if !self.locales_db.exists(loc.as_str()) {
+                return Err(zbus::fdo::Error::Failed(format!(
+                    "Unsupported locale value '{loc}'"
+                )));
+            }
+        }
+        self.locales = locales;
+        Ok(())
+    }
+
+    #[dbus_interface(property, name = "UILocale")]
+    pub fn ui_locale(&self) -> String {
+        self.ui_locale.to_string()
+    }
+
+    #[dbus_interface(property, name = "UILocale")]
+    pub fn set_ui_locale(&mut self, locale: &str) -> zbus::fdo::Result<()> {
+        let locale: LocaleId = locale
+            .try_into()
+            .map_err(|_e| zbus::fdo::Error::Failed(format!("Invalid locale value '{locale}'")))?;
+        helpers::set_service_locale(&locale);
+        Ok(self.translate(&locale)?)
+    }
+
+    #[dbus_interface(property)]
+    pub fn keymap(&self) -> String {
+        self.keymap.to_string()
+    }
+
+    #[dbus_interface(property)]
+    fn set_keymap(&mut self, keymap_id: &str) -> Result<(), zbus::fdo::Error> {
+        let keymap_id: KeymapId = keymap_id
+            .parse()
+            .map_err(|_e| zbus::fdo::Error::InvalidArgs("Cannot parse keymap ID".to_string()))?;
+
+        if !self.keymaps_db.exists(&keymap_id) {
+            return Err(zbus::fdo::Error::Failed(
+                "Cannot find this keymap".to_string(),
+            ));
+        }
+        self.keymap = keymap_id;
+        Ok(())
+    }
+
+    #[dbus_interface(property)]
+    pub fn timezone(&self) -> &str {
+        self.timezone.as_str()
+    }
+
+    #[dbus_interface(property)]
+    pub fn set_timezone(&mut self, timezone: &str) -> Result<(), zbus::fdo::Error> {
+        let timezone = timezone.to_string();
+        if !self.timezones_db.exists(&timezone) {
+            return Err(zbus::fdo::Error::Failed(format!(
+                "Unsupported timezone value '{timezone}'"
+            )));
+        }
+        self.timezone = timezone;
+        Ok(())
+    }
+
+    // TODO: what should be returned value for commit?
+    pub fn commit(&mut self) -> zbus::fdo::Result<()> {
+        const ROOT: &str = "/mnt";
+
+        Command::new("/usr/bin/systemd-firstboot")
+            .args([
+                "--root",
+                ROOT,
+                "--force",
+                "--locale",
+                self.locales.first().unwrap_or(&"en_US.UTF-8".to_string()),
+                "--keymap",
+                &self.keymap.to_string(),
+                "--timezone",
+                &self.timezone,
+            ])
+            .status()
+            .map_err(|e| {
+                zbus::fdo::Error::Failed(format!("Could not apply the l10n configuration: {e}"))
+            })?;
+
+        Ok(())
+    }
+}
+
+pub async fn export_dbus_objects(
+    connection: &Connection,
+    locale: &LocaleId,
+) -> Result<(), Box<dyn std::error::Error>> {
+    const PATH: &str = "/org/opensuse/Agama1/Locale";
+
+    // When serving, request the service name _after_ exposing the main object
+    let locale_iface = Locale::new_with_locale(locale)?;
+    connection.object_server().at(PATH, locale_iface).await?;
+
+    Ok(())
+}

--- a/rust/agama-server/src/l10n/dbus.rs
+++ b/rust/agama-server/src/l10n/dbus.rs
@@ -3,10 +3,10 @@ use std::process::Command;
 use agama_locale_data::{KeymapId, LocaleId};
 use zbus::{dbus_interface, Connection};
 
-use super::{helpers, Locale};
+use super::{helpers, L10n};
 
 #[dbus_interface(name = "org.opensuse.Agama1.Locale")]
-impl Locale {
+impl L10n {
     #[dbus_interface(property)]
     pub fn locales(&self) -> Vec<String> {
         self.locales.to_owned()
@@ -113,7 +113,7 @@ pub async fn export_dbus_objects(
     const PATH: &str = "/org/opensuse/Agama1/Locale";
 
     // When serving, request the service name _after_ exposing the main object
-    let locale_iface = Locale::new_with_locale(locale)?;
+    let locale_iface = L10n::new_with_locale(locale)?;
     connection.object_server().at(PATH, locale_iface).await?;
 
     Ok(())

--- a/rust/agama-server/src/l10n/error.rs
+++ b/rust/agama-server/src/l10n/error.rs
@@ -1,0 +1,13 @@
+use agama_locale_data::InvalidKeymap;
+
+#[derive(thiserror::Error, Debug)]
+pub enum LocaleError {
+    #[error("Unknown locale code: {0}")]
+    UnknownLocale(String),
+    #[error("Unknown timezone: {0}")]
+    UnknownTimezone(String),
+    #[error("Invalid keymap: {0}")]
+    InvalidKeymap(#[from] InvalidKeymap),
+    #[error("Could not apply the changes")]
+    Commit(#[from] std::io::Error),
+}

--- a/rust/agama-server/src/l10n/error.rs
+++ b/rust/agama-server/src/l10n/error.rs
@@ -1,4 +1,4 @@
-use agama_locale_data::InvalidKeymap;
+use agama_locale_data::{InvalidKeymap, KeymapId};
 
 #[derive(thiserror::Error, Debug)]
 pub enum LocaleError {
@@ -6,6 +6,8 @@ pub enum LocaleError {
     UnknownLocale(String),
     #[error("Unknown timezone: {0}")]
     UnknownTimezone(String),
+    #[error("Unknown keymap: {0}")]
+    UnknownKeymap(KeymapId),
     #[error("Invalid keymap: {0}")]
     InvalidKeymap(#[from] InvalidKeymap),
     #[error("Could not apply the changes")]

--- a/rust/agama-server/src/l10n/l10n.rs
+++ b/rust/agama-server/src/l10n/l10n.rs
@@ -100,8 +100,14 @@ impl L10n {
     }
 
     // TODO: use LocaleError
-    pub fn set_ui_keymap(&mut self, keymap: KeymapId) -> Result<(), Error> {
-        let keymap = keymap.to_string();
+    pub fn set_ui_keymap(&mut self, keymap_id: KeymapId) -> Result<(), LocaleError> {
+        if !self.keymaps_db.exists(&keymap_id) {
+            return Err(LocaleError::UnknownKeymap(keymap_id));
+        }
+
+        let keymap = keymap_id.to_string();
+        self.ui_keymap = keymap_id;
+
         Command::new("/usr/bin/localectl")
             .args(["set-x11-keymap", &keymap])
             .output()

--- a/rust/agama-server/src/l10n/l10n.rs
+++ b/rust/agama-server/src/l10n/l10n.rs
@@ -1,0 +1,86 @@
+use crate::error::Error;
+use agama_locale_data::{KeymapId, LocaleId};
+
+use super::keyboard::KeymapsDatabase;
+use super::locale::LocalesDatabase;
+use super::timezone::TimezonesDatabase;
+use regex::Regex;
+use std::{io, process::Command};
+
+pub struct L10n {
+    pub timezone: String,
+    pub timezones_db: TimezonesDatabase,
+    pub locales: Vec<String>,
+    pub locales_db: LocalesDatabase,
+    pub keymap: KeymapId,
+    pub keymaps_db: KeymapsDatabase,
+    pub ui_locale: LocaleId,
+    pub ui_keymap: KeymapId,
+}
+
+impl L10n {
+    pub fn new_with_locale(ui_locale: &LocaleId) -> Result<Self, Error> {
+        const DEFAULT_TIMEZONE: &str = "Europe/Berlin";
+
+        let locale = ui_locale.to_string();
+        let mut locales_db = LocalesDatabase::new();
+        locales_db.read(&locale)?;
+
+        let mut default_locale = ui_locale.to_string();
+        if !locales_db.exists(locale.as_str()) {
+            // TODO: handle the case where the database is empty (not expected!)
+            default_locale = locales_db.entries().first().unwrap().id.to_string();
+        };
+
+        let mut timezones_db = TimezonesDatabase::new();
+        timezones_db.read(&ui_locale.language)?;
+
+        let mut default_timezone = DEFAULT_TIMEZONE.to_string();
+        if !timezones_db.exists(&default_timezone) {
+            default_timezone = timezones_db.entries().first().unwrap().code.to_string();
+        };
+
+        let mut keymaps_db = KeymapsDatabase::new();
+        keymaps_db.read()?;
+
+        let ui_keymap = Self::x11_keymap().unwrap_or("us".to_string());
+
+        let locale = Self {
+            keymap: "us".parse().unwrap(),
+            timezone: default_timezone,
+            locales: vec![default_locale],
+            locales_db,
+            timezones_db,
+            keymaps_db,
+            ui_locale: ui_locale.clone(),
+            ui_keymap: ui_keymap.parse().unwrap_or_default(),
+        };
+
+        Ok(locale)
+    }
+
+    pub fn translate(&mut self, locale: &LocaleId) -> Result<(), Error> {
+        self.timezones_db.read(&locale.language)?;
+        self.locales_db.read(&locale.language)?;
+        self.ui_locale = locale.clone();
+        Ok(())
+    }
+
+    fn x11_keymap() -> Result<String, io::Error> {
+        let output = Command::new("setxkbmap")
+            .arg("-query")
+            .env("DISPLAY", ":0")
+            .output()?;
+        let output = String::from_utf8(output.stdout)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        let keymap_regexp = Regex::new(r"(?m)^layout: (.+)$").unwrap();
+        let captures = keymap_regexp.captures(&output);
+        let keymap = captures
+            .and_then(|c| c.get(1).map(|e| e.as_str()))
+            .unwrap_or("us")
+            .to_string();
+
+        Ok(keymap)
+    }
+}

--- a/rust/agama-server/src/l10n/web.rs
+++ b/rust/agama-server/src/l10n/web.rs
@@ -1,6 +1,6 @@
 //! This module implements the web API for the localization module.
 
-use super::{keyboard::Keymap, locale::LocaleEntry, timezone::TimezoneEntry, Locale};
+use super::{keyboard::Keymap, locale::LocaleEntry, timezone::TimezoneEntry, L10n};
 use crate::{
     error::Error,
     l10n::helpers,
@@ -32,7 +32,7 @@ pub enum LocaleError {
 
 #[derive(Clone)]
 struct LocaleState {
-    locale: Arc<RwLock<Locale>>,
+    locale: Arc<RwLock<L10n>>,
     events: EventsSender,
 }
 
@@ -41,7 +41,7 @@ struct LocaleState {
 /// * `events`: channel to send the events to the main service.
 pub fn l10n_service(events: EventsSender) -> Router {
     let id = LocaleId::default();
-    let locale = Locale::new_with_locale(&id).unwrap();
+    let locale = L10n::new_with_locale(&id).unwrap();
     let state = LocaleState {
         locale: Arc::new(RwLock::new(locale)),
         events,
@@ -180,7 +180,7 @@ async fn get_config(State(state): State<LocaleState>) -> Json<LocaleConfig> {
 
 #[cfg(test)]
 mod tests {
-    use crate::l10n::{web::LocaleState, Locale};
+    use crate::l10n::{web::LocaleState, L10n};
     use agama_locale_data::{KeymapId, LocaleId};
     use std::sync::{Arc, RwLock};
     use tokio::{sync::broadcast::channel, test};
@@ -188,7 +188,7 @@ mod tests {
     fn build_state() -> LocaleState {
         let (tx, _) = channel(16);
         let default_code = LocaleId::default();
-        let locale = Locale::new_with_locale(&default_code).unwrap();
+        let locale = L10n::new_with_locale(&default_code).unwrap();
         LocaleState {
             locale: Arc::new(RwLock::new(locale)),
             events: tx,

--- a/rust/agama-server/src/l10n/web.rs
+++ b/rust/agama-server/src/l10n/web.rs
@@ -1,12 +1,14 @@
 //! This module implements the web API for the localization module.
 
-use super::{keyboard::Keymap, locale::LocaleEntry, timezone::TimezoneEntry, L10n};
+use super::{
+    error::LocaleError, keyboard::Keymap, locale::LocaleEntry, timezone::TimezoneEntry, L10n,
+};
 use crate::{
     error::Error,
     l10n::helpers,
     web::{Event, EventsSender},
 };
-use agama_locale_data::{InvalidKeymap, LocaleId};
+use agama_locale_data::LocaleId;
 use axum::{
     extract::State,
     routing::{get, put},
@@ -17,18 +19,6 @@ use std::{
     process::Command,
     sync::{Arc, RwLock},
 };
-
-#[derive(thiserror::Error, Debug)]
-pub enum LocaleError {
-    #[error("Unknown locale code: {0}")]
-    UnknownLocale(String),
-    #[error("Unknown timezone: {0}")]
-    UnknownTimezone(String),
-    #[error("Invalid keymap: {0}")]
-    InvalidKeymap(#[from] InvalidKeymap),
-    #[error("Could not apply the changes")]
-    Commit(#[from] std::io::Error),
-}
 
 #[derive(Clone)]
 struct LocaleState {

--- a/rust/agama-server/src/l10n/web.rs
+++ b/rust/agama-server/src/l10n/web.rs
@@ -60,6 +60,7 @@ async fn locales(State(state): State<LocaleState<'_>>) -> Json<Vec<LocaleEntry>>
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct LocaleConfig {
     /// Locales to install in the target system
     locales: Option<Vec<String>>,

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -54,7 +54,7 @@ where
         .expect("Could not connect to NetworkManager to read the configuration");
 
     let router = MainServiceBuilder::new(events.clone(), web_ui_dir)
-        .add_service("/l10n", l10n_service(events.clone()))
+        .add_service("/l10n", l10n_service(dbus.clone(), events.clone()).await?)
         .add_service("/manager", manager_service(dbus.clone()).await?)
         .add_service("/software", software_service(dbus.clone()).await?)
         .add_service(

--- a/rust/agama-server/tests/l10n.rs
+++ b/rust/agama-server/tests/l10n.rs
@@ -88,11 +88,11 @@ async fn test_set_config_locales() -> Result<(), Box<dyn Error>> {
 
     let content = "{\"locales\":[\"es_ES.UTF-8\"]}";
     let body = Body::from(content);
-    let request = Request::put("/config")
+    let request = Request::patch("/config")
         .header("Content-Type", "application/json")
         .body(body)?;
     let response = service.clone().oneshot(request).await?;
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
     // check whether the value changed
     let request = Request::get("/config")

--- a/rust/agama-server/tests/l10n.rs
+++ b/rust/agama-server/tests/l10n.rs
@@ -1,34 +1,45 @@
 pub mod common;
 
-use agama_server::l10n::web::l10n_service;
+use std::{error::Error, future::pending, thread, time};
+
+use agama_lib::localization::LocalizationClient;
+use agama_locale_data::LocaleId;
+use agama_server::l10n::{export_dbus_objects, web::l10n_service};
 use axum::{
     body::Body,
     http::{Request, StatusCode},
     Router,
 };
-use common::body_to_string;
-use tokio::{sync::broadcast::channel, test};
+use common::{body_to_string, DBusServer};
+use tokio::{
+    sync::broadcast::channel,
+    test,
+    time::{sleep, Duration},
+};
 use tower::ServiceExt;
 
-fn build_service() -> Router {
+async fn build_service(dbus: zbus::Connection) -> Router {
     let (tx, _) = channel(16);
-    l10n_service(tx)
+    l10n_service(dbus, tx).await.unwrap()
 }
 
 #[test]
-async fn test_get_config() {
-    let service = build_service();
+async fn test_get_config() -> Result<(), Box<dyn Error>> {
+    let dbus_server = DBusServer::new().start().await?;
+    let service = build_service(dbus_server.connection()).await;
     let request = Request::builder()
         .uri("/config")
         .body(Body::empty())
         .unwrap();
     let response = service.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+    Ok(())
 }
 
 #[test]
-async fn test_locales() {
-    let service = build_service();
+async fn test_locales() -> Result<(), Box<dyn Error>> {
+    let dbus_server = DBusServer::new().start().await?;
+    let service = build_service(dbus_server.connection()).await;
     let request = Request::builder()
         .uri("/locales")
         .body(Body::empty())
@@ -37,11 +48,13 @@ async fn test_locales() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_to_string(response.into_body()).await;
     assert!(body.contains(r#""language":"English""#));
+    Ok(())
 }
 
 #[test]
-async fn test_keymaps() {
-    let service = build_service();
+async fn test_keymaps() -> Result<(), Box<dyn Error>> {
+    let dbus_server = DBusServer::new().start().await?;
+    let service = build_service(dbus_server.connection()).await;
     let request = Request::builder()
         .uri("/keymaps")
         .body(Body::empty())
@@ -50,11 +63,13 @@ async fn test_keymaps() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_to_string(response.into_body()).await;
     assert!(body.contains(r#""id":"us""#));
+    Ok(())
 }
 
 #[test]
-async fn test_timezones() {
-    let service = build_service();
+async fn test_timezones() -> Result<(), Box<dyn Error>> {
+    let dbus_server = DBusServer::new().start().await?;
+    let service = build_service(dbus_server.connection()).await;
     let request = Request::builder()
         .uri("/timezones")
         .body(Body::empty())
@@ -63,4 +78,32 @@ async fn test_timezones() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_to_string(response.into_body()).await;
     assert!(body.contains(r#""code":"Atlantic/Canary""#));
+    Ok(())
+}
+
+#[test]
+async fn test_set_config_locales() -> Result<(), Box<dyn Error>> {
+    let dbus_server = DBusServer::new().start().await?;
+    let service = build_service(dbus_server.connection()).await;
+
+    let content = "{\"locales\":[\"es_ES.UTF-8\"]}";
+    let body = Body::from(content);
+    let request = Request::put("/config")
+        .header("Content-Type", "application/json")
+        .body(body)?;
+    let response = service.clone().oneshot(request).await?;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // check whether the value changed
+    let request = Request::get("/config")
+        .header("Content-Type", "application/json")
+        .body(Body::empty())?;
+    let response = service.oneshot(request).await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_to_string(response.into_body()).await;
+    assert!(body.contains(r#""locales":["es_ES.UTF-8"]"#));
+
+    // TODO: check whether the D-Bus value was synchronized
+
+    Ok(())
 }

--- a/web/src/client/http.js
+++ b/web/src/client/http.js
@@ -151,6 +151,21 @@ class HTTPClient {
   }
 
   /**
+   * @param {string} url - Endpoint URL (e.g., "/l10n/config").
+   * @param {object} data - Data to submit
+   * @return {Promise<void>} Server response.
+   */
+  async patch(url, data) {
+    await fetch(`${this.baseUrl}/${url}`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  /**
    * Registers a handler for a given type of events.
    *
    * @param {string} type - Event type (e.g., "LocaleChanged").

--- a/web/src/client/l10n.js
+++ b/web/src/client/l10n.js
@@ -71,7 +71,7 @@ class L10nClient {
    * @return {Promise<void>}
    */
   async setUILocale(id) {
-    return this.client.put("/l10n/config", { ui_locale: id });
+    return this.client.patch("/l10n/config", { uiLocale: id });
   }
 
   /**
@@ -83,7 +83,7 @@ class L10nClient {
    */
   async getUIKeymap() {
     const config = await this.client.get("/l10n/config");
-    return config.ui_locale;
+    return config.uiKeymap;
   }
 
   /**
@@ -95,7 +95,7 @@ class L10nClient {
    * @return {Promise<void>}
    */
   async setUIKeymap(id) {
-    return this.client.put("/l10n/config", { ui_keymap: id });
+    return this.client.patch("/l10n/config", { uiKeymap: id });
   }
 
   /**
@@ -254,7 +254,7 @@ class L10nClient {
    * @return {Promise<object>}
    */
   async setConfig(data) {
-    return this.client.put("/l10n/config", data);
+    return this.client.patch("/l10n/config", data);
   }
 
   /**


### PR DESCRIPTION
Trello: https://trello.com/c/npg6apH0/351-make-l10n-http-json-and-d-bus-interfaces-share-the-same-state

At this point, two different (and disconnected) interfaces handle localization settings. The preferred one is HTTP-based, but a D-Bus one is still needed for internal communication.

This pull request tries reorganizing the code and keeping both APIs in sync.

## Tasks

- [x] Keep both APIs in sync
- [x] Reorganize the code to decouple the D-Bus interface from the original `Locale` struct.
- [x] Move common logic to the `Locale` struct (now `L10n`).
- [ ] Find a better name for the `L10n` struct.