### PR TITLE
Enable IPv6 on agama-web-server

### DIFF
--- a/rust/share/agama-web-server.service
+++ b/rust/share/agama-web-server.service
@@ -4,7 +4,7 @@ After=network-online.target agama.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/agama-web-server serve --address 0.0.0.0:80 --address2 0.0.0.0:443 --generate-token /run/agama/token
+ExecStart=/usr/bin/agama-web-server serve --address :::80 --address2 :::443 --generate-token /run/agama/token
 PIDFile=/run/agama/web.pid
 User=root
 TimeoutStopSec=5


### PR DESCRIPTION
Enable IPv6 support in the `agama-web-server` service (thanks @lslezak for the hint).
