### PR TITLE
Adapt product registration to the new architecture

### DIFF
--- a/rust/agama-lib/src/product.rs
+++ b/rust/agama-lib/src/product.rs
@@ -5,6 +5,6 @@ mod proxies;
 mod settings;
 mod store;
 
-pub use client::{Product, ProductClient};
+pub use client::{Product, ProductClient, RegistrationRequirement};
 pub use settings::ProductSettings;
 pub use store::ProductStore;

--- a/rust/agama-lib/src/product.rs
+++ b/rust/agama-lib/src/product.rs
@@ -1,7 +1,7 @@
 //! Implements support for handling the product settings
 
 mod client;
-mod proxies;
+pub mod proxies;
 mod settings;
 mod store;
 

--- a/rust/agama-lib/src/product/client.rs
+++ b/rust/agama-lib/src/product/client.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::error::ServiceError;
 use crate::software::proxies::SoftwareProductProxy;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use zbus::Connection;
 
 use super::proxies::RegistrationProxy;
@@ -18,6 +18,7 @@ pub struct Product {
     pub description: String,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub enum RegistrationRequirement {
     /// Product does not require registration
     NotRequired = 0,
@@ -32,9 +33,15 @@ impl TryFrom<u32> for RegistrationRequirement {
 
     fn try_from(v: u32) -> Result<Self, Self::Error> {
         match v {
-            x if x == RegistrationRequirement::NotRequired as u32 => Ok(RegistrationRequirement::NotRequired),
-            x if x == RegistrationRequirement::Optional as u32 => Ok(RegistrationRequirement::Optional),
-            x if x == RegistrationRequirement::Mandatory as u32 => Ok(RegistrationRequirement::Mandatory),
+            x if x == RegistrationRequirement::NotRequired as u32 => {
+                Ok(RegistrationRequirement::NotRequired)
+            }
+            x if x == RegistrationRequirement::Optional as u32 => {
+                Ok(RegistrationRequirement::Optional)
+            }
+            x if x == RegistrationRequirement::Mandatory as u32 => {
+                Ok(RegistrationRequirement::Mandatory)
+            }
             _ => Err(()),
         }
     }

--- a/rust/agama-lib/src/product/client.rs
+++ b/rust/agama-lib/src/product/client.rs
@@ -24,7 +24,7 @@ pub enum RegistrationRequirement {
     NotRequired = 0,
     /// Product has optional registration
     Optional = 1,
-    /// It is mandatory to register product
+    /// It is mandatory to register the product
     Mandatory = 2,
 }
 

--- a/rust/agama-lib/src/product/client.rs
+++ b/rust/agama-lib/src/product/client.rs
@@ -18,6 +18,28 @@ pub struct Product {
     pub description: String,
 }
 
+pub enum RegistrationRequirement {
+    /// Product does not require registration
+    NotRequired = 0,
+    /// Product has optional registration
+    Optional = 1,
+    /// It is mandatory to register product
+    Mandatory = 2,
+}
+
+impl TryFrom<u32> for RegistrationRequirement {
+    type Error = ();
+
+    fn try_from(v: u32) -> Result<Self, Self::Error> {
+        match v {
+            x if x == RegistrationRequirement::NotRequired as u32 => Ok(RegistrationRequirement::NotRequired),
+            x if x == RegistrationRequirement::Optional as u32 => Ok(RegistrationRequirement::Optional),
+            x if x == RegistrationRequirement::Mandatory as u32 => Ok(RegistrationRequirement::Mandatory),
+            _ => Err(()),
+        }
+    }
+}
+
 /// D-Bus client for the software service
 #[derive(Clone)]
 pub struct ProductClient<'a> {
@@ -86,6 +108,13 @@ impl<'a> ProductClient<'a> {
         Ok(self.registration_proxy.email().await?)
     }
 
+    pub async fn registration_requirement(&self) -> Result<RegistrationRequirement, ServiceError> {
+        let requirement = self.registration_proxy.requirement().await?;
+        // unknown number can happen only if we do programmer mistake
+        let result: RegistrationRequirement = requirement.try_into().unwrap();
+        Ok(result)
+    }
+
     /// register product
     pub async fn register(&self, code: &str, email: &str) -> Result<(u32, String), ServiceError> {
         let mut options: HashMap<&str, zbus::zvariant::Value> = HashMap::new();
@@ -93,5 +122,10 @@ impl<'a> ProductClient<'a> {
             options.insert("Email", zbus::zvariant::Value::new(email));
         }
         Ok(self.registration_proxy.register(code, options).await?)
+    }
+
+    /// de-register product
+    pub async fn deregister(&self) -> Result<(u32, String), ServiceError> {
+        Ok(self.registration_proxy.deregister().await?)
     }
 }

--- a/rust/agama-server/src/software.rs
+++ b/rust/agama-server/src/software.rs
@@ -1,2 +1,2 @@
 pub mod web;
-pub use web::{software_service, software_stream};
+pub use web::{software_service, software_streams};

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use agama_lib::{
     error::ServiceError,
-    product::{Product, ProductClient, RegistrationRequirement, proxies::RegistrationProxy},
+    product::{proxies::RegistrationProxy, Product, ProductClient, RegistrationRequirement},
     software::{
         proxies::{Software1Proxy, SoftwareProductProxy},
         Pattern, SelectedBy, SoftwareClient, UnknownSelectedBy,
@@ -49,9 +49,7 @@ pub struct SoftwareConfig {
 /// It emits the Event::ProductChanged and Event::PatternsChanged events.
 ///
 /// * `connection`: D-Bus connection to listen for events.
-pub async fn software_streams(
-    dbus: zbus::Connection,
-) -> Result<Streams, Error> {
+pub async fn software_streams(dbus: zbus::Connection) -> Result<Streams, Error> {
     let result: Streams = vec![
         (
             "patterns_changed",
@@ -118,7 +116,8 @@ async fn patterns_changed_stream(
     Ok(stream)
 }
 
-async fn registration_requirement_changed_stream(dbus: zbus::Connection,
+async fn registration_requirement_changed_stream(
+    dbus: zbus::Connection,
 ) -> Result<impl Stream<Item = Event>, Error> {
     // TODO: move registration requirement to product in dbus and so just one event will be needed.
     let proxy = RegistrationProxy::new(&dbus).await?;
@@ -128,7 +127,9 @@ async fn registration_requirement_changed_stream(dbus: zbus::Connection,
         .then(|change| async move {
             if let Ok(id) = change.get().await {
                 // unwrap is safe as possible numbers is send by our controlled dbus
-                return Some(Event::RegistrationRequirementChanged { requirement: id.try_into().unwrap() });
+                return Some(Event::RegistrationRequirementChanged {
+                    requirement: id.try_into().unwrap(),
+                });
             }
             None
         })
@@ -136,7 +137,8 @@ async fn registration_requirement_changed_stream(dbus: zbus::Connection,
     Ok(stream)
 }
 
-async fn registration_email_changed_stream(dbus: zbus::Connection,
+async fn registration_email_changed_stream(
+    dbus: zbus::Connection,
 ) -> Result<impl Stream<Item = Event>, Error> {
     let proxy = RegistrationProxy::new(&dbus).await?;
     let stream = proxy
@@ -153,7 +155,8 @@ async fn registration_email_changed_stream(dbus: zbus::Connection,
     Ok(stream)
 }
 
-async fn registration_code_changed_stream(dbus: zbus::Connection,
+async fn registration_code_changed_stream(
+    dbus: zbus::Connection,
 ) -> Result<impl Stream<Item = Event>, Error> {
     let proxy = RegistrationProxy::new(&dbus).await?;
     let stream = proxy

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -8,7 +8,7 @@
 use crate::{
     error::Error,
     web::{
-        common::{issues_router, progress_router, service_status_router, Streams},
+        common::{issues_router, progress_router, service_status_router, EventStreams},
         Event,
     },
 };
@@ -51,8 +51,8 @@ pub struct SoftwareConfig {
 /// It emits the Event::ProductChanged and Event::PatternsChanged events.
 ///
 /// * `connection`: D-Bus connection to listen for events.
-pub async fn software_streams(dbus: zbus::Connection) -> Result<Streams, Error> {
-    let result: Streams = vec![
+pub async fn software_streams(dbus: zbus::Connection) -> Result<EventStreams, Error> {
+    let result: EventStreams = vec![
         (
             "patterns_changed",
             Box::pin(patterns_changed_stream(dbus.clone()).await?),

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -120,6 +120,7 @@ async fn patterns_changed_stream(
 
 async fn registration_requirement_changed_stream(dbus: zbus::Connection,
 ) -> Result<impl Stream<Item = Event>, Error> {
+    // TODO: move registration requirement to product in dbus and so just one event will be needed.
     let proxy = RegistrationProxy::new(&dbus).await?;
     let stream = proxy
         .receive_requirement_changed()
@@ -143,7 +144,7 @@ async fn registration_email_changed_stream(dbus: zbus::Connection,
         .await
         .then(|change| async move {
             if let Ok(_id) = change.get().await {
-                // unwrap is safe as possible numbers is send by our controlled dbus
+                // TODO: add to stream also proxy and return whole cached registration info
                 return Some(Event::RegistrationChanged);
             }
             None
@@ -160,7 +161,6 @@ async fn registration_code_changed_stream(dbus: zbus::Connection,
         .await
         .then(|change| async move {
             if let Ok(_id) = change.get().await {
-                // unwrap is safe as possible numbers is send by our controlled dbus
                 return Some(Event::RegistrationChanged);
             }
             None

--- a/rust/agama-server/src/users/web.rs
+++ b/rust/agama-server/src/users/web.rs
@@ -30,9 +30,7 @@ struct UsersState<'a> {
 /// It emits the Event::RootPasswordChange, Event::RootSSHKeyChanged and Event::FirstUserChanged events.
 ///
 /// * `connection`: D-Bus connection to listen for events.
-pub async fn users_streams(
-    dbus: zbus::Connection,
-) -> Result<Streams, Error> {
+pub async fn users_streams(dbus: zbus::Connection) -> Result<Streams, Error> {
     const FIRST_USER_ID: &str = "first_user";
     const ROOT_PASSWORD_ID: &str = "root_password";
     const ROOT_SSHKEY_ID: &str = "root_sshkey";

--- a/rust/agama-server/src/users/web.rs
+++ b/rust/agama-server/src/users/web.rs
@@ -7,7 +7,7 @@
 use crate::{
     error::Error,
     web::{
-        common::{service_status_router, validation_router, Streams},
+        common::{service_status_router, validation_router, EventStreams},
         Event,
     },
 };
@@ -17,7 +17,6 @@ use agama_lib::{
 };
 use axum::{extract::State, routing::get, Json, Router};
 use serde::{Deserialize, Serialize};
-use std::pin::Pin;
 use tokio_stream::{Stream, StreamExt};
 
 #[derive(Clone)]
@@ -30,14 +29,14 @@ struct UsersState<'a> {
 /// It emits the Event::RootPasswordChange, Event::RootSSHKeyChanged and Event::FirstUserChanged events.
 ///
 /// * `connection`: D-Bus connection to listen for events.
-pub async fn users_streams(dbus: zbus::Connection) -> Result<Streams, Error> {
+pub async fn users_streams(dbus: zbus::Connection) -> Result<EventStreams, Error> {
     const FIRST_USER_ID: &str = "first_user";
     const ROOT_PASSWORD_ID: &str = "root_password";
     const ROOT_SSHKEY_ID: &str = "root_sshkey";
     // here we have three streams, but only two events. Reason is
     // that we have three streams from dbus about property change
     // and unify two root user properties into single event to http API
-    let result: Streams = vec![
+    let result: EventStreams = vec![
         (
             FIRST_USER_ID,
             Box::pin(first_user_changed_stream(dbus.clone()).await?),

--- a/rust/agama-server/src/users/web.rs
+++ b/rust/agama-server/src/users/web.rs
@@ -7,7 +7,7 @@
 use crate::{
     error::Error,
     web::{
-        common::{service_status_router, validation_router},
+        common::{service_status_router, validation_router, Streams},
         Event,
     },
 };
@@ -32,14 +32,14 @@ struct UsersState<'a> {
 /// * `connection`: D-Bus connection to listen for events.
 pub async fn users_streams(
     dbus: zbus::Connection,
-) -> Result<Vec<(&'static str, Pin<Box<dyn Stream<Item = Event> + Send>>)>, Error> {
+) -> Result<Streams, Error> {
     const FIRST_USER_ID: &str = "first_user";
     const ROOT_PASSWORD_ID: &str = "root_password";
     const ROOT_SSHKEY_ID: &str = "root_sshkey";
     // here we have three streams, but only two events. Reason is
     // that we have three streams from dbus about property change
     // and unify two root user properties into single event to http API
-    let result: Vec<(&str, Pin<Box<dyn Stream<Item = Event> + Send>>)> = vec![
+    let result: Streams = vec![
         (
             FIRST_USER_ID,
             Box::pin(first_user_changed_stream(dbus.clone()).await?),

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -10,7 +10,7 @@ use crate::{
     manager::web::{manager_service, manager_stream},
     network::{web::network_service, NetworkManagerAdapter},
     questions::web::{questions_service, questions_stream},
-    software::web::{software_service, software_stream},
+    software::web::{software_service, software_streams},
     users::web::{users_service, users_streams},
     web::common::{issues_stream, progress_stream, service_status_stream},
 };
@@ -110,7 +110,9 @@ async fn run_events_monitor(dbus: zbus::Connection, events: EventsSender) -> Res
     for (id, user_stream) in users_streams(dbus.clone()).await? {
         stream.insert(id, user_stream);
     }
-    stream.insert("software", software_stream(dbus.clone()).await?);
+    for (id, software_stream) in software_streams(dbus.clone()).await? {
+        stream.insert(id, software_stream);
+    }
     stream.insert(
         "software-status",
         service_status_stream(

--- a/rust/agama-server/src/web/common.rs
+++ b/rust/agama-server/src/web/common.rs
@@ -17,6 +17,8 @@ use crate::error::Error;
 
 use super::Event;
 
+pub type Streams = Vec<(&'static str, Pin<Box<dyn Stream<Item = Event> + Send>>)>;
+
 /// Builds a router to the `org.opensuse.Agama1.ServiceStatus` interface of the
 /// given D-Bus object.
 ///

--- a/rust/agama-server/src/web/common.rs
+++ b/rust/agama-server/src/web/common.rs
@@ -17,7 +17,7 @@ use crate::error::Error;
 
 use super::Event;
 
-pub type Streams = Vec<(&'static str, Pin<Box<dyn Stream<Item = Event> + Send>>)>;
+pub type EventStreams = Vec<(&'static str, Pin<Box<dyn Stream<Item = Event> + Send>>)>;
 
 /// Builds a router to the `org.opensuse.Agama1.ServiceStatus` interface of the
 /// given D-Bus object.

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -1,7 +1,7 @@
 use crate::l10n::web::LocaleConfig;
 use agama_lib::{
-    manager::InstallationPhase, progress::Progress, software::SelectedBy, users::FirstUser,
-    product::RegistrationRequirement,
+    manager::InstallationPhase, product::RegistrationRequirement, progress::Progress,
+    software::SelectedBy, users::FirstUser,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -24,7 +24,7 @@ pub enum Event {
     ProductChanged {
         id: String,
     },
-    RegistrationRequirementChanged{
+    RegistrationRequirementChanged {
         requirement: RegistrationRequirement,
     },
     RegistrationChanged,

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -1,6 +1,7 @@
 use crate::l10n::web::LocaleConfig;
 use agama_lib::{
     manager::InstallationPhase, progress::Progress, software::SelectedBy, users::FirstUser,
+    product::RegistrationRequirement,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -23,6 +24,10 @@ pub enum Event {
     ProductChanged {
         id: String,
     },
+    RegistrationRequirementChanged{
+        requirement: RegistrationRequirement,
+    },
+    RegistrationChanged,
     FirstUserChanged(FirstUser),
     RootChanged {
         password: Option<bool>,

--- a/web/src/Main.jsx
+++ b/web/src/Main.jsx
@@ -21,17 +21,15 @@
 
 import React from "react";
 import { Outlet } from "react-router-dom";
-// import { Questions } from "~/components/questions";
+import { Questions } from "~/components/questions";
 
 function Main() {
-  // FIXME: adapt to the new API
-  // return (
-  //   <>
-  //     <Questions />
-  //     <Outlet />
-  //   </>
-  // );
-  return <Outlet />;
+  return (
+    <>
+      <Questions />
+      <Outlet />
+    </>
+  );
 }
 
 export default Main;

--- a/web/src/client/software.js
+++ b/web/src/client/software.js
@@ -21,12 +21,10 @@
 
 // @ts-check
 
-import DBusClient from "./dbus";
 import { WithIssues, WithProgress, WithStatus } from "./mixins";
 
 const SOFTWARE_SERVICE = "org.opensuse.Agama.Software1";
 const PRODUCT_PATH = "/org/opensuse/Agama/Software1/Product";
-const REGISTRATION_IFACE = "org.opensuse.Agama1.Registration";
 
 /**
  * Enum for the reasons to select a pattern
@@ -281,7 +279,7 @@ class ProductBaseClient {
    * @returns {Promise<ActionResult>}
    */
   async register(code, email = "") {
-    const response = await this.client.post("/software/registration", { code, email });
+    const response = await this.client.post("/software/registration", { key: code, email });
 
     return {
       success: response.ok,
@@ -309,8 +307,10 @@ class ProductBaseClient {
    * @param {(registration: Registration) => void} handler - Callback function.
    */
   onRegistrationChange(handler) {
-    return this.client.onEvent("RegistrationChanged", () => {
-      this.getRegistration().then(handler);
+    return this.client.ws.onEvent((event) => {
+      if (event.type === "RegistrationChanged" || event.type === "RegistrationRequirementChanged") {
+        this.getRegistration().then(handler);
+      }
     });
   }
 }

--- a/web/src/components/overview/ProductSection.jsx
+++ b/web/src/components/overview/ProductSection.jsx
@@ -51,15 +51,15 @@ const Content = ({ isLoading = false }) => {
 };
 
 export default function ProductSection() {
-  const { software } = useInstallerClient();
+  const { product } = useInstallerClient();
   const [issues, setIssues] = useState([]);
   const { selectedProduct } = useProduct();
   const { cancellablePromise } = useCancellablePromise();
 
   useEffect(() => {
-    // cancellablePromise(software.product.getIssues()).then(setIssues);
-    // return software.product.onIssuesChange(setIssues);
-  }, [cancellablePromise, setIssues, software]);
+    cancellablePromise(product.getIssues()).then(setIssues);
+    return product.onIssuesChange(setIssues);
+  }, [cancellablePromise, setIssues, product]);
 
   const isLoading = !selectedProduct;
   const errors = isLoading ? [] : errorsFrom(issues);

--- a/web/src/components/overview/ProductSection.test.jsx
+++ b/web/src/components/overview/ProductSection.test.jsx
@@ -49,11 +49,9 @@ beforeEach(() => {
 
   createClient.mockImplementation(() => {
     return {
-      software: {
-        product: {
-          getIssues: jest.fn().mockResolvedValue(issues),
-          onIssuesChange: jest.fn()
-        }
+      product: {
+        getIssues: jest.fn().mockResolvedValue(issues),
+        onIssuesChange: jest.fn()
       }
     };
   });

--- a/web/src/components/product/ProductPage.jsx
+++ b/web/src/components/product/ProductPage.jsx
@@ -382,7 +382,7 @@ const RegistrationContent = ({ isLoading = false }) => {
 const RegistrationSection = ({ isLoading = false }) => {
   const { registration } = useProduct();
 
-  const isRequired = registration?.requirement !== "not-required";
+  const isRequired = registration?.requirement !== "NotRequired";
   const isRegistered = registration?.code !== null;
 
   return (

--- a/web/src/components/product/ProductPage.jsx
+++ b/web/src/components/product/ProductPage.jsx
@@ -43,7 +43,7 @@ import { useProduct } from "~/context/product";
  * @param {function} props.onCancel - Callback to be called when the product selection is canceled.
  */
 const ChangeProductPopup = ({ isOpen = false, onFinish = noop, onCancel = noop }) => {
-  const { manager, software } = useInstallerClient();
+  const { manager, software, product } = useInstallerClient();
   const { products, selectedProduct } = useProduct();
   const [newProductId, setNewProductId] = useState(selectedProduct?.id);
 
@@ -51,7 +51,7 @@ const ChangeProductPopup = ({ isOpen = false, onFinish = noop, onCancel = noop }
     e.preventDefault();
 
     if (newProductId !== selectedProduct?.id) {
-      await software.product.select(newProductId);
+      await product.select(newProductId);
       manager.startProbing();
     }
 
@@ -92,7 +92,7 @@ const RegisterProductPopup = ({
   onFinish = noop,
   onCancel: onCancelProp = noop
 }) => {
-  const { software } = useInstallerClient();
+  const { software, product } = useInstallerClient();
   const { selectedProduct } = useProduct();
   const [isLoading, setIsLoading] = useState(false);
   const [isFormValid, setIsFormValid] = useState(true);
@@ -100,7 +100,7 @@ const RegisterProductPopup = ({
 
   const onSubmit = async ({ code, email }) => {
     setIsLoading(true);
-    const result = await software.product.register(code, email);
+    const result = await product.register(code, email);
     setIsLoading(false);
     if (result.success) {
       software.probe();
@@ -161,14 +161,14 @@ const DeregisterProductPopup = ({
   onFinish = noop,
   onCancel: onCancelProp = noop
 }) => {
-  const { software } = useInstallerClient();
+  const { software, product } = useInstallerClient();
   const { selectedProduct } = useProduct();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState();
 
   const onAccept = async () => {
     setIsLoading(true);
-    const result = await software.product.deregister();
+    const result = await product.deregister();
     setIsLoading(false);
     if (result.success) {
       software.probe();

--- a/web/src/components/product/ProductPage.test.jsx
+++ b/web/src/components/product/ProductPage.test.jsx
@@ -30,6 +30,7 @@ import { createClient } from "~/client";
 let mockManager;
 let mockSoftware;
 let mockProducts;
+let mockProduct;
 let mockRegistration;
 
 const products = [
@@ -69,11 +70,12 @@ beforeEach(() => {
     probe: jest.fn(),
     getStatus: jest.fn().mockResolvedValue(),
     onStatusChange: jest.fn(),
-    product: {
-      getSelected: selectedProduct.id,
-      select: jest.fn().mockResolvedValue(),
-      onChange: jest.fn()
-    }
+  };
+
+  mockProduct = {
+    getSelected: selectedProduct.id,
+    select: jest.fn().mockResolvedValue(),
+    onChange: jest.fn()
   };
 
   mockProducts = products;
@@ -87,7 +89,8 @@ beforeEach(() => {
   createClient.mockImplementation(() => (
     {
       manager: mockManager,
-      software: mockSoftware
+      software: mockSoftware,
+      product: mockProduct,
     }
   ));
 });
@@ -132,7 +135,7 @@ describe("if the product is already registered", () => {
 
 describe("if the product does not require registration", () => {
   beforeEach(() => {
-    mockRegistration.requirement = "not-required";
+    mockRegistration.requirement = "NotRequired";
   });
 
   it("does not show a button to register the product", async () => {
@@ -208,7 +211,7 @@ describe("when the button for changing the product is clicked", () => {
       const accept = within(popup).getByRole("button", { name: "Accept" });
       await user.click(accept);
 
-      expect(mockSoftware.product.select).toHaveBeenCalledWith("Test-Product2");
+      expect(mockProduct.select).toHaveBeenCalledWith("Test-Product2");
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
@@ -226,7 +229,7 @@ describe("when the button for changing the product is clicked", () => {
         const cancel = within(popup).getByRole("button", { name: "Cancel" });
         await user.click(cancel);
 
-        expect(mockSoftware.product.select).not.toHaveBeenCalled();
+        expect(mockProduct.select).not.toHaveBeenCalled();
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       });
     });
@@ -259,7 +262,7 @@ describe("when the button for registering the product is clicked", () => {
   beforeEach(() => {
     mockRegistration.requirement = "mandatory";
     mockRegistration.code = null;
-    mockSoftware.product.register = jest.fn().mockResolvedValue({ success: true });
+    mockProduct.register = jest.fn().mockResolvedValue({ success: true });
   });
 
   it("opens a popup for registering the product", async () => {
@@ -278,7 +281,7 @@ describe("when the button for registering the product is clicked", () => {
     const accept = within(popup).getByRole("button", { name: "Accept" });
     await user.click(accept);
 
-    expect(mockSoftware.product.register).toHaveBeenCalledWith("111222", "test@test.com");
+    expect(mockProduct.register).toHaveBeenCalledWith("111222", "test@test.com");
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
@@ -293,14 +296,14 @@ describe("when the button for registering the product is clicked", () => {
       const cancel = within(popup).getByRole("button", { name: "Cancel" });
       await user.click(cancel);
 
-      expect(mockSoftware.product.register).not.toHaveBeenCalled();
+      expect(mockProduct.register).not.toHaveBeenCalled();
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });
 
   describe("if there is an error registering the product", () => {
     beforeEach(() => {
-      mockSoftware.product.register = jest.fn().mockResolvedValue({
+      mockProduct.register = jest.fn().mockResolvedValue({
         success: false,
         message: "Error registering product"
       });
@@ -329,7 +332,7 @@ describe("when the button to perform product de-registration is clicked", () => 
   beforeEach(() => {
     mockRegistration.requirement = "mandatory";
     mockRegistration.code = "111222";
-    mockSoftware.product.deregister = jest.fn().mockResolvedValue({ success: true });
+    mockProduct.deregister = jest.fn().mockResolvedValue({ success: true });
   });
 
   it("opens a popup to deregister the product", async () => {
@@ -344,7 +347,7 @@ describe("when the button to perform product de-registration is clicked", () => 
     const accept = within(popup).getByRole("button", { name: "Accept" });
     await user.click(accept);
 
-    expect(mockSoftware.product.deregister).toHaveBeenCalled();
+    expect(mockProduct.deregister).toHaveBeenCalled();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
@@ -359,14 +362,14 @@ describe("when the button to perform product de-registration is clicked", () => 
       const cancel = within(popup).getByRole("button", { name: "Cancel" });
       await user.click(cancel);
 
-      expect(mockSoftware.product.deregister).not.toHaveBeenCalled();
+      expect(mockProduct.deregister).not.toHaveBeenCalled();
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });
 
   describe("if there is an error performing the product de-registration", () => {
     beforeEach(() => {
-      mockSoftware.product.deregister = jest.fn().mockResolvedValue({
+      mockProduct.deregister = jest.fn().mockResolvedValue({
         success: false,
         message: "Product cannot be deregistered"
       });

--- a/web/src/components/product/ProductSelectionPage.test.jsx
+++ b/web/src/components/product/ProductSelectionPage.test.jsx
@@ -54,20 +54,18 @@ const managerMock = {
   startProbing: jest.fn()
 };
 
-const softwareMock = {
-  product: {
-    getAll: () => Promise.resolve(products),
-    getSelected: jest.fn(() => Promise.resolve(products[0])),
-    select: jest.fn().mockResolvedValue(),
-    onChange: jest.fn()
-  }
+const productMock = {
+  getAll: () => Promise.resolve(products),
+  getSelected: jest.fn(() => Promise.resolve(products[0])),
+  select: jest.fn().mockResolvedValue(),
+  onChange: jest.fn()
 };
 
 beforeEach(() => {
   createClient.mockImplementation(() => {
     return {
       manager: managerMock,
-      software: softwareMock
+      product: productMock,
     };
   });
 });
@@ -79,7 +77,7 @@ describe("when the user chooses a product", () => {
     const selectButton = screen.getByRole("button", { name: "Select" });
     await user.click(productOption);
     await user.click(selectButton);
-    expect(softwareMock.product.select).toHaveBeenCalledWith("MicroOS");
+    expect(productMock.select).toHaveBeenCalledWith("MicroOS");
     expect(managerMock.startProbing).toHaveBeenCalled();
     expect(mockNavigateFn).toHaveBeenCalledWith("/");
   });
@@ -91,7 +89,7 @@ describe("when the user chooses does not change the product", () => {
     screen.getByText("openSUSE Tumbleweed");
     const selectButton = await screen.findByRole("button", { name: "Select" });
     await user.click(selectButton);
-    expect(softwareMock.product.select).not.toHaveBeenCalled();
+    expect(productMock.select).not.toHaveBeenCalled();
     expect(managerMock.startProbing).not.toHaveBeenCalled();
     expect(mockNavigateFn).toHaveBeenCalledWith("/");
   });

--- a/web/src/context/product.jsx
+++ b/web/src/context/product.jsx
@@ -42,10 +42,10 @@ function ProductProvider({ children }) {
       const productClient = client.product;
       const available = await cancellablePromise(productClient.getAll());
       const selected = await cancellablePromise(productClient.getSelected());
-      // const registration = await cancellablePromise(productManager.getRegistration());
+      const registration = await cancellablePromise(productClient.getRegistration());
       setProducts(available);
       setSelectedId(selected);
-      // setRegistration(registration);
+      setRegistration(registration);
     };
 
     if (client) {
@@ -60,9 +60,9 @@ function ProductProvider({ children }) {
   }, [client, setSelectedId]);
 
   useEffect(() => {
-    // if (!client) return;
+    if (!client) return;
 
-    // return client.product.onRegistrationChange(setRegistration);
+    return client.product.onRegistrationChange(setRegistration);
   }, [client, setRegistration]);
 
   const value = { products, selectedId, registration };


### PR DESCRIPTION
Another change in set that switch web UI from using dbus to HTTP API. As part of this change the rust code is added to provide that HTTP API and also adapted web UI. It also fixes all relevant js tests.

Things discussed but postponed (due to size of change and time constraints ) in this change was:

1. move registration requirement from registration to product as it is highly coupled with it
2. provide all changed data in websocket signal, so client does not need to do another http call to get correct data

Matching trello card: https://trello.com/c/2bTZOnpB