### PR TITLE
Include the encryption status in the device description

### DIFF
--- a/service/lib/agama/dbus/storage/interfaces/device/device.rb
+++ b/service/lib/agama/dbus/storage/interfaces/device/device.rb
@@ -62,7 +62,7 @@ module Agama
             #
             # @return [String] e.g., "EXT4 Partition".
             def device_description
-              Y2Storage::DeviceDescription.new(storage_device).to_s
+              Y2Storage::DeviceDescription.new(storage_device, include_encryption: true).to_s
             end
 
             def self.included(base)

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -38,8 +38,7 @@
     Requires:       yast2-iscsi-client >= 4.5.7
     Requires:       yast2-network
     Requires:       yast2-proxy
-    # TODO: update the required version
-    Requires:       yast2-storage-ng >= 5.0.10
+    Requires:       yast2-storage-ng >= 5.0.12
     Requires:       yast2-users
     %ifarch s390 s390x
     Requires:       yast2-s390 >= 4.6.4

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -38,6 +38,7 @@
     Requires:       yast2-iscsi-client >= 4.5.7
     Requires:       yast2-network
     Requires:       yast2-proxy
+    # TODO: update the required version
     Requires:       yast2-storage-ng >= 5.0.10
     Requires:       yast2-users
     %ifarch s390 s390x

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 18 08:46:06 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Display encryption status in the storage result
+  (gh#openSUSE/agama#1155)
+
+-------------------------------------------------------------------
 Wed Apr 10 11:35:53 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed setting unlimited maximum partition size

--- a/service/test/agama/dbus/storage/interfaces/device/device_examples.rb
+++ b/service/test/agama/dbus/storage/interfaces/device/device_examples.rb
@@ -46,7 +46,9 @@ shared_examples "Device interface" do
 
     describe "#device_description" do
       before do
-        allow(Y2Storage::DeviceDescription).to receive(:new).with(device).and_return(description)
+        allow(Y2Storage::DeviceDescription).to receive(:new)
+          .with(device, include_encryption: true)
+          .and_return(description)
       end
 
       let(:description) { instance_double(Y2Storage::DeviceDescription, to_s: "test") }


### PR DESCRIPTION
## Problem

- The device summary does not include the  encryption status in the device labels

## Solution

- Pass a new flag to `yast2-libstorage-ng` so the encryption status is included in the labels
- See https://github.com/yast/yast-storage-ng/pull/1379


## Testing

- Tested manually

