### PR TITLE
Adapt to recent changes on Y2Storage::GuidedProposal

### DIFF
--- a/service/lib/agama/storage/proposal_settings_conversion/to_y2storage.rb
+++ b/service/lib/agama/storage/proposal_settings_conversion/to_y2storage.rb
@@ -207,20 +207,9 @@ module Agama
         #
         # @see ProposalSettings#installation_devices
         #
-        # If a device is partitioned, then its partitions are included instead of the device.
-        #
         # @return [Array<String>]
         def all_devices
-          settings.installation_devices
-            .map { |d| device_or_partitions(d) }
-            .flatten
-        end
-
-        # @param device [String]
-        # @return [String, Array<String>]
-        def device_or_partitions(device)
-          partitions = partitions(device)
-          partitions.empty? ? device : partitions
+          settings.installation_devices.flat_map { |d| partitions(d) }
         end
 
         # @param device [String]

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -38,7 +38,7 @@
     Requires:       yast2-iscsi-client >= 4.5.7
     Requires:       yast2-network
     Requires:       yast2-proxy
-    Requires:       yast2-storage-ng >= 5.0.12
+    Requires:       yast2-storage-ng >= 5.0.13
     Requires:       yast2-users
     %ifarch s390 s390x
     Requires:       yast2-s390 >= 4.6.4

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 25 13:40:06 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adapted to recent changes on Y2Storage::GuidedProposal
+  (gh#yast/yast-storage-ng#1382)
+
+-------------------------------------------------------------------
 Thu Apr 18 08:46:06 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Display encryption status in the storage result

--- a/service/test/agama/storage/proposal_settings_conversion/to_y2storage_test.rb
+++ b/service/test/agama/storage/proposal_settings_conversion/to_y2storage_test.rb
@@ -262,7 +262,7 @@ describe Agama::Storage::ProposalSettingsConversion::ToY2Storage do
           settings.space.policy = :delete
         end
 
-        it "generates delete actions for all used devices" do
+        it "generates delete actions for all the partitions at the used devices" do
           y2storage_settings = subject.convert
 
           expect(y2storage_settings.space_settings).to have_attributes(
@@ -270,9 +270,7 @@ describe Agama::Storage::ProposalSettingsConversion::ToY2Storage do
             actions:  {
               "/dev/sda1" => :force_delete,
               "/dev/sda2" => :force_delete,
-              "/dev/sda3" => :force_delete,
-              "/dev/sdb"  => :force_delete,
-              "/dev/sdc"  => :force_delete
+              "/dev/sda3" => :force_delete
             }
           )
         end
@@ -283,7 +281,7 @@ describe Agama::Storage::ProposalSettingsConversion::ToY2Storage do
           settings.space.policy = :resize
         end
 
-        it "generates resize actions for all used devices" do
+        it "generates resize actions for all the partitions at the used devices" do
           y2storage_settings = subject.convert
 
           expect(y2storage_settings.space_settings).to have_attributes(
@@ -291,9 +289,7 @@ describe Agama::Storage::ProposalSettingsConversion::ToY2Storage do
             actions:  {
               "/dev/sda1" => :resize,
               "/dev/sda2" => :resize,
-              "/dev/sda3" => :resize,
-              "/dev/sdb"  => :resize,
-              "/dev/sdc"  => :resize
+              "/dev/sda3" => :resize
             }
           )
         end

--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 25 13:40:06 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adapted to recent changes on Y2Storage::GuidedProposal
+  (gh#yast/yast-storage-ng#1382)
+
+-------------------------------------------------------------------
 Tue Apr 16 11:15:13 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
 - Use better icons in storage proposal page

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -539,7 +539,7 @@ class ProposalManager {
         const names = uniq(compact(values)).filter(d => d.length > 0);
 
         // #findDevice returns undefined if no device is found with the given name.
-        return compact(names.map(findDevice));
+        return compact(names.sort().map(findDevice));
       };
 
       const dbusSettings = proxy.Settings;

--- a/web/src/components/storage/SpacePolicyDialog.jsx
+++ b/web/src/components/storage/SpacePolicyDialog.jsx
@@ -114,19 +114,12 @@ export default function SpacePolicyDialog({
 
   // Generates the action value according to the policy.
   const deviceAction = (device) => {
-    let action;
-
     if (policy.id === "custom") {
-      action = actions.find(a => a.device === device.name)?.action || "keep";
-    } else {
-      const policyAction = { delete: "force_delete", resize: "resize", keep: "keep" };
-      action = policyAction[policy.id];
+      return actions.find(a => a.device === device.name)?.action || "keep";
     }
 
-    // For a drive device (e.g., Disk, RAID) it does not make sense to offer the resize action.
-    // At this moment, the Agama backend generates a resize action for drives if the policy is set
-    // to 'resize'. In that cases, the action is converted here to 'keep'.
-    return ((device.isDrive && action === "resize") ? "keep" : action);
+    const policyAction = { delete: "force_delete", resize: "resize", keep: "keep" };
+    return policyAction[policy.id];
   };
 
   const changeActions = (spaceAction) => {

--- a/web/src/components/storage/SpacePolicyDialog.test.jsx
+++ b/web/src/components/storage/SpacePolicyDialog.test.jsx
@@ -49,7 +49,7 @@ const sda = {
 const sda1 = {
   sid: 60,
   isDrive: false,
-  type: "",
+  type: "partition",
   active: true,
   name: "/dev/sda1",
   size: 512,
@@ -62,7 +62,7 @@ const sda1 = {
 const sda2 = {
   sid: 61,
   isDrive: false,
-  type: "",
+  type: "partition",
   active: true,
   name: "/dev/sda2",
   size: 512,
@@ -194,7 +194,7 @@ describe("SpacePolicyDialog", () => {
       // TODO: use a more inclusive way to disable the actions.
       // https://css-tricks.com/making-disabled-buttons-more-inclusive/
       const spaceActions = screen.getAllByRole("combobox", { name: /Space action selector/, hidden: true });
-      expect(spaceActions.length).toEqual(3);
+      expect(spaceActions.length).toEqual(2);
     });
   });
 
@@ -213,7 +213,7 @@ describe("SpacePolicyDialog", () => {
     it("allows to modify the space actions", async () => {
       plainRender(<SpacePolicyDialog { ...props } />);
       const spaceActions = screen.getAllByRole("combobox", { name: /Space action selector/ });
-      expect(spaceActions.length).toEqual(3);
+      expect(spaceActions.length).toEqual(2);
     });
   });
 
@@ -222,7 +222,7 @@ describe("SpacePolicyDialog", () => {
       props.policy = customPolicy;
     });
 
-    it("renders the space actions selector for devices without partition table", async () => {
+    it("renders the space actions selector for partitions", async () => {
       plainRender(<SpacePolicyDialog { ...props } />);
       // sda has partition table, the selector shouldn't be found
       const sdaRow = screen.getByRole("row", { name: /sda gpt/i });
@@ -232,17 +232,10 @@ describe("SpacePolicyDialog", () => {
       const unusedRow = screen.getByRole("row", { name: /unused space/i });
       const unusedActionsSelector = within(unusedRow).queryByRole("combobox");
       expect(unusedActionsSelector).toBeNull();
-      // sdb does not have partition table, selector should be there
+      // sdb is a disk, selector shouldn't be there
       const sdbRow = screen.getByRole("row", { name: /sdb/ });
-      within(sdbRow).getByRole("combobox");
-    });
-
-    it("does not renders the 'resize' option for drives", async () => {
-      plainRender(<SpacePolicyDialog { ...props } />);
-      const sdbRow = screen.getByRole("row", { name: /sdb/ });
-      const spaceActionsSelector = within(sdbRow).getByRole("combobox");
-      const resizeOption = within(spaceActionsSelector).queryByRole("option", { name: /resize/ });
-      expect(resizeOption).toBeNull();
+      const sdbActionsSelector = within(sdbRow).queryByRole("combobox");
+      expect(sdbActionsSelector).toBeNull();
     });
 
     it("renders the 'resize' option for devices other than drives", async () => {


### PR DESCRIPTION
## Problem

Agama uses the `Y2Storage` strategy to find space called `:bigger_resize`. That strategy was found to be inconsistent, so it was slightly modified.

See more details at https://github.com/yast/yast-storage-ng/pull/1382

## Solution

This pull request adapts Agama to the new approach, in which the space actions are only expected for partitions (and maybe in the future for logical volumes), but not for whole disks.

1) The actions generated for the pre-defined policies do not longer include the disks, only partitions.

2) The "Find Space" form only offers the action selector for the partitions. In the case of disks without partitions, some static texts are added to help the user understand what can happen with the content of the disk.

![partition_actions](https://github.com/openSUSE/agama/assets/3638289/d1996c0b-a8de-4cea-8a76-14d8b3240199)

Note we plan to rethink the whole interface of "Find Space" in the short term. This pull request only aims to keep the UI consistent with the new logic in the proposal, while the bigger changes arrive.

## Testing

- Unit tests adapted.
- Tested manually together with https://github.com/yast/yast-storage-ng/pull/1382