### PR TITLE
Fix webpack configuration to load CockpitPoPlugin

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -8,6 +8,7 @@ const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const HtmlMinimizerPlugin = require("html-minimizer-webpack-plugin");
 const CompressionPlugin = require("compression-webpack-plugin");
 const ESLintPlugin = require('eslint-webpack-plugin');
+const CockpitPoPlugin = require("./src/lib/cockpit-po-plugin");
 const StylelintPlugin = require('stylelint-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');


### PR DESCRIPTION
Add a missing line to load the CockpitCoPlugin in webpack.
