### PR TITLE
Use "DIAG" (upper case) label, added translators comment

### DIFF
--- a/web/src/components/storage/DASDTable.jsx
+++ b/web/src/components/storage/DASDTable.jsx
@@ -65,7 +65,10 @@ const columns = [
   { id: "status", label: _("Status") },
   { id: "name", label: _("Device") },
   { id: "type", label: _("Type") },
-  { id: "diag", label: _("Diag") },
+  // TRANSLATORS: table header, the column contains "Yes"/"No" values
+  // for the DIAG access mode (special disk access mode on IBM mainframes),
+  // usually keep untranslated
+  { id: "diag", label: _("DIAG") },
   { id: "formatted", label: _("Formatted") },
   { id: "partitionInfo", label: _("Partition Info") }
 ];


### PR DESCRIPTION
## Problem

- The "Diag" label is confusing for the translators (see the [weblate discussion](https://l10n.opensuse.org/translate/agama/agama-web/en/?q=has:comment#comments))
- Usually it is written in the upper case form


## Solution

- Use upper case
- Added a comment for translators with more details and a hint that usually it is not translated

