### PR TITLE
web: Improve Patterns selector UI

### DIFF
--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -248,7 +248,7 @@ ul[data-type="agama/list"] {
 
   li {
     border: 2px solid var(--color-gray-dark);
-    padding: var(--spacer-normal);
+    padding: var(--spacer-small);
     text-align: start;
     background: var(--color-gray-light);
     margin-block-end: 0;
@@ -276,7 +276,6 @@ ul[data-type="agama/list"] {
   // not belongs to a listbox or grid list ul.
   li[aria-selected] {
     background: var(--color-gray-dark);
-    font-weight: 700;
 
     &:not(:last-child) {
       border-bottom-color: white;
@@ -314,15 +313,33 @@ ul[data-type="agama/list"][role="grid"] {
     div[role="gridcell"] {
       display: flex;
       align-items: center;
-      gap: var(--spacer-normal);
+      gap: var(--spacer-small);
 
-      & > input {
+      input {
         --size: var(--fs-h2);
+        cursor: pointer;
         block-size: var(--size);
         inline-size: var(--size);
+
+        &[data-auto-selected] {
+          accent-color: white;
+          box-shadow: 0 0 1px;
+        }
       }
 
-      & > div {
+      & > div:first-child {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--spacer-small);
+
+        span {
+          font-size: var(--fs-small);
+          font-weight: bold;
+        }
+      }
+
+      & > div:last-child {
         flex: 1;
       }
     }
@@ -383,6 +400,18 @@ ul[data-type="agama/list"][role="grid"] {
   > :nth-child(3) {
     color: var(--color-gray-dimmed);
     text-align: end;
+  }
+}
+
+ul[data-items-type="agama/patterns"] {
+  div[role="gridcell"] {
+    & > div:first-child {
+      min-width: 65px;
+    }
+
+    & > div:last-child * {
+      margin-block-end: var(--spacer-small);
+    }
   }
 }
 

--- a/web/src/components/core/Selector.jsx
+++ b/web/src/components/core/Selector.jsx
@@ -21,6 +21,7 @@
 
 // @ts-check
 import React from "react";
+import { _ } from "~/i18n";
 import { noop } from "~/utils";
 
 /**
@@ -61,6 +62,7 @@ import { noop } from "~/utils";
  * @param {function} props.renderOption=noop - Function used for rendering options.
  * @param {string} [props.optionIdKey="id"] - Key used for retrieve options id.
  * @param {Array<*>} [props.selectedIds=[]] - Identifiers for selected options.
+ * @param {function} props.autoSelectionCheck=noop - Function used to check if option should be marked as auto selected.
  * @param {onSelectionChangeCallback} [props.onSelectionChange=noop] - Callback to be called when the selection changes.
  * @param {function|undefined} [props.onOptionClick] - Callback to be called when the selection changes.
  * @param {object} [props.props] - Other props sent to the internal selector <ul> component
@@ -72,6 +74,7 @@ const Selector = ({
   renderOption = noop,
   optionIdKey = "id",
   selectedIds = [],
+  autoSelectionCheck = noop,
   onSelectionChange = noop,
   onOptionClick,
   ...props
@@ -99,6 +102,7 @@ const Selector = ({
         const optionId = option[optionIdKey];
         const optionHtmlId = `${id}-option-${optionId}`;
         const isSelected = selectedIds.includes(optionId);
+        const isAutoSelected = isSelected && autoSelectionCheck(option);
         const onClick = () => onOptionClicked(optionId);
 
         return (
@@ -108,14 +112,19 @@ const Selector = ({
             role="row"
             onClick={onClick}
             aria-selected={isSelected || undefined}
+            data-auto-selected={isAutoSelected || undefined}
           >
             <div role="gridcell">
-              <input
-                type={isMultiple ? "checkbox" : "radio"}
-                checked={isSelected}
-                onChange={onClick}
-                aria-labelledby={optionHtmlId}
-              />
+              <div>
+                <input
+                  type={isMultiple ? "checkbox" : "radio"}
+                  checked={isSelected}
+                  onChange={onClick}
+                  aria-labelledby={optionHtmlId}
+                  data-auto-selected={isAutoSelected || undefined}
+                />
+                {isAutoSelected && <div><span>{_("auto selected")}</span></div>}
+              </div>
               {renderOption(option)}
             </div>
           </li>

--- a/web/src/components/core/Selector.test.jsx
+++ b/web/src/components/core/Selector.test.jsx
@@ -71,6 +71,21 @@ describe("Selector", () => {
     expect(onChangeFn).toHaveBeenCalledWith([2]);
   });
 
+  it("sets data-auto-selected attribute to selected options for which `autoSelectionCheck` returns true", () => {
+    plainRender(
+      // Forcing a not selected option (en_GB) as auto selected for checking that it is not.
+      <TestingSelector autoSelectionCheck={o => ["es_ES", "en_GB"].includes(o.id)} />
+    );
+    const spanishRow = screen.getByRole("row", { name: "Spanish - Spain auto selected" });
+    const englishRow = screen.getByRole("row", { name: "English - United Kingdom" });
+    const spanishOption = within(spanishRow).getByRole("radio");
+    const englishOption = within(englishRow).getByRole("radio");
+    expect(spanishRow).toHaveAttribute("data-auto-selected");
+    expect(spanishOption).toHaveAttribute("data-auto-selected");
+    expect(englishRow).not.toHaveAttribute("data-auto-selected");
+    expect(englishOption).not.toHaveAttribute("data-auto-selected");
+  });
+
   describe("when set as single selector", () => {
     it("renders a radio input for each option", () => {
       plainRender(<TestingSelector />);

--- a/web/src/components/software/PatternSelector.jsx
+++ b/web/src/components/software/PatternSelector.jsx
@@ -134,16 +134,14 @@ function PatternSelector({ patterns, onSelectionChanged = noop }) {
 
   const groups = groupPatterns(visiblePatterns);
 
-  const renderPatternOption = (pattern) => {
-    return (
+  const renderPatternOption = (pattern) => (
+    <div>
       <div>
-        <div>
-          <b>{pattern.summary}</b>
-        </div>
-        <div>{pattern.description}</div>
+        <b>{pattern.summary}</b>
       </div>
-    );
-  }
+      <div>{pattern.description}</div>
+    </div>
+  );
 
   const selector = sortGroups(groups).map((groupName) => {
     const selectedIds = groups[groupName].filter((p) => p.selectedBy !== SelectedBy.NONE).map((p) =>

--- a/web/src/components/software/PatternSelector.jsx
+++ b/web/src/components/software/PatternSelector.jsx
@@ -134,14 +134,16 @@ function PatternSelector({ patterns, onSelectionChanged = noop }) {
 
   const groups = groupPatterns(visiblePatterns);
 
-  const renderPatternOption = (pattern) => (
-    <>
+  const renderPatternOption = (pattern) => {
+    return (
       <div>
-        <b>{pattern.summary}</b>
+        <div>
+          <b>{pattern.summary}</b>
+        </div>
+        <div>{pattern.description}</div>
       </div>
-      <div>{pattern.description}</div>
-    </>
-  );
+    );
+  }
 
   const selector = sortGroups(groups).map((groupName) => {
     const selectedIds = groups[groupName].filter((p) => p.selectedBy !== SelectedBy.NONE).map((p) =>
@@ -159,6 +161,8 @@ function PatternSelector({ patterns, onSelectionChanged = noop }) {
           onOptionClick={onToggle}
           optionIdKey="name"
           selectedIds={selectedIds}
+          autoSelectionCheck={pattern => pattern.selectedBy === SelectedBy.AUTO}
+          data-items-type="agama/patterns"
         />
       </Section>
     );


### PR DESCRIPTION
In #1112, the _Patterns selector_ was changed to be more consistent with the rest of the UI selection dialogs. However, the _core/Selector_ component used under the hood wasn't ready to handle auto selection. A partial adaptation was made by allowing overriding how it behaves when an option is clicked (see 61b0c0f), but the UI part is being addressed here by

* Improving how the information is layout
* Letting the user know which patterns are auto selected
  - Using a different _accent-color_ for the checkbox.
    
    After a few attemps, @imobachgs and me decided to go for a white accent color by now since it was the less out of line. We tested using the primary color (too dark, a bit confusing), only the border (quite confusing), using a dotted bottom border (it does not provide too much information nowadays, honestly), a solid square (weird). In any case, this is just an starting point, we can improve these details later, when we have time for playing a bit and/or giving love to the whole UI radio/checkbox.

  - Explicitly adding the "auto selected" text below the checkbox, since a just a different checkbox style (whatever we choose) is not enough for letting the user know that it has been auto selected pattern in a quick way. And no, a tooltip is not a good solution for this use case: it is hidden until the user focus or hover the widget.

| Before | After |
|-|-|
| ![Screenshot from 2024-04-01 21-01-07](https://github.com/openSUSE/agama/assets/1691872/aa48bc92-2099-4d43-a5d0-7cc70b3bcb73) | ![Screenshot from 2024-04-01 21-01-36](https://github.com/openSUSE/agama/assets/1691872/07ae6646-de4e-430a-b1c9-2a87cf46664d) |


The "auto selected" text might looks a bit longer, but honestly "auto" does not provide too much value there: _auto what?_ Maybe we can put it in another place (as a label in the bottom right corner of the item. or in the top left. Whatever. In any case, **please accept this change as it is** unless you find a very strong stopper. As said above, we can (and should) improve this later, when we can invest the deserved time for this kind of things. And, IMHO, the improvement should start in the back-end by allowing the user to get back to the auto selected state. As it is now is ok (I guess) for YaST user, but it quite confusing. Of course, I know that it isn't something trivial.
