### PR TITLE
web: Overrides few rules for PF/Table headers

### DIFF
--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -471,14 +471,7 @@ ul[data-type="agama/list"][role="grid"] {
 
 table[data-type="agama/tree-table"] {
   th:first-child {
-    block-size: fit-content;
     padding-inline-end: var(--spacer-normal);
-  }
-
-  th.fit-content {
-    block-size: fit-content;
-    overflow: visible;
-    text-overflow: unset;
   }
 
   /**

--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -263,6 +263,11 @@ ul {
   border-block-end: 0;
 }
 
+.pf-v5-c-table tr:where(.pf-v5-c-table__tr) > th {
+  white-space: normal;
+  vertical-align: middle;
+}
+
 @media screen and (width <= 768px) {
   .pf-m-grid-md.pf-v5-c-table tr:where(.pf-v5-c-table__tr):not(.pf-v5-c-table__expandable-row) {
     padding-inline: 0;

--- a/web/src/components/storage/ProposalResultSection.jsx
+++ b/web/src/components/storage/ProposalResultSection.jsx
@@ -186,7 +186,7 @@ const DevicesTreeTable = ({ devicesManager }) => {
     <TreeTable
       columns={[
         { title: _("Device"), content: renderDeviceName },
-        { title: _("Mount Point"), content: renderMountPoint, classNames: "fit-content" },
+        { title: _("Mount Point"), content: renderMountPoint },
         { title: _("Details"), content: renderDetails, classNames: "details-column" },
         { title: _("Size"), content: renderSize, classNames: "sizes-column" }
       ]}


### PR DESCRIPTION
## Problem

Sometimes table headers with an space in their content are cut and uses the `text-overflow` value of CSS property, even when looking at it _seems_ that there is enough space. Actually, there isn't because of `margin`s `padding`s and so.

## Solution

To overrides the PF/Table styles for setting the `white-space` CSS property from `nowrap` to `normal`. 

Forcing a size per column it's not a solution because 

* it does not warrant that it's the right size for the same content in different languages, and
* it is preferred to let the browser laying out the table according to the available space (among others)

## Testing

Tested manually.


## Note for reviewers

Although it has a little visual impact, I do not believe this deserves an entry in the changelog. But let me know if you think it should be added.

## Screenshots

| Before | After |
|-|-|
| ![Screen Shot 2024-04-16 at 15 40 56](https://github.com/openSUSE/agama/assets/1691872/1524bd3d-8037-4b58-8620-f3890371ff83) | ![Screen Shot 2024-04-16 at 15 32 32](https://github.com/openSUSE/agama/assets/1691872/f1ae3b3a-6166-4af5-8b7c-7c838045917d) |

