### PR TITLE
GitHub Action: bind mount /usr/bin/gh into the containers

### DIFF
--- a/.github/workflows/weblate-merge-po.yml
+++ b/.github/workflows/weblate-merge-po.yml
@@ -22,18 +22,20 @@ jobs:
 
     container:
       image: registry.opensuse.org/opensuse/tumbleweed:latest
+      volumes:
+        # bind mount the GitHub CLI tool from the Ubuntu host,
+        # it is a statically linked binary so it should work also in TumbleWeed
+        - /usr/bin/gh:/usr/bin/gh
 
     steps:
       - name: Configure and refresh repositories
         run: |
-          # install the GitHub command line tool "gh"
-          zypper addrepo https://cli.github.com/packages/rpm/gh-cli.repo
           # disable unused repositories to have a faster refresh
           zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && \
-            zypper --non-interactive --gpg-auto-import-keys ref
+            zypper --non-interactive ref
 
       - name: Install tools
-        run: zypper --non-interactive install --no-recommends gh git gettext-tools python3-langtable
+        run: zypper --non-interactive install --no-recommends git gettext-tools python3-langtable
 
       - name: Configure Git
         run: |

--- a/.github/workflows/weblate-merge-products-po.yml
+++ b/.github/workflows/weblate-merge-products-po.yml
@@ -22,18 +22,20 @@ jobs:
 
     container:
       image: registry.opensuse.org/opensuse/tumbleweed:latest
+      volumes:
+        # bind mount the GitHub CLI tool from the Ubuntu host,
+        # it is a statically linked binary so it should work also in TumbleWeed
+        - /usr/bin/gh:/usr/bin/gh
 
     steps:
       - name: Configure and refresh repositories
         run: |
-          # install the GitHub command line tool "gh"
-          zypper addrepo https://cli.github.com/packages/rpm/gh-cli.repo
           # disable unused repositories to have a faster refresh
           zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && \
-            zypper --non-interactive --gpg-auto-import-keys ref
+            zypper --non-interactive ref
 
       - name: Install tools
-        run: zypper --non-interactive install --no-recommends gh git gettext-tools npm-default
+        run: zypper --non-interactive install --no-recommends git gettext-tools npm-default
 
       - name: Configure Git
         run: |

--- a/.github/workflows/weblate-merge-service-po.yml
+++ b/.github/workflows/weblate-merge-service-po.yml
@@ -24,7 +24,7 @@ jobs:
       image: registry.opensuse.org/opensuse/tumbleweed:latest
       volumes:
         # bind mount the GitHub CLI tool from the Ubuntu host,
-        # it is a statically linked binary so it should work everywhere
+        # it is a statically linked binary so it should work also in TumbleWeed
         - /usr/bin/gh:/usr/bin/gh
 
     steps:
@@ -32,7 +32,7 @@ jobs:
         run: |
           # disable unused repositories to have a faster refresh
           zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && \
-            zypper --non-interactive --gpg-auto-import-keys ref
+            zypper --non-interactive ref
 
       - name: Install tools
         run: zypper --non-interactive install --no-recommends git gettext-tools


### PR DESCRIPTION

## Problem

- GitHub action which merges the translations from Weblate failed ([Action log](https://github.com/openSUSE/agama/actions/runs/8769617276/job/24065296950#step:3:27))
- The problem is that the repository changed the GPG signature and the `gh` package cannot be installed


## Solution

- Do not install it, it already is pre-installed in the default Ubuntu host system
- The `gh` tool is a statically linked binary without any dependencies so we can simply just bind mount it from the host into the container
- We already use this solution in the `.github/workflows/weblate-merge-service-po.yml` file, let's use it everywhere
