### PR TITLE
Delete not needed "dangerouslySetInnerHTML" parts

### DIFF
--- a/web/src/components/overview/StorageSection.jsx
+++ b/web/src/components/overview/StorageSection.jsx
@@ -102,15 +102,15 @@ const ProposalSummary = ({ proposal }) => {
     const msg = sprintf(fullMsg(result.settings.spacePolicy, pvDevices.length), vg, "%dev%");
 
     if (pvDevices.length > 1) {
-      return (<span dangerouslySetInnerHTML={{ __html: msg }} />);
+      return (<span>{msg}</span>);
     } else {
       const [msg1, msg2] = msg.split("%dev%");
 
       return (
         <Text>
-          <span dangerouslySetInnerHTML={{ __html: msg1 }} />
+          <span>{msg1}</span>
           <Em>{label(pvDevices[0])}</Em>
-          <span dangerouslySetInnerHTML={{ __html: msg2 }} />
+          <span>{msg2}</span>
         </Text>
       );
     }


### PR DESCRIPTION
## Problem

- We should avoid using `dangerouslySetInnerHTML` in the code
- In this case it is actually not needed anymore as the text messages do not contain any HTML markup

## Solution

- Just delete the `dangerouslySetInnerHTML` parts