### PR TITLE
Refactor the NetworkSystem API

### DIFF
--- a/rust/agama-server/src/network/dbus/service.rs
+++ b/rust/agama-server/src/network/dbus/service.rs
@@ -3,12 +3,12 @@
 //! This module defines a D-Bus service which exposes Agama's network configuration.
 use crate::network::{Adapter, NetworkSystem};
 use std::error::Error;
-use tokio;
 use zbus::Connection;
 
 /// Represents the Agama networking D-Bus service.
 ///
 /// It is responsible for starting the [NetworkSystem] on a different thread.
+/// TODO: this struct might not be needed anymore.
 pub struct NetworkService;
 
 impl NetworkService {
@@ -17,16 +17,8 @@ impl NetworkService {
         connection: &Connection,
         adapter: T,
     ) -> Result<(), Box<dyn Error>> {
-        let mut network = NetworkSystem::new(connection.clone(), adapter);
-
-        tokio::spawn(async move {
-            network
-                .setup()
-                .await
-                .expect("Could not set up the D-Bus tree");
-
-            network.listen().await;
-        });
+        let network = NetworkSystem::new(connection.clone(), adapter);
+        network.start().await?;
         Ok(())
     }
 }

--- a/rust/agama-server/src/network/system.rs
+++ b/rust/agama-server/src/network/system.rs
@@ -51,7 +51,7 @@ pub enum NetworkSystemError {
 ///     .expect("Could not connect to Agama's D-Bus server.");
 /// let network = NetworkSystem::new(dbus, adapter);
 ///
-/// // Start the networking service and get the channel for communication.
+/// // Start the networking service and get the client for communication.
 /// let client = network.start()
 ///     .await
 ///     .expect("Could not start the networking configuration system.");


### PR DESCRIPTION
## The problem

While working in introducing an API to get the runtime configuration of the network, we decided that we were not happy with the current `NetworkSystem` API. There was quite some manual to do when using the API, like dealing with channels and having to explictly move the server to a separate Tokio task.

## The solution

This change splits the API into smaller pieces:

* `NetworkSystem` is still the main entry point.
* `NetworkSystemClient` wraps the `actions` channel and offers a higher-level API by hiding the message passing handling.
* `NetworkSystemServer` keeps the network state and dispatches the actions. Beware that this struct is private and the `NetworkSystemClient` should be the only way to communicate with it.
* 
You can get a better idea of how it looks like through the following example (included in the documentation):

```rust
let adapter = NetworkManagerAdapter::from_system()
    .await
    .expect("Could not connect to NetworkManager.");
let dbus = connection()
    .await
    .expect("Could not connect to Agama's D-Bus server.");
let network = NetworkSystem::new(dbus, adapter);

// Start the networking service and get the client for communication.
let actions = network.start()
    .await
    .expect("Could not start the networking configuration system.");

// Perform some action, like getting the list of devices.
let devices = client.get_devices().await.unwrap();
```

## To do

* [ ] Get rid of `NetworkService` as it is not needed anymore. Should we rename `NetworkSystem*`?.
* [x] Adapt the HTTP/JSON interface to the new API (partially done).