### PR TITLE
web: Reuse devices

### DIFF
--- a/service/lib/agama/dbus/storage/interfaces/device/filesystem.rb
+++ b/service/lib/agama/dbus/storage/interfaces/device/filesystem.rb
@@ -58,7 +58,7 @@ module Agama
             #
             # @return [String] e.g., "ext4"
             def filesystem_type
-              storage_device.filesystem.type.to_s
+              storage_device.filesystem.type.to_human_string
             end
 
             # Mount path of the file system.

--- a/service/lib/agama/storage/proposal_settings_conversion/to_y2storage.rb
+++ b/service/lib/agama/storage/proposal_settings_conversion/to_y2storage.rb
@@ -169,7 +169,9 @@ module Agama
         def volume_device_conversion(target)
           return unless settings.device.is_a?(DeviceSettings::Disk)
 
-          target.volumes.select(&:proposed?).each { |v| v.device ||= settings.device.name }
+          target.volumes
+            .select { |v| v.proposed? && !v.reuse_name }
+            .each { |v| v.device ||= settings.device.name }
         end
 
         # @param target [Y2Storage::ProposalSettings]

--- a/service/lib/agama/storage/volume_conversion/from_y2storage.rb
+++ b/service/lib/agama/storage/volume_conversion/from_y2storage.rb
@@ -59,8 +59,8 @@ module Agama
           planned = planned_device_for(target.mount_path)
           return unless planned
 
-          target.min_size = planned.min
-          target.max_size = planned.max
+          target.min_size = planned.min if planned.respond_to?(:min)
+          target.max_size = planned.max if planned.respond_to?(:max)
         end
 
         # Planned device for the given mount path.

--- a/service/test/agama/dbus/storage/interfaces/device/filesystem_examples.rb
+++ b/service/test/agama/dbus/storage/interfaces/device/filesystem_examples.rb
@@ -36,7 +36,7 @@ shared_examples "Filesystem interface" do
 
     describe "#filesystem_type" do
       it "returns the file system type" do
-        expect(subject.filesystem_type).to eq("ext4")
+        expect(subject.filesystem_type).to eq("Ext4")
       end
     end
 

--- a/service/test/agama/storage/proposal_settings_conversion/to_y2storage_test.rb
+++ b/service/test/agama/storage/proposal_settings_conversion/to_y2storage_test.rb
@@ -135,6 +135,25 @@ describe Agama::Storage::ProposalSettingsConversion::ToY2Storage do
             expect(y2storage_settings.candidate_devices).to contain_exactly("/dev/sda")
           end
         end
+
+        context "and a volume is reusing a device" do
+          before do
+            settings.volumes = [
+              Agama::Storage::Volume.new("/test1").tap do |volume|
+                volume.location.target = :device
+                volume.location.device = "/dev/sdb"
+              end
+            ]
+          end
+
+          it "does not set the target device as device for the volume with missing device" do
+            y2storage_settings = subject.convert
+
+            expect(y2storage_settings.volumes).to contain_exactly(
+              an_object_having_attributes(mount_point: "/test1", device: nil)
+            )
+          end
+        end
       end
 
       context "when the device settings is set to create a new LVM volume group" do

--- a/web/cspell.json
+++ b/web/cspell.json
@@ -71,6 +71,7 @@
         "subvolume",
         "subvolumes",
         "svgrrc",
+        "scrollbox",
         "teleporter",
         "testfile",
         "testsuite",

--- a/web/package/cockpit-agama.changes
+++ b/web/package/cockpit-agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May  3 09:45:36 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Allow reusing an existing device or file system
+  (gh#openSUSE/agama#1165).
+
+-------------------------------------------------------------------
 Thu May 02 11:07:23 UTC 2024 - Balsa Asanovic <balsaasanovic95@gmail.com>
 
 - Added keyboard support for navigating dropdown

--- a/web/src/assets/styles/composition.scss
+++ b/web/src/assets/styles/composition.scss
@@ -3,6 +3,10 @@
   margin-block-end: var(--stack-gutter);
 }
 
+.stack.small {
+  --stack-gutter: var(--spacer-smaller);
+}
+
 .flex-stack {
   display: flex;
   flex-direction: column;

--- a/web/src/assets/styles/composition.scss
+++ b/web/src/assets/styles/composition.scss
@@ -47,6 +47,20 @@
   }
 }
 
+.location-layout table button[id^="expand-toggle"] {
+  display: none;
+}
+
+.location-layout table tbody tr:not(:first-child) {
+  td:nth-child(2) {
+    padding-inline-start: 2ch;
+  }
+
+  td:nth-child(3) {
+    padding-inline-start: 5ch;
+  }
+}
+
 [data-state="reversed"] {
   flex-direction: row-reverse;
 }

--- a/web/src/assets/styles/composition.scss
+++ b/web/src/assets/styles/composition.scss
@@ -32,11 +32,14 @@
     display: flex;
     flex-direction: column;
     flex: 1 1 0;
+    gap: 0
   }
 
-  form > div:first-child {
-    min-block-size: 120px;
+  form > div:nth-child(2) {
     overflow-y: auto;
+    min-block-size: 120px;
+    margin-block-end: var(--spacer-medium);
+    table { background: transparent; }
   }
 
   form > div:last-child {

--- a/web/src/assets/styles/composition.scss
+++ b/web/src/assets/styles/composition.scss
@@ -3,10 +3,6 @@
   margin-block-end: var(--stack-gutter);
 }
 
-.stack.small {
-  --stack-gutter: var(--spacer-smaller);
-}
-
 .flex-stack {
   display: flex;
   flex-direction: column;
@@ -39,6 +35,7 @@
   }
 
   form > div:first-child {
+    min-block-size: 120px;
     overflow-y: auto;
   }
 
@@ -47,15 +44,12 @@
   }
 }
 
+// FIXME: Teporary solution to hide expand button. The button should be removed instead.
 .location-layout table button[id^="expand-toggle"] {
   display: none;
 }
 
 .location-layout table tbody tr:not(:first-child) {
-  td:nth-child(2) {
-    padding-inline-start: 2ch;
-  }
-
   td:nth-child(3) {
     padding-inline-start: 5ch;
   }

--- a/web/src/assets/styles/composition.scss
+++ b/web/src/assets/styles/composition.scss
@@ -47,7 +47,7 @@
   }
 }
 
-// FIXME: Teporary solution to hide expand button. The button should be removed instead.
+// FIXME: Temporary solution to hide expand button. The button should be removed instead.
 .location-layout table button[id^="expand-toggle"] {
   display: none;
 }

--- a/web/src/assets/styles/composition.scss
+++ b/web/src/assets/styles/composition.scss
@@ -24,6 +24,25 @@
   flex-wrap: wrap;
 }
 
+// TODO: make it less specific.
+.location-layout > div {
+  display: flex;
+
+  form {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 0;
+  }
+
+  form > div:first-child {
+    overflow-y: auto;
+  }
+
+  form > div:last-child {
+    min-block-size: min-content;
+  }
+}
+
 [data-state="reversed"] {
   flex-direction: row-reverse;
 }

--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -268,6 +268,10 @@ ul {
   vertical-align: middle;
 }
 
+.pf-v5-c-radio__label {
+  font-size: var(--fs-large);
+}
+
 @media screen and (width <= 768px) {
   .pf-m-grid-md.pf-v5-c-table tr:where(.pf-v5-c-table__tr):not(.pf-v5-c-table__expandable-row) {
     padding-inline: 0;

--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -268,8 +268,12 @@ ul {
   vertical-align: middle;
 }
 
+.pf-v5-c-radio {
+  align-items: center;
+}
+
 .pf-v5-c-radio__label {
-  font-size: var(--fs-large);
+  font-size: var(--pf-v5-c-form__label--FontSize);
 }
 
 @media screen and (width <= 768px) {

--- a/web/src/assets/styles/utilities.scss
+++ b/web/src/assets/styles/utilities.scss
@@ -223,6 +223,18 @@
   max-inline-size: calc(var(--ui-max-inline-size) + var(--spacer-large))
 }
 
+.scrollbox {
+  background:
+    linear-gradient(#fff 33%, rgb(255 255 255 / 0%)),
+    linear-gradient(rgb(255 255 255 / 0%), #fff 66%) 0 100%,
+    radial-gradient(farthest-side at 50% 0, rgb(102 102 102 / 50%), rgb(0 0 0 / 0%)),
+    radial-gradient(farthest-side at 50% 100%, rgba(102 102 102 / 50%), rgb(0 0 0 / 0%)) 0 100%;
+  background-color: #fff;
+  background-repeat: no-repeat;
+  background-attachment: local, local, scroll, scroll;
+  background-size: 100% 48px, 100% 48px, 100% 16px, 100% 16px;
+}
+
 .height-75 {
   height: 75dvh;
 }

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -472,10 +472,7 @@ class ProposalManager {
         return !!partitions.find(d => d.name === device.name);
       };
 
-      return (
-        !!availableDevices.find(d => d.name === device.name) ||
-        !!availableDevices.find(d => isChildren(device, d))
-      );
+      return !!availableDevices.find(d => d.name === device.name || isChildren(device, d));
     };
 
     /** @type {(device: StorageDevice[]) => boolean} */

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -566,7 +566,7 @@ class ProposalManager {
         return dbusTargetPVDevices.v.map(d => d.v);
       };
 
-      // TODO: Read installation devices from D-Bus.
+      /** @todo Read installation devices from D-Bus. */
       const buildInstallationDevices = (dbusSettings, devices) => {
         const findDevice = (name) => {
           const device = devices.find(d => d.name === name);
@@ -576,10 +576,14 @@ class ProposalManager {
           return device;
         };
 
+        const volumes = dbusSettings.Volumes.v.filter(vol => (
+          [VolumeTargets.NEW_PARTITION, VolumeTargets.NEW_VG].includes(vol.v.Target.v))
+        );
+
         const values = [
           dbusSettings.TargetDevice?.v,
           buildTargetPVDevices(dbusSettings.TargetPVDevices),
-          dbusSettings.Volumes.v.map(vol => vol.v.TargetDevice.v)
+          volumes.map(vol => vol.v.TargetDevice.v)
         ].flat();
 
         if (dbusSettings.ConfigureBoot.v) values.push(dbusSettings.BootDevice.v);

--- a/web/src/components/core/ExpandableSelector.jsx
+++ b/web/src/components/core/ExpandableSelector.jsx
@@ -112,7 +112,7 @@ const sanitizeSelection = (selection, allowMultiple) => {
  * @property {(item: object) => boolean} [itemSelectable=() => true] - Whether an item will be selectable or not.
  * @property {(item: object) => (string|undefined)} [itemClassNames=() => ""] - Callback that allows adding additional CSS class names to item row.
  * @property {object[]} [itemsSelected=[]] - Collection of selected items.
- * @property {string[]} [initialExpandedKeys=[]] - Ids of initially expanded items.
+ * @property {any[]} [initialExpandedKeys=[]] - Ids of initially expanded items.
  * @property {(selection: Array<object>) => void} [onSelectionChange=noop] - Callback to be triggered when selection changes.
  *
  * @typedef {ExpandableSelectorBaseProps & TableProps & HTMLTableProps} ExpandableSelectorProps

--- a/web/src/components/core/ExpandableSelector.jsx
+++ b/web/src/components/core/ExpandableSelector.jsx
@@ -25,6 +25,11 @@ import React, { useState } from "react";
 import { Table, Thead, Tr, Th, Tbody, Td, ExpandableRowContent, RowSelectVariant } from "@patternfly/react-table";
 
 /**
+ * @typedef {import("@patternfly/react-table").TableProps} TableProps
+ * @typedef {import("react").RefAttributes<HTMLTableElement>} HTMLTableProps
+ */
+
+/**
  * An object for sharing data across nested maps
  *
  * Since function arguments are always passed by value, an object passed by
@@ -93,23 +98,26 @@ const sanitizeSelection = (selection, allowMultiple) => {
 };
 
 /**
- * Build a expandable table with selectable items
+ * Build a expandable table with selectable items.
  * @component
  *
  * @note It only accepts one nesting level.
  *
- * @param {object} props
- * @param {ExpandableSelectorColumn[]} props.columns - Collection of objects defining columns.
- * @param {boolean} [props.isMultiple=false] - Whether multiple selection is allowed.
- * @param {object[]} props.items - Collection of items to be rendered.
- * @param {string} [props.itemIdKey="id"] - The key for retrieving the item id.
- * @param {(item: object) => Array<object>} [props.itemChildren=() => []] - Lookup method to retrieve children from given item.
- * @param {(item: object) => boolean} [props.itemSelectable=() => true] - Whether an item will be selectable or not.
- * @param {(item: object) => (string|undefined)} [props.itemClassNames=() => ""] - Callback that allows adding additional CSS class names to item row.
- * @param {object[]} [props.itemsSelected=[]] - Collection of selected items.
- * @param {string[]} [props.initialExpandedKeys=[]] - Ids of initially expanded items.
- * @param {(selection: Array<object>) => void} [props.onSelectionChange=noop] - Callback to be triggered when selection changes.
- * @param {object} [props.tableProps] - Props for {@link https://www.patternfly.org/components/table/#table PF/Table}.
+ * @typedef {object} ExpandableSelectorBaseProps
+ * @property {ExpandableSelectorColumn[]} [columns=[]] - Collection of objects defining columns.
+ * @property {boolean} [isMultiple=false] - Whether multiple selection is allowed.
+ * @property {object[]} [items=[]] - Collection of items to be rendered.
+ * @property {string} [itemIdKey="id"] - The key for retrieving the item id.
+ * @property {(item: object) => Array<object>} [itemChildren=() => []] - Lookup method to retrieve children from given item.
+ * @property {(item: object) => boolean} [itemSelectable=() => true] - Whether an item will be selectable or not.
+ * @property {(item: object) => (string|undefined)} [itemClassNames=() => ""] - Callback that allows adding additional CSS class names to item row.
+ * @property {object[]} [itemsSelected=[]] - Collection of selected items.
+ * @property {string[]} [initialExpandedKeys=[]] - Ids of initially expanded items.
+ * @property {(selection: Array<object>) => void} [onSelectionChange=noop] - Callback to be triggered when selection changes.
+ *
+ * @typedef {ExpandableSelectorBaseProps & TableProps & HTMLTableProps} ExpandableSelectorProps
+ *
+ * @param {ExpandableSelectorProps} props
  */
 export default function ExpandableSelector({
   columns = [],
@@ -126,7 +134,14 @@ export default function ExpandableSelector({
 }) {
   const [expandedItemsKeys, setExpandedItemsKeys] = useState(initialExpandedKeys);
   const selection = sanitizeSelection(itemsSelected, isMultiple);
-  const isItemSelected = (item) => selection.includes(item);
+  const isItemSelected = (item) => {
+    const selected = selection.find((selectionItem) => {
+      return Object.hasOwn(selectionItem, itemIdKey) &&
+        selectionItem[itemIdKey] === item[itemIdKey];
+    });
+
+    return selected !== undefined || selection.includes(item);
+  };
   const isItemExpanded = (key) => expandedItemsKeys.includes(key);
   const toggleExpanded = (key) => {
     if (isItemExpanded(key)) {

--- a/web/src/components/core/TreeTable.jsx
+++ b/web/src/components/core/TreeTable.jsx
@@ -30,8 +30,8 @@ import { Table, Thead, Tr, Th, Tbody, Td, TreeRowWrapper } from '@patternfly/rea
 
 /**
  * @typedef {object} TreeTableColumn
- * @property {string} title
- * @property {(any) => React.ReactNode} content
+ * @property {string} name
+ * @property {(object) => React.ReactNode} value
  * @property {string} [classNames]
  */
 
@@ -82,14 +82,14 @@ export default function TreeTable({
   const renderColumns = (item, treeRow) => {
     return columns.map((c, cIdx) => {
       const props = {
-        dataLabel: c.title,
+        dataLabel: c.name,
         className: c.classNames
       };
 
       if (cIdx === 0) props.treeRow = treeRow;
 
       return (
-        <Td key={cIdx} {...props}>{c.content(item)}</Td>
+        <Td key={cIdx} {...props}>{c.value(item)}</Td>
       );
     });
   };
@@ -138,7 +138,7 @@ export default function TreeTable({
     >
       <Thead>
         <Tr>
-          { columns.map((c, i) => <Th key={i} className={c.classNames}>{c.title}</Th>) }
+          { columns.map((c, i) => <Th key={i} className={c.classNames}>{c.name}</Th>) }
         </Tr>
       </Thead>
       <Tbody>

--- a/web/src/components/storage/BootConfigField.jsx
+++ b/web/src/components/storage/BootConfigField.jsx
@@ -60,7 +60,7 @@ const Button = ({ isBold = false, onClick }) => {
  * @param {boolean} props.configureBoot
  * @param {StorageDevice|undefined} props.bootDevice
  * @param {StorageDevice|undefined} props.defaultBootDevice
- * @param {StorageDevice[]} props.devices
+ * @param {StorageDevice[]} props.availableDevices
  * @param {boolean} props.isLoading
  * @param {(boot: BootConfig) => void} props.onChange
  *
@@ -72,7 +72,7 @@ export default function BootConfigField({
   configureBoot,
   bootDevice,
   defaultBootDevice,
-  devices,
+  availableDevices,
   isLoading,
   onChange
 }) {
@@ -113,7 +113,7 @@ export default function BootConfigField({
             configureBoot={configureBoot}
             bootDevice={bootDevice}
             defaultBootDevice={defaultBootDevice}
-            devices={devices}
+            availableDevices={availableDevices}
             onAccept={onAccept}
             onCancel={closeDialog}
           />

--- a/web/src/components/storage/BootConfigField.jsx
+++ b/web/src/components/storage/BootConfigField.jsx
@@ -56,17 +56,19 @@ const Button = ({ isBold = false, onClick }) => {
  * Allows to select the boot config.
  * @component
  *
- * @param {object} props
- * @param {boolean} props.configureBoot
- * @param {StorageDevice|undefined} props.bootDevice
- * @param {StorageDevice|undefined} props.defaultBootDevice
- * @param {StorageDevice[]} props.availableDevices
- * @param {boolean} props.isLoading
- * @param {(boot: BootConfig) => void} props.onChange
+ * @typedef {object} BootConfigFieldProps
+ * @property {boolean} configureBoot
+ * @property {StorageDevice|undefined} bootDevice
+ * @property {StorageDevice|undefined} defaultBootDevice
+ * @property {StorageDevice[]} availableDevices
+ * @property {boolean} isLoading
+ * @property {(boot: BootConfig) => void} onChange
  *
  * @typedef {object} BootConfig
  * @property {boolean} configureBoot
  * @property {StorageDevice} bootDevice
+ *
+ * @param {BootConfigFieldProps} props
  */
 export default function BootConfigField({
   configureBoot,

--- a/web/src/components/storage/BootConfigField.test.jsx
+++ b/web/src/components/storage/BootConfigField.test.jsx
@@ -26,6 +26,12 @@ import { screen, within } from "@testing-library/react";
 import { plainRender } from "~/test-utils";
 import BootConfigField from "~/components/storage/BootConfigField";
 
+/**
+ * @typedef {import("~/components/storage/BootConfigField").BootConfigFieldProps} BootConfigFieldProps
+ * @typedef {import ("~/client/storage").StorageDevice} StorageDevice
+ */
+
+/** @type {StorageDevice} */
 const sda = {
   sid: 59,
   description: "A fake disk for testing",
@@ -48,6 +54,7 @@ const sda = {
   udevPaths: ["pci-0000:00-12", "pci-0000:00-12-ata"],
 };
 
+/** @type {BootConfigFieldProps} */
 let props;
 
 beforeEach(() => {
@@ -55,7 +62,7 @@ beforeEach(() => {
     configureBoot: false,
     bootDevice: undefined,
     defaultBootDevice: undefined,
-    devices: [sda],
+    availableDevices: [sda],
     isLoading: false,
     onChange: jest.fn()
   };

--- a/web/src/components/storage/BootSelectionDialog.jsx
+++ b/web/src/components/storage/BootSelectionDialog.jsx
@@ -19,16 +19,15 @@
  * find current contact information at www.suse.com.
  */
 
+// @ts-check
+
 import React, { useState } from "react";
 import { Form } from "@patternfly/react-core";
 import { _ } from "~/i18n";
 import { DevicesFormSelect } from "~/components/storage";
-import { noop } from "~/utils";
 import { Popup } from "~/components/core";
 import { deviceLabel } from "~/components/storage/utils";
 import { sprintf } from "sprintf-js";
-
-// @ts-check
 
 /**
  * @typedef {import ("~/client/storage").StorageDevice} StorageDevice
@@ -58,18 +57,20 @@ const RadioOption = ({ id, onChange, defaultChecked, children }) => {
  * Renders a dialog that allows the user to select the boot configuration.
  * @component
  *
- * @typedef {object} Boot
+ * @typedef {object} BootSelectionDialogProps
+ * @property {boolean} configureBoot - Whether the boot is configurable
+ * @property {StorageDevice|undefined} bootDevice - Currently selected booting device.
+ * @property {StorageDevice|undefined} defaultBootDevice - Default booting device.
+ * @property {StorageDevice[]} availableDevices - Devices that user can select to boot from.
+ * @property {boolean} [isOpen=false] - Whether the dialog is visible or not.
+ * @property {() => void} onCancel
+ * @property {(boot: BootConfig) => void} onAccept
+ *
+ * @typedef {object} BootConfig
  * @property {boolean} configureBoot
  * @property {StorageDevice|undefined} bootDevice
  *
- * @param {object} props
- * @param {boolean} props.configureBoot - Whether the boot is configurable
- * @param {StorageDevice|undefined} props.bootDevice - Currently selected booting device.
- * @param {StorageDevice|undefined} props.defaultBootDevice - Default booting device.
- * @param {StorageDevice[]} props.availableDevices - Devices that user can select to boot from.
- * @param {boolean} [props.isOpen=false] - Whether the dialog is visible or not.
- * @param {function} [props.onCancel=noop]
- * @param {(boot: Boot) => void} [props.onAccept=noop]
+ * @param {BootSelectionDialogProps} props
  */
 export default function BootSelectionDialog({
   configureBoot: configureBootProp,
@@ -77,8 +78,8 @@ export default function BootSelectionDialog({
   defaultBootDevice,
   availableDevices,
   isOpen,
-  onCancel = noop,
-  onAccept = noop,
+  onCancel,
+  onAccept,
   ...props
 }) {
   const [configureBoot, setConfigureBoot] = useState(configureBootProp);

--- a/web/src/components/storage/BootSelectionDialog.jsx
+++ b/web/src/components/storage/BootSelectionDialog.jsx
@@ -66,7 +66,7 @@ const RadioOption = ({ id, onChange, defaultChecked, children }) => {
  * @param {boolean} props.configureBoot - Whether the boot is configurable
  * @param {StorageDevice|undefined} props.bootDevice - Currently selected booting device.
  * @param {StorageDevice|undefined} props.defaultBootDevice - Default booting device.
- * @param {StorageDevice[]} props.devices - Devices that user can select to boot from.
+ * @param {StorageDevice[]} props.availableDevices - Devices that user can select to boot from.
  * @param {boolean} [props.isOpen=false] - Whether the dialog is visible or not.
  * @param {function} [props.onCancel=noop]
  * @param {(boot: Boot) => void} [props.onAccept=noop]
@@ -75,7 +75,7 @@ export default function BootSelectionDialog({
   configureBoot: configureBootProp,
   bootDevice: bootDeviceProp,
   defaultBootDevice,
-  devices,
+  availableDevices,
   isOpen,
   onCancel = noop,
   onAccept = noop,
@@ -161,7 +161,7 @@ partitions in the appropriate disk."
             </div>
             <DevicesFormSelect
               aria-label={_("Choose a disk for placing the boot loader")}
-              devices={devices}
+              devices={availableDevices}
               selectedDevice={bootDevice}
               onChange={setBootDevice}
               isDisabled={!isBootManual}

--- a/web/src/components/storage/BootSelectionDialog.test.jsx
+++ b/web/src/components/storage/BootSelectionDialog.test.jsx
@@ -26,6 +26,12 @@ import { screen, within } from "@testing-library/react";
 import { plainRender } from "~/test-utils";
 import { BootSelectionDialog } from "~/components/storage";
 
+/**
+ * @typedef {import("./BootSelectionDialog").BootSelectionDialogProps} BootSelectionDialogProps
+ * @typedef {import ("~/client/storage").StorageDevice} StorageDevice
+ */
+
+/** @type {StorageDevice} */
 const sda = {
   sid: 59,
   isDrive: true,
@@ -40,6 +46,7 @@ const sda = {
   sdCard: true,
   active: true,
   name: "/dev/sda",
+  description: "",
   size: 1024,
   recoverableSize: 0,
   systems : [],
@@ -47,6 +54,7 @@ const sda = {
   udevPaths: ["pci-0000:00-12", "pci-0000:00-12-ata"],
 };
 
+/** @type {StorageDevice} */
 const sdb = {
   sid: 62,
   isDrive: true,
@@ -61,6 +69,7 @@ const sdb = {
   sdCard: false,
   active: true,
   name: "/dev/sdb",
+  description: "",
   size: 2048,
   recoverableSize: 0,
   systems : [],
@@ -68,6 +77,7 @@ const sdb = {
   udevPaths: ["pci-0000:00-19"]
 };
 
+/** @type {StorageDevice} */
 const sdc = {
   sid: 63,
   isDrive: true,
@@ -82,6 +92,7 @@ const sdc = {
   sdCard: false,
   active: true,
   name: "/dev/sdc",
+  description: "",
   size: 2048,
   recoverableSize: 0,
   systems : [],
@@ -89,6 +100,7 @@ const sdc = {
   udevPaths: ["pci-0000:00-19"]
 };
 
+/** @type {BootSelectionDialogProps} */
 let props;
 
 describe("BootSelectionDialog", () => {
@@ -96,7 +108,9 @@ describe("BootSelectionDialog", () => {
     props = {
       isOpen: true,
       configureBoot: false,
-      devices: [sda, sdb, sdc],
+      availableDevices: [sda, sdb, sdc],
+      bootDevice: undefined,
+      defaultBootDevice: undefined,
       onCancel: jest.fn(),
       onAccept: jest.fn()
     };

--- a/web/src/components/storage/DeviceSelectionDialog.jsx
+++ b/web/src/components/storage/DeviceSelectionDialog.jsx
@@ -28,7 +28,7 @@ import { _ } from "~/i18n";
 import { deviceChildren } from "~/components/storage/utils";
 import { ControlledPanels as Panels, Popup } from "~/components/core";
 import { DeviceSelectorTable } from "~/components/storage";
-import { noop } from "~/utils";
+import { compact, noop } from "~/utils";
 
 /**
  * @typedef {import ("~/client/storage").ProposalTarget} ProposalTarget
@@ -46,20 +46,21 @@ const OPTIONS_NAME = "selection-mode";
  * Renders a dialog that allows the user to select a target device for installation.
  * @component
  *
- * @param {object} props
- * @param {ProposalTarget} props.target
- * @param {StorageDevice|undefined} props.targetDevice
- * @param {StorageDevice[]} props.targetPVDevices
- * @param {StorageDevice[]} props.devices - The actions to perform in the system.
- * @param {boolean} [props.isOpen=false] - Whether the dialog is visible or not.
- * @param {() => void} [props.onCancel=noop]
- * @param {(target: Target) => void} [props.onAccept=noop]
+ * @typedef {object} DeviceSelectionDialogProps
+ * @property {ProposalTarget} target
+ * @property {StorageDevice|undefined} targetDevice
+ * @property {StorageDevice[]} targetPVDevices
+ * @property {StorageDevice[]} devices - The actions to perform in the system.
+ * @property {boolean} [isOpen=false] - Whether the dialog is visible or not.
+ * @property {() => void} [onCancel=noop]
+ * @property {(target: TargetConfig) => void} [onAccept=noop]
  *
- * @typedef {object} Target
+ * @typedef {object} TargetConfig
  * @property {string} target
  * @property {StorageDevice|undefined} targetDevice
  * @property {StorageDevice[]} targetPVDevices
-
+ *
+ * @param {DeviceSelectionDialogProps} props
  */
 export default function DeviceSelectionDialog({
   target: defaultTarget,
@@ -149,7 +150,7 @@ devices.").split(/[[\]]/);
             <DeviceSelectorTable
               aria-label={_("Device selector for target disk")}
               devices={devices}
-              selected={[targetDevice]}
+              selectedDevices={compact([targetDevice])}
               itemChildren={deviceChildren}
               itemSelectable={isDeviceSelectable}
               onSelectionChange={selectTargetDevice}
@@ -166,7 +167,7 @@ devices.").split(/[[\]]/);
               aria-label={_("Device selector for new LVM volume group")}
               isMultiple
               devices={devices}
-              selected={targetPVDevices}
+              selectedDevices={targetPVDevices}
               itemChildren={deviceChildren}
               itemSelectable={isDeviceSelectable}
               onSelectionChange={setTargetPVDevices}

--- a/web/src/components/storage/DeviceSelectionDialog.test.jsx
+++ b/web/src/components/storage/DeviceSelectionDialog.test.jsx
@@ -26,6 +26,12 @@ import { screen, within } from "@testing-library/react";
 import { plainRender } from "~/test-utils";
 import { DeviceSelectionDialog } from "~/components/storage";
 
+/**
+ * @typedef {import ("~/client/storage").StorageDevice} StorageDevice
+ * @typedef {import("./DeviceSelectionDialog").DeviceSelectionDialogProps} DeviceSelectionDialogProps
+ */
+
+/** @type {StorageDevice} */
 const sda = {
   sid: 59,
   isDrive: true,
@@ -40,6 +46,7 @@ const sda = {
   sdCard: true,
   active: true,
   name: "/dev/sda",
+  description: "",
   size: 1024,
   recoverableSize: 0,
   systems : [],
@@ -47,6 +54,7 @@ const sda = {
   udevPaths: ["pci-0000:00-12", "pci-0000:00-12-ata"],
 };
 
+/** @type {StorageDevice} */
 const sdb = {
   sid: 62,
   isDrive: true,
@@ -61,6 +69,7 @@ const sdb = {
   sdCard: false,
   active: true,
   name: "/dev/sdb",
+  description: "",
   size: 2048,
   recoverableSize: 0,
   systems : [],
@@ -68,6 +77,7 @@ const sdb = {
   udevPaths: ["pci-0000:00-19"]
 };
 
+/** @type {StorageDevice} */
 const sdc = {
   sid: 63,
   isDrive: true,
@@ -82,6 +92,7 @@ const sdc = {
   sdCard: false,
   active: true,
   name: "/dev/sdc",
+  description: "",
   size: 2048,
   recoverableSize: 0,
   systems : [],
@@ -89,6 +100,7 @@ const sdc = {
   udevPaths: ["pci-0000:00-19"]
 };
 
+/** @type {DeviceSelectionDialogProps} */
 let props;
 
 const expectSelector = (selector) => {
@@ -124,6 +136,7 @@ describe("DeviceSelectionDialog", () => {
     props = {
       isOpen: true,
       target: "DISK",
+      targetDevice: undefined,
       targetPVDevices: [],
       devices: [sda, sdb, sdc],
       onCancel: jest.fn(),

--- a/web/src/components/storage/DeviceSelectionDialog.test.jsx
+++ b/web/src/components/storage/DeviceSelectionDialog.test.jsx
@@ -20,6 +20,7 @@
  */
 
 // @ts-check
+// cspell:ignore dasda ddgdcbibhd
 
 import React from "react";
 import { screen, within } from "@testing-library/react";
@@ -47,7 +48,7 @@ const vda = {
   name: "/dev/vda",
   description: "",
   size: 1024,
-  systems : ["Windows 11", "openSUSE Leap 15.2"],
+  systems: ["Windows 11", "openSUSE Leap 15.2"],
   udevIds: ["ata-Micron_1100_SATA_512GB_12563", "scsi-0ATA_Micron_1100_SATA_512GB"],
   udevPaths: ["pci-0000:00-12", "pci-0000:00-12-ata"],
 };
@@ -64,7 +65,7 @@ const vda1 = {
   start: 123,
   encrypted: false,
   recoverableSize: 128,
-  systems : [],
+  systems: [],
   udevIds: [],
   udevPaths: [],
   isEFI: false
@@ -82,7 +83,7 @@ const vda2 = {
   start: 1789,
   encrypted: false,
   recoverableSize: 0,
-  systems : [],
+  systems: [],
   udevIds: [],
   udevPaths: [],
   isEFI: false
@@ -115,7 +116,7 @@ const vdb = {
   start: 0,
   encrypted: false,
   recoverableSize: 0,
-  systems : [],
+  systems: [],
   udevIds: [],
   udevPaths: []
 };
@@ -138,7 +139,7 @@ const vdc = {
   description: "",
   size: 2048,
   recoverableSize: 0,
-  systems : [],
+  systems: [],
   udevIds: [],
   udevPaths: ["pci-0000:00-19"]
 };
@@ -155,7 +156,7 @@ const md0 = {
   name: "/dev/md0",
   description: "",
   size: 2048,
-  systems : [],
+  systems: [],
   udevIds: [],
   udevPaths: []
 };
@@ -178,7 +179,7 @@ const raid = {
   name: "/dev/mapper/isw_ddgdcbibhd_244",
   description: "",
   size: 2048,
-  systems : [],
+  systems: [],
   udevIds: [],
   udevPaths: []
 };
@@ -201,7 +202,7 @@ const multipath = {
   name: "/dev/mapper/36005076305ffc73a00000000000013b4",
   description: "",
   size: 2048,
-  systems : [],
+  systems: [],
   udevIds: [],
   udevPaths: []
 };
@@ -223,7 +224,7 @@ const dasd = {
   name: "/dev/dasda",
   description: "",
   size: 2048,
-  systems : [],
+  systems: [],
   udevIds: [],
   udevPaths: []
 };

--- a/web/src/components/storage/DeviceSelectionDialog.test.jsx
+++ b/web/src/components/storage/DeviceSelectionDialog.test.jsx
@@ -32,7 +32,7 @@ import { DeviceSelectionDialog } from "~/components/storage";
  */
 
 /** @type {StorageDevice} */
-const sda = {
+const vda = {
   sid: 59,
   isDrive: true,
   type: "disk",
@@ -40,45 +40,88 @@ const sda = {
   model: "Micron 1100 SATA",
   driver: ["ahci", "mmcblk"],
   bus: "IDE",
-  busId: "",
   transport: "usb",
   dellBOSS: false,
   sdCard: true,
   active: true,
-  name: "/dev/sda",
+  name: "/dev/vda",
   description: "",
   size: 1024,
-  recoverableSize: 0,
-  systems : [],
+  systems : ["Windows 11", "openSUSE Leap 15.2"],
   udevIds: ["ata-Micron_1100_SATA_512GB_12563", "scsi-0ATA_Micron_1100_SATA_512GB"],
   udevPaths: ["pci-0000:00-12", "pci-0000:00-12-ata"],
 };
 
 /** @type {StorageDevice} */
-const sdb = {
+const vda1 = {
+  sid: 60,
+  isDrive: false,
+  type: "partition",
+  active: true,
+  name: "/dev/vda1",
+  description: "",
+  size: 512,
+  start: 123,
+  encrypted: false,
+  recoverableSize: 128,
+  systems : [],
+  udevIds: [],
+  udevPaths: [],
+  isEFI: false
+};
+
+/** @type {StorageDevice} */
+const vda2 = {
+  sid: 61,
+  isDrive: false,
+  type: "partition",
+  active: true,
+  name: "/dev/vda2",
+  description: "",
+  size: 256,
+  start: 1789,
+  encrypted: false,
+  recoverableSize: 0,
+  systems : [],
+  udevIds: [],
+  udevPaths: [],
+  isEFI: false
+};
+
+vda.partitionTable = {
+  type: "gpt",
+  partitions: [vda1, vda2],
+  unpartitionedSize: 0,
+  unusedSlots: []
+};
+
+/** @type {StorageDevice} */
+const vdb = {
   sid: 62,
   isDrive: true,
   type: "disk",
-  vendor: "Samsung",
-  model: "Samsung Evo 8 Pro",
-  driver: ["ahci"],
+  vendor: "Disk",
+  model: "",
+  driver: [],
   bus: "IDE",
   busId: "",
   transport: "",
   dellBOSS: false,
   sdCard: false,
   active: true,
-  name: "/dev/sdb",
+  name: "/dev/vdb",
   description: "",
   size: 2048,
+  start: 0,
+  encrypted: false,
   recoverableSize: 0,
   systems : [],
   udevIds: [],
-  udevPaths: ["pci-0000:00-19"]
+  udevPaths: []
 };
 
 /** @type {StorageDevice} */
-const sdc = {
+const vdc = {
   sid: 63,
   isDrive: true,
   type: "disk",
@@ -91,13 +134,98 @@ const sdc = {
   dellBOSS: false,
   sdCard: false,
   active: true,
-  name: "/dev/sdc",
+  name: "/dev/vdc",
   description: "",
   size: 2048,
   recoverableSize: 0,
   systems : [],
   udevIds: [],
   udevPaths: ["pci-0000:00-19"]
+};
+
+/** @type {StorageDevice} */
+const md0 = {
+  sid: 63,
+  isDrive: false,
+  type: "md",
+  level: "raid0",
+  uuid: "12345:abcde",
+  devices: [vdb],
+  active: true,
+  name: "/dev/md0",
+  description: "",
+  size: 2048,
+  systems : [],
+  udevIds: [],
+  udevPaths: []
+};
+
+/** @type {StorageDevice} */
+const raid = {
+  sid: 64,
+  isDrive: true,
+  type: "raid",
+  devices: [vda, vdb],
+  vendor: "Dell",
+  model: "Dell BOSS-N1 Modular",
+  driver: [],
+  bus: "",
+  busId: "",
+  transport: "",
+  dellBOSS: true,
+  sdCard: false,
+  active: true,
+  name: "/dev/mapper/isw_ddgdcbibhd_244",
+  description: "",
+  size: 2048,
+  systems : [],
+  udevIds: [],
+  udevPaths: []
+};
+
+/** @type {StorageDevice} */
+const multipath = {
+  sid: 65,
+  isDrive: true,
+  type: "multipath",
+  wires: [vda, vdb],
+  vendor: "",
+  model: "",
+  driver: [],
+  bus: "",
+  busId: "",
+  transport: "",
+  dellBOSS: false,
+  sdCard: false,
+  active: true,
+  name: "/dev/mapper/36005076305ffc73a00000000000013b4",
+  description: "",
+  size: 2048,
+  systems : [],
+  udevIds: [],
+  udevPaths: []
+};
+
+/** @type {StorageDevice} */
+const dasd = {
+  sid: 66,
+  isDrive: true,
+  type: "dasd",
+  vendor: "IBM",
+  model: "IBM",
+  driver: [],
+  bus: "",
+  busId: "0.0.0150",
+  transport: "",
+  dellBOSS: false,
+  sdCard: false,
+  active: true,
+  name: "/dev/dasda",
+  description: "",
+  size: 2048,
+  systems : [],
+  udevIds: [],
+  udevPaths: []
 };
 
 /** @type {DeviceSelectionDialogProps} */
@@ -138,7 +266,7 @@ describe("DeviceSelectionDialog", () => {
       target: "DISK",
       targetDevice: undefined,
       targetPVDevices: [],
-      devices: [sda, sdb, sdc],
+      devices: [vda, vdb, vdc, md0, raid, multipath, dasd],
       onCancel: jest.fn(),
       onAccept: jest.fn()
     };
@@ -157,7 +285,7 @@ describe("DeviceSelectionDialog", () => {
   describe("if the target is a disk", () => {
     beforeEach(() => {
       props.target = "DISK";
-      props.targetDevice = sda;
+      props.targetDevice = vda;
     });
 
     it("selects the disk option by default", () => {
@@ -179,9 +307,9 @@ describe("DeviceSelectionDialog", () => {
     it("shows the target disk as selected", () => {
       plainRender(<DeviceSelectionDialog {...props} />);
       const selector = screen.getByRole("grid", { name: /selector for target disk/i });
-      expectSelector(selector).toHaveCheckedOption(/sda/);
-      expectSelector(selector).not.toHaveCheckedOption(/sdb/);
-      expectSelector(selector).not.toHaveCheckedOption(/sdc/);
+      expectSelector(selector).toHaveCheckedOption(/\/dev\/vda/);
+      expectSelector(selector).not.toHaveCheckedOption(/\/dev\/vdb/);
+      expectSelector(selector).not.toHaveCheckedOption(/\/dev\/vdc/);
     });
 
     it("allows to switch to new LVM", async () => {
@@ -204,7 +332,7 @@ describe("DeviceSelectionDialog", () => {
   describe("if the target is a new LVM volume group", () => {
     beforeEach(() => {
       props.target = "NEW_LVM_VG";
-      props.targetPVDevices = [sda, sdc];
+      props.targetPVDevices = [vda, vdc];
     });
 
     it("selects the LVM option by default", () => {
@@ -226,9 +354,9 @@ describe("DeviceSelectionDialog", () => {
     it("shows the current candidate devices as selected", () => {
       plainRender(<DeviceSelectionDialog {...props} />);
       const selector = screen.getByRole("grid", { name: /selector for new lvm/i });
-      expectSelector(selector).toHaveCheckedOption(/sda/);
-      expectSelector(selector).not.toHaveCheckedOption(/sdb/);
-      expectSelector(selector).toHaveCheckedOption(/sdc/);
+      expectSelector(selector).toHaveCheckedOption(/\/dev\/vda/);
+      expectSelector(selector).not.toHaveCheckedOption(/\/dev\/vdb/);
+      expectSelector(selector).toHaveCheckedOption(/\/dev\/vdc/);
     });
 
     it("allows to switch to disk", async () => {
@@ -260,7 +388,7 @@ describe("DeviceSelectionDialog", () => {
   describe("if the option to select a disk as target device is selected", () => {
     beforeEach(() => {
       props.target = "NEW_LVM_VG";
-      props.targetDevice = sda;
+      props.targetDevice = vda;
     });
 
     it("calls onAccept with the selected target and disk on accept", async () => {
@@ -270,14 +398,14 @@ describe("DeviceSelectionDialog", () => {
       await user.click(diskOption);
 
       const selector = screen.getByRole("grid", { name: /selector for target disk/i });
-      await clickSelectorOption(user, selector, /sdb/);
+      await clickSelectorOption(user, selector, /\/dev\/vdb/);
 
       const accept = screen.getByRole("button", { name: "Confirm" });
       await user.click(accept);
 
       expect(props.onAccept).toHaveBeenCalledWith({
         target: "DISK",
-        targetDevice: sdb,
+        targetDevice: vdb,
         targetPVDevices: []
       });
     });
@@ -286,7 +414,7 @@ describe("DeviceSelectionDialog", () => {
   describe("if the option to create a new LVM volume group is selected", () => {
     beforeEach(() => {
       props.target = "DISK";
-      props.targetDevice = sdb;
+      props.targetDevice = vdb;
     });
 
     it("calls onAccept with the selected target and the candidate devices on accept", async () => {
@@ -296,17 +424,94 @@ describe("DeviceSelectionDialog", () => {
       await user.click(lvmOption);
 
       const selector = screen.getByRole("grid", { name: /selector for new lvm/i });
-      await clickSelectorOption(user, selector, /sda/);
-      await clickSelectorOption(user, selector, /sdc/);
+      await clickSelectorOption(user, selector, /\/dev\/vda/);
+      await clickSelectorOption(user, selector, /\/dev\/vdb/);
 
       const accept = screen.getByRole("button", { name: "Confirm" });
       await user.click(accept);
 
       expect(props.onAccept).toHaveBeenCalledWith({
         target: "NEW_LVM_VG",
-        targetDevice: sdb,
-        targetPVDevices: [sda, sdc]
+        targetDevice: vdb,
+        targetPVDevices: [vda, vdb]
       });
+    });
+  });
+
+  describe("content", () => {
+    const row = (name) => {
+      const selector = screen.getByRole("grid", { name: /selector for target disk/i });
+      return within(selector).getByRole("row", { name });
+    };
+
+    it("renders the device model", () => {
+      plainRender(<DeviceSelectionDialog {...props} />);
+      within(row(/\/dev\/vda/)).getByText("Micron 1100 SATA");
+    });
+
+    describe("when there is a SDCard", () => {
+      it("renders 'SD Card'", () => {
+        plainRender(<DeviceSelectionDialog {...props} />);
+        within(row(/\/dev\/vda/)).getByText("SD Card");
+      });
+    });
+
+    describe("when there is a software RAID", () => {
+      it("renders its level", () => {
+        plainRender(<DeviceSelectionDialog {...props} />);
+        within(row(/\/dev\/md0/)).getByText("Software RAID0");
+      });
+
+      it("renders its members", () => {
+        plainRender(<DeviceSelectionDialog {...props} />);
+        const mdRow = row(/\/dev\/md0/);
+        within(mdRow).getByText(/Members/);
+        within(mdRow).getByText(/vdb/);
+      });
+    });
+
+    describe("when device is RAID", () => {
+      it("renders its devices", () => {
+        plainRender(<DeviceSelectionDialog {...props} />);
+        const raidRow = row(/\/dev\/mapper\/isw_ddgdcbibhd_244/);
+        within(raidRow).getByText(/Devices/);
+        within(raidRow).getByText(/vda/);
+        within(raidRow).getByText(/vdb/);
+      });
+    });
+
+    describe("when device is a multipath", () => {
+      it("renders 'Multipath'", () => {
+        plainRender(<DeviceSelectionDialog {...props} />);
+        within(row(/\/dev\/mapper\/36005076305ffc73a00000000000013b4/)).getByText("Multipath");
+      });
+
+      it("renders its wires", () => {
+        plainRender(<DeviceSelectionDialog {...props} />);
+        const multipathRow = row(/\/dev\/mapper\/36005076305ffc73a00000000000013b4/);
+        within(multipathRow).getByText(/Wires/);
+        within(multipathRow).getByText(/vda/);
+        within(multipathRow).getByText(/vdb/);
+      });
+    });
+
+    describe("when device is DASD", () => {
+      it("renders its bus id", () => {
+        plainRender(<DeviceSelectionDialog {...props} />);
+        within(row(/\/dev\/dasda/)).getByText("DASD 0.0.0150");
+      });
+    });
+
+    it("renders the partition table info", () => {
+      plainRender(<DeviceSelectionDialog {...props} />);
+      within(row(/\/dev\/vda/)).getByText("GPT with 2 partitions");
+    });
+
+    it("renders systems info", () => {
+      plainRender(<DeviceSelectionDialog {...props} />);
+      const vdaRow = row(/\/dev\/vda/);
+      within(vdaRow).getByText("Windows 11");
+      within(vdaRow).getByText("openSUSE Leap 15.2");
     });
   });
 });

--- a/web/src/components/storage/DeviceSelectorTable.jsx
+++ b/web/src/components/storage/DeviceSelectorTable.jsx
@@ -168,7 +168,7 @@ const DeviceExtendedDetails = ({ item }) => {
     const System = ({ system }) => {
       const logo = /windows/i.test(system) ? "windows_logo" : "linux_logo";
 
-      return <><Icon name={logo} size="14" /> {system}</>;
+      return <div><Icon name={logo} size="14" /> {system}</div>;
     };
 
     return device.systems.map((s, i) => <System key={i} system={s} />);

--- a/web/src/components/storage/DeviceSelectorTable.jsx
+++ b/web/src/components/storage/DeviceSelectorTable.jsx
@@ -19,33 +19,192 @@
  * find current contact information at www.suse.com.
  */
 
+// @ts-check
+
 import React from "react";
+import { sprintf } from "sprintf-js";
+
 import { _ } from "~/i18n";
-import { deviceSize } from '~/components/storage/utils';
-import { DeviceExtendedInfo, DeviceContentInfo } from "~/components/storage";
-import { ExpandableSelector } from "~/components/core";
+import { deviceBaseName } from "~/components/storage/utils";
+import {
+  DeviceName, DeviceDetails, DeviceSize, FilesystemLabel, toStorageDevice
+} from "~/components/storage/device-utils";
+import { ExpandableSelector, If } from "~/components/core";
+import { Icon } from "~/components/layout";
 
 /**
- * @typedef {import ("~/client/storage").ProposalSettings} ProposalSettings
+ * @typedef {import("../core/ExpandableSelector").ExpandableSelectorColumn} ExpandableSelectorColumn
+ * @typedef {import("../core/ExpandableSelector").ExpandableSelectorProps} ExpandableSelectorProps
+ * @typedef {import("~/client/storage").PartitionSlot} PartitionSlot
  * @typedef {import ("~/client/storage").StorageDevice} StorageDevice
  */
 
-const DeviceInfo = ({ device }) => {
-  if (!device.sid) return _("Unused space");
+/**
+ * @component
+ *
+ * @param {object} props
+ * @param {PartitionSlot|StorageDevice} props.item
+ */
+const DeviceInfo = ({ item }) => {
+  const device = toStorageDevice(item);
+  if (!device) return null;
 
-  return <DeviceExtendedInfo device={device} />;
+  const DeviceType = () => {
+    let type;
+
+    switch (device.type) {
+      case "multipath": {
+        // TRANSLATORS: multipath device type
+        type = _("Multipath");
+        break;
+      }
+      case "dasd": {
+        // TRANSLATORS: %s is replaced by the device bus ID
+        type = sprintf(_("DASD %s"), device.busId);
+        break;
+      }
+      case "md": {
+        // TRANSLATORS: software RAID device, %s is replaced by the RAID level, e.g. RAID-1
+        type = sprintf(_("Software %s"), device.level.toUpperCase());
+        break;
+      }
+      case "disk": {
+        if (device.sdCard) {
+          type = _("SD Card");
+        } else {
+          const technology = device.transport || device.bus;
+          type = technology
+            // TRANSLATORS: %s is substituted by the type of disk like "iSCSI" or "SATA"
+            ? sprintf(_("%s disk"), technology)
+            : _("Disk");
+        }
+      }
+    }
+
+    return <If condition={type} then={<div>{type}</div>} />;
+  };
+
+  const DeviceModel = () => {
+    if (!device.model || device.model === "") return null;
+
+    return <div>{device.model}</div>;
+  };
+
+  const MDInfo = () => {
+    if (device.type !== "md" || !device.devices) return null;
+
+    const members = device.devices.map(deviceBaseName);
+
+    // TRANSLATORS: RAID details, %s is replaced by list of devices used by the array
+    return <div>{sprintf(_("Members: %s"), members.sort().join(", "))}</div>;
+  };
+
+  const RAIDInfo = () => {
+    if (device.type !== "raid") return null;
+
+    const devices = device.devices.map(deviceBaseName);
+
+    // TRANSLATORS: RAID details, %s is replaced by list of devices used by the array
+    return <div>{sprintf(_("Devices: %s"), devices.sort().join(", "))}</div>;
+  };
+
+  const MultipathInfo = () => {
+    if (device.type !== "multipath") return null;
+
+    const wires = device.wires.map(deviceBaseName);
+
+    // TRANSLATORS: multipath details, %s is replaced by list of connections used by the device
+    return <div>{sprintf(_("Wires: %s"), wires.sort().join(", "))}</div>;
+  };
+
+  return (
+    <div>
+      <DeviceName item={device} />
+      <DeviceType />
+      <DeviceModel />
+      <MDInfo />
+      <RAIDInfo />
+      <MultipathInfo />
+    </div>
+  );
 };
 
-const deviceColumns = [
-  { name: _("Device"), value: (device) => <DeviceInfo device={device} /> },
-  { name: _("Content"), value: (device) => <DeviceContentInfo device={device} /> },
-  { name: _("Size"), value: (device) => deviceSize(device.size), classNames: "sizes-column" }
+/**
+ * @component
+ *
+ * @param {object} props
+ * @param {PartitionSlot|StorageDevice} props.item
+ */
+const DeviceExtendedDetails = ({ item }) => {
+  const device = toStorageDevice(item);
+
+  if (!device || ["partition", "lvmLv"].includes(device.type))
+    return <DeviceDetails item={item} />;
+
+  // TODO: there is a lot of room for improvement here, but first we would need
+  // device.description (comes from YaST) to be way more granular
+  const Description = () => {
+    if (device.partitionTable) {
+      const type = device.partitionTable.type.toUpperCase();
+      const numPartitions = device.partitionTable.partitions.length;
+
+      // TRANSLATORS: disk partition info, %s is replaced by partition table
+      // type (MS-DOS or GPT), %d is the number of the partitions
+      return sprintf(_("%s with %d partitions"), type, numPartitions);
+    }
+
+    if (!!device.model && device.model === device.description) {
+      // TRANSLATORS: status message, no existing content was found on the disk,
+      // i.e. the disk is completely empty
+      return _("No content found");
+    }
+
+    return <div>{device.description} <FilesystemLabel item={device} /></div>;
+  };
+
+  const Systems = () => {
+    if (!device.systems || device.systems.length === 0) return null;
+
+    const System = ({ system }) => {
+      const logo = /windows/i.test(system) ? "windows_logo" : "linux_logo";
+
+      return <><Icon name={logo} size="14" /> {system}</>;
+    };
+
+    return device.systems.map((s, i) => <System key={i} system={s} />);
+  };
+
+  return (
+    <div>
+      <Description />
+      <Systems />
+    </div>
+  );
+};
+
+/** @type {ExpandableSelectorColumn[]} */
+const columns = [
+  { name: _("Device"), value: (item) => <DeviceInfo item={item} /> },
+  { name: _("Details"), value: (item) => <DeviceExtendedDetails item={item} /> },
+  { name: _("Size"), value: (item) => <DeviceSize item={item} />, classNames: "sizes-column" }
 ];
 
-export default function DeviceSelectorTable({ devices, selected, ...props }) {
+/**
+ * Table for selecting the installation device.
+ * @component
+ *
+ * @typedef {object} DeviceSelectorTableBaseProps
+ * @property {StorageDevice[]} devices
+ * @property {StorageDevice[]} selectedDevices
+ *
+ * @typedef {DeviceSelectorTableBaseProps & ExpandableSelectorProps} DeviceSelectorTableProps
+ *
+ * @param {DeviceSelectorTableProps} props
+ */
+export default function DeviceSelectorTable({ devices, selectedDevices, ...props }) {
   return (
     <ExpandableSelector
-      columns={deviceColumns}
+      columns={columns}
       items={devices}
       itemIdKey="sid"
       itemClassNames={(device) => {
@@ -53,7 +212,7 @@ export default function DeviceSelectorTable({ devices, selected, ...props }) {
           return "dimmed-row";
         }
       }}
-      itemsSelected={selected}
+      itemsSelected={selectedDevices}
       className="devices-table"
       {...props}
     />

--- a/web/src/components/storage/DevicesManager.js
+++ b/web/src/components/storage/DevicesManager.js
@@ -33,6 +33,8 @@ import { compact, uniq } from "~/utils";
  */
 export default class DevicesManager {
   /**
+   * @constructor
+   *
    * @param {StorageDevice[]} system - Devices representing the current state of the system.
    * @param {StorageDevice[]} staging - Devices representing the target state of the system.
    * @param {Action[]} actions - Actions to perform from system to staging.
@@ -45,6 +47,7 @@ export default class DevicesManager {
 
   /**
    * System device with the given SID.
+   * @method
    *
    * @param {Number} sid
    * @returns {StorageDevice|undefined}
@@ -55,6 +58,7 @@ export default class DevicesManager {
 
   /**
    * Staging device with the given SID.
+   * @method
    *
    * @param {Number} sid
    * @returns {StorageDevice|undefined}
@@ -65,6 +69,7 @@ export default class DevicesManager {
 
   /**
    * Whether the given device exists in system.
+   * @method
    *
    * @param {StorageDevice} device
    * @returns {Boolean}
@@ -75,6 +80,7 @@ export default class DevicesManager {
 
   /**
    * Whether the given device exists in staging.
+   * @method
    *
    * @param {StorageDevice} device
    * @returns {Boolean}
@@ -85,6 +91,7 @@ export default class DevicesManager {
 
   /**
    * Whether the given device is going to be formatted.
+   * @method
    *
    * @param {StorageDevice} device
    * @returns {Boolean}
@@ -100,6 +107,7 @@ export default class DevicesManager {
 
   /**
    * Whether the given device is going to be shrunk.
+   * @method
    *
    * @param {StorageDevice} device
    * @returns {Boolean}
@@ -110,6 +118,7 @@ export default class DevicesManager {
 
   /**
    * Amount of bytes the given device is going to be shrunk.
+   * @method
    *
    * @param {StorageDevice} device
    * @returns {Number}
@@ -126,6 +135,7 @@ export default class DevicesManager {
 
   /**
    * Disk devices and LVM volume groups used for the installation.
+   * @method
    *
    * @note The used devices are extracted from the actions.
    *
@@ -147,6 +157,7 @@ export default class DevicesManager {
 
   /**
    * Devices deleted.
+   * @method
    *
    * @note The devices are extracted from the actions.
    *
@@ -158,6 +169,7 @@ export default class DevicesManager {
 
   /**
    * Systems deleted.
+   * @method
    *
    * @returns {string[]}
    */

--- a/web/src/components/storage/DevicesManager.js
+++ b/web/src/components/storage/DevicesManager.js
@@ -142,7 +142,7 @@ export default class DevicesManager {
    * @returns {StorageDevice[]}
    */
   usedDevices() {
-    const isTarget = (device) => device.isDrive || device.type === "lvmVg";
+    const isTarget = (device) => device.isDrive || ["md", "lvmVg"].includes(device.type);
 
     // Check in system devices to detect removals.
     const targetSystem = this.system.filter(isTarget);

--- a/web/src/components/storage/PartitionsField.jsx
+++ b/web/src/components/storage/PartitionsField.jsx
@@ -349,42 +349,20 @@ const VolumeRow = ({
    * @component
    * @param {object} props
    * @param {Volume} props.volume
-   * @param {() => void} props.onEditClick
-   * @param {() => void} props.onResetLocationClick,
-   * @param {() => void} props.onLocationClick
-   * @param {(volume: Volume) => void} props.onDeleteClick
+   * @param {() => void} props.onEdit
+   * @param {() => void} props.onResetLocation
+   * @param {() => void} props.onLocation
+   * @param {() => void} props.onDelete
    */
-  const VolumeActions = ({ volume, onEditClick, onResetLocationClick, onLocationClick, onDeleteClick }) => {
-    const actions = () => {
-      const actions = {
-        edit: {
-          title: _("Edit"),
-          onClick: onEditClick
-        },
-        location: {
-          title: _("Change location"),
-          onClick: onLocationClick
-        },
-        delete: {
-          title: _("Delete"),
-          onClick: () => onDeleteClick(volume),
-          isDanger: true
-        },
-      };
+  const VolumeActions = ({ volume, onEdit, onResetLocation, onLocation, onDelete }) => {
+    const actions = [
+      { title: _("Edit"), onClick: onEdit },
+      volume.target !== "DEFAULT" && { title: _("Reset location"), onClick: onResetLocation },
+      { title: _("Change location"), onClick: onLocation },
+      !volume.outline.required && { title: _("Delete"), onClick: onDelete, isDanger: true }
+    ];
 
-      if (volume.target !== "DEFAULT") {
-        actions.reset_location = {
-          title: _("Reset location"),
-          onClick: onResetLocationClick
-        };
-      }
-
-      if (!volume.outline.required) return Object.values(actions);
-
-      return [actions.edit, actions.location];
-    };
-
-    return <RowActions id="volume_actions" actions={actions()} />;
+    return <RowActions id="volume_actions" actions={actions.filter(Boolean)} />;
   };
 
   if (isLoading) {
@@ -405,10 +383,10 @@ const VolumeRow = ({
         <Td isActionCell>
           <VolumeActions
             volume={volume}
-            onEditClick={openEditDialog}
-            onResetLocationClick={onResetLocationClick}
-            onLocationClick={openLocationDialog}
-            onDeleteClick={onDelete}
+            onEdit={openEditDialog}
+            onResetLocation={onResetLocationClick}
+            onLocation={openLocationDialog}
+            onDelete={onDelete}
           />
         </Td>
       </Tr>
@@ -505,7 +483,7 @@ const VolumesTable = ({
           targetDevice={targetDevice}
           isLoading={isLoading}
           onEdit={editVolume}
-          onDelete={deleteVolume}
+          onDelete={() => deleteVolume(volume)}
         />
       );
     });

--- a/web/src/components/storage/PartitionsField.jsx
+++ b/web/src/components/storage/PartitionsField.jsx
@@ -352,11 +352,6 @@ const VolumeRow = ({
   const VolumeActions = ({ volume, onEditClick, onLocationClick, onDeleteClick }) => {
     const actions = () => {
       const actions = {
-        delete: {
-          title: _("Delete"),
-          onClick: () => onDeleteClick(volume),
-          isDanger: true
-        },
         edit: {
           title: _("Edit"),
           onClick: onEditClick
@@ -364,7 +359,12 @@ const VolumeRow = ({
         location: {
           title: _("Change location"),
           onClick: onLocationClick
-        }
+        },
+        delete: {
+          title: _("Delete"),
+          onClick: () => onDeleteClick(volume),
+          isDanger: true
+        },
       };
 
       if (!volume.outline.required) return Object.values(actions);

--- a/web/src/components/storage/PartitionsField.jsx
+++ b/web/src/components/storage/PartitionsField.jsx
@@ -239,7 +239,7 @@ const BootLabel = ({ bootDevice, configureBoot }) => {
 };
 
 // TODO: Extract VolumesTable or at least VolumeRow and all related internal
-// comonents to a new file.
+// components to a new file.
 
 /**
   * @component

--- a/web/src/components/storage/PartitionsField.jsx
+++ b/web/src/components/storage/PartitionsField.jsx
@@ -29,21 +29,20 @@ import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { sprintf } from "sprintf-js";
 
 import { _ } from "~/i18n";
+import BootConfigField from "~/components/storage/BootConfigField";
+import {
+  deviceSize, hasSnapshots, isTransactionalRoot, isTransactionalSystem, reuseDevice
+} from '~/components/storage/utils';
 import { If, ExpandableField, RowActions, Tip } from '~/components/core';
+import { noop } from "~/utils";
+import SnapshotsField from "~/components/storage/SnapshotsField";
 import VolumeDialog from '~/components/storage/VolumeDialog';
 import VolumeLocationDialog from '~/components/storage/VolumeLocationDialog';
-import {
-  deviceSize, hasSnapshots, isTransactionalRoot, isTransactionalSystem
-} from '~/components/storage/utils';
-import SnapshotsField from "~/components/storage/SnapshotsField";
-import BootConfigField from "~/components/storage/BootConfigField";
-import { noop } from "~/utils";
 
 /**
  * @typedef {import ("~/client/storage").ProposalTarget} ProposalTarget
  * @typedef {import ("~/client/storage").StorageDevice} StorageDevice
  * @typedef {import("~/components/storage/SnapshotsField").SnapshotsConfig} SnapshotsConfig
- *
  * @typedef {import ("~/client/storage").Volume} Volume
  */
 
@@ -55,7 +54,7 @@ import { noop } from "~/utils";
  */
 const SizeText = ({ volume }) => {
   let targetSize;
-  if (volume.target === "FILESYSTEM" || volume.target === "DEVICE")
+  if (reuseDevice(volume))
     targetSize = volume.targetDevice.size;
 
   const minSize = deviceSize(targetSize || volume.minSize);
@@ -253,7 +252,10 @@ const VolumeSizeLimits = ({ volume }) => {
     <div className="split">
       <span>{SizeText({ volume })}</span>
       {/* TRANSLATORS: device flag, the partition size is automatically computed */}
-      <If condition={isAuto} then={<Tip description={AutoCalculatedHint({ volume })}>{_("auto")}</Tip>} />
+      <If
+        condition={isAuto && !reuseDevice(volume)}
+        then={<Tip description={AutoCalculatedHint({ volume })}>{_("auto")}</Tip>}
+      />
     </div>
   );
 };

--- a/web/src/components/storage/PartitionsField.jsx
+++ b/web/src/components/storage/PartitionsField.jsx
@@ -328,21 +328,21 @@ const VolumeActions = ({ volume, onEdit, onResetLocation, onLocation, onDelete }
  * @param {Volume} [props.volume] - Volume to show
  * @param {Volume[]} [props.volumes] - List of current volumes
  * @param {Volume[]} [props.templates] - List of available templates
- * @param {StorageDevice[]} [props.devices=[]] - Devices available for installation
- * @param {ProposalTarget} [props.target] - Installation target
- * @param {StorageDevice} [props.targetDevice] - Device selected for installation, if target is a disk
+ * @param {StorageDevice[]} [props.volumeDevices=[]] - Devices available for installation
+ * @param {ProposalTarget} [props.target]
+ * @param {StorageDevice[]} [props.targetDevices] - Device selected for installation, if target is a disk
  * @param {boolean} props.isLoading - Whether to show the row as loading
  * @param {(volume: Volume) => void} [props.onEdit=noop] - Function to use for editing the volume
- * @param {(volume: Volume) => void} [props.onDelete=noop] - Function to use for deleting the volume
+ * @param {() => void} [props.onDelete=noop] - Function to use for deleting the volume
  */
 const VolumeRow = ({
   columns,
   volume,
   volumes,
   templates,
-  devices,
+  volumeDevices,
   target,
-  targetDevice,
+  targetDevices,
   isLoading,
   onEdit = noop,
   onDelete = noop
@@ -412,9 +412,9 @@ const VolumeRow = ({
           <VolumeLocationDialog
             isOpen
             volume={volume}
-            devices={devices}
-            target={target}
-            targetDevice={targetDevice}
+            volumes={volumes}
+            volumeDevices={volumeDevices}
+            targetDevices={targetDevices}
             onAccept={acceptForm}
             onCancel={closeDialog}
           />
@@ -431,18 +431,18 @@ const VolumeRow = ({
  * @param {object} props
  * @param {Volume[]} props.volumes - Volumes to show
  * @param {Volume[]} props.templates - List of available templates
- * @param {StorageDevice[]} props.devices - Devices available for installation
- * @param {ProposalTarget} props.target - Installation target
- * @param {StorageDevice|undefined} props.targetDevice - Device selected for installation, if target is a disk
+ * @param {StorageDevice[]} props.volumeDevices
+ * @param {ProposalTarget} props.target
+ * @param {StorageDevice[]} props.targetDevices
  * @param {boolean} props.isLoading - Whether to show the table as loading
  * @param {(volumes: Volume[]) => void} props.onVolumesChange - Function to submit changes in volumes
  */
 const VolumesTable = ({
   volumes,
   templates,
-  devices,
+  volumeDevices,
   target,
-  targetDevice,
+  targetDevices,
   isLoading,
   onVolumesChange
 }) => {
@@ -481,9 +481,9 @@ const VolumesTable = ({
           volume={volume}
           volumes={volumes}
           templates={templates}
-          devices={devices}
+          volumeDevices={volumeDevices}
           target={target}
-          targetDevice={targetDevice}
+          targetDevices={targetDevices}
           isLoading={isLoading}
           onEdit={editVolume}
           onDelete={() => deleteVolume(volume)}
@@ -608,9 +608,10 @@ const AddVolumeButton = ({ options, onClick }) => {
  * @param {object} props
  * @param {Volume[]} props.volumes
  * @param {Volume[]} props.templates
- * @param {StorageDevice[]} props.devices
+ * @param {StorageDevice[]} props.availableDevices
+ * @param {StorageDevice[]} props.volumeDevices
  * @param {ProposalTarget} props.target
- * @param {StorageDevice|undefined} props.targetDevice
+ * @param {StorageDevice[]} props.targetDevices
  * @param {boolean} props.configureBoot
  * @param {StorageDevice|undefined} props.bootDevice
  * @param {StorageDevice|undefined} props.defaultBootDevice
@@ -621,9 +622,10 @@ const AddVolumeButton = ({ options, onClick }) => {
 const Advanced = ({
   volumes,
   templates,
-  devices,
+  availableDevices,
+  volumeDevices,
   target,
-  targetDevice,
+  targetDevices,
   configureBoot,
   bootDevice,
   defaultBootDevice,
@@ -713,9 +715,9 @@ const Advanced = ({
       <VolumesTable
         volumes={volumes}
         templates={templates}
-        devices={devices}
+        volumeDevices={volumeDevices}
         target={target}
-        targetDevice={targetDevice}
+        targetDevices={targetDevices}
         onVolumesChange={onVolumesChange}
         isLoading={isLoading}
       />
@@ -744,7 +746,7 @@ const Advanced = ({
         configureBoot={configureBoot}
         bootDevice={bootDevice}
         defaultBootDevice={defaultBootDevice}
-        devices={devices}
+        availableDevices={availableDevices}
         isLoading={isLoading}
         onChange={onBootChange}
       />
@@ -762,9 +764,10 @@ const Advanced = ({
  * @typedef {object} PartitionsFieldProps
  * @property {Volume[]} volumes - Volumes to show
  * @property {Volume[]} templates - Templates to use for new volumes
- * @property {StorageDevice[]} devices - Devices available for installation
+ * @property {StorageDevice[]} availableDevices - Devices available for installation
+ * @property {StorageDevice[]} volumeDevices
  * @property {ProposalTarget} target - Installation target
- * @property {StorageDevice|undefined} targetDevice - Device selected for installation, if target is a disk
+ * @property {StorageDevice[]} targetDevices
  * @property {boolean} configureBoot - Whether to configure boot partitions.
  * @property {StorageDevice|undefined} bootDevice - Device to use for creating boot partitions.
  * @property {StorageDevice|undefined} defaultBootDevice - Default device for boot partitions if no device has been indicated yet.
@@ -781,9 +784,10 @@ const Advanced = ({
 export default function PartitionsField({
   volumes,
   templates,
-  devices,
+  availableDevices,
+  volumeDevices,
   target,
-  targetDevice,
+  targetDevices,
   configureBoot,
   bootDevice,
   defaultBootDevice,
@@ -807,9 +811,10 @@ export default function PartitionsField({
           <Advanced
             volumes={volumes}
             templates={templates}
-            devices={devices}
+            volumeDevices={volumeDevices}
+            availableDevices={availableDevices}
             target={target}
-            targetDevice={targetDevice}
+            targetDevices={targetDevices}
             configureBoot={configureBoot}
             bootDevice={bootDevice}
             defaultBootDevice={defaultBootDevice}

--- a/web/src/components/storage/PartitionsField.jsx
+++ b/web/src/components/storage/PartitionsField.jsx
@@ -275,6 +275,10 @@ const VolumeRow = ({
 
   const closeDialog = () => setDialog(undefined);
 
+  const onResetLocationClick = () => {
+    onEdit({ ...volume, target: "DEFAULT", targetDevice: undefined });
+  };
+
   const acceptForm = (volume) => {
     closeDialog();
     onEdit(volume);
@@ -346,10 +350,11 @@ const VolumeRow = ({
    * @param {object} props
    * @param {Volume} props.volume
    * @param {() => void} props.onEditClick
+   * @param {() => void} props.onResetLocationClick,
    * @param {() => void} props.onLocationClick
    * @param {(volume: Volume) => void} props.onDeleteClick
    */
-  const VolumeActions = ({ volume, onEditClick, onLocationClick, onDeleteClick }) => {
+  const VolumeActions = ({ volume, onEditClick, onResetLocationClick, onLocationClick, onDeleteClick }) => {
     const actions = () => {
       const actions = {
         edit: {
@@ -366,6 +371,13 @@ const VolumeRow = ({
           isDanger: true
         },
       };
+
+      if (volume.target !== "DEFAULT") {
+        actions.reset_location = {
+          title: _("Reset location"),
+          onClick: onResetLocationClick
+        };
+      }
 
       if (!volume.outline.required) return Object.values(actions);
 
@@ -394,6 +406,7 @@ const VolumeRow = ({
           <VolumeActions
             volume={volume}
             onEditClick={openEditDialog}
+            onResetLocationClick={onResetLocationClick}
             onLocationClick={openLocationDialog}
             onDeleteClick={onDelete}
           />

--- a/web/src/components/storage/PartitionsField.jsx
+++ b/web/src/components/storage/PartitionsField.jsx
@@ -767,7 +767,7 @@ const Advanced = ({
  * @property {Volume[]} volumes - Volumes to show
  * @property {Volume[]} templates - Templates to use for new volumes
  * @property {StorageDevice[]} availableDevices - Devices available for installation
- * @property {StorageDevice[]} volumeDevices
+ * @property {StorageDevice[]} volumeDevices - Devices that can be selected as target for a volume
  * @property {ProposalTarget} target - Installation target
  * @property {StorageDevice[]} targetDevices
  * @property {boolean} configureBoot - Whether to configure boot partitions.

--- a/web/src/components/storage/PartitionsField.test.jsx
+++ b/web/src/components/storage/PartitionsField.test.jsx
@@ -183,10 +183,10 @@ beforeEach(() => {
   props = {
     volumes: [rootVolume, swapVolume],
     templates: [],
-    devices: [],
-    system: [sda],
+    availableDevices: [],
+    volumeDevices: [sda],
     target: "DISK",
-    targetDevice: undefined,
+    targetDevices: [],
     configureBoot: false,
     bootDevice: undefined,
     defaultBootDevice: undefined,

--- a/web/src/components/storage/PartitionsField.test.jsx
+++ b/web/src/components/storage/PartitionsField.test.jsx
@@ -350,7 +350,7 @@ describe("if there are volumes", () => {
   });
 
   // FIXME: improve at least the test description
-  it("does not allow reseting the volume location when already using the default location", async () => {
+  it("does not allow resetting the volume location when already using the default location", async () => {
     const { user } = await expandField();
 
     const [, body] = await screen.findAllByRole("rowgroup");
@@ -360,12 +360,12 @@ describe("if there are volumes", () => {
     expect(within(row).queryByRole("menuitem", { name: "Reset location" })).toBeNull();
   });
 
-  describe("and a volume has a non defautl location", () => {
+  describe("and a volume has a non default location", () => {
     beforeEach(() => {
       props.volumes = [{ ...homeVolume, target: "NEW_PARTITION", targetDevice: sda }];
     });
 
-    it("allows reseting the volume location", async () => {
+    it("allows resetting the volume location", async () => {
       const { user } = await expandField();
 
       const [, body] = await screen.findAllByRole("rowgroup");
@@ -380,7 +380,7 @@ describe("if there are volumes", () => {
         ])
       );
 
-      // NOTE: sadly we cannot peform the below check because the component is
+      // NOTE: sadly we cannot perform the below check because the component is
       // always receiving the same mocked props and will still having a /home as
       // "Partition at /dev/sda"
       // await within(body).findByRole("row", { name: "/home XFS at least 1 KiB Partition at installation device" });

--- a/web/src/components/storage/ProposalPage.jsx
+++ b/web/src/components/storage/ProposalPage.jsx
@@ -36,6 +36,7 @@ import { IDLE } from "~/client/status";
 const initialState = {
   loading: true,
   availableDevices: [],
+  volumeDevices: [],
   volumeTemplates: [],
   encryptionMethods: [],
   settings: {},
@@ -58,6 +59,11 @@ const reducer = (state, action) => {
     case "UPDATE_AVAILABLE_DEVICES": {
       const { availableDevices } = action.payload;
       return { ...state, availableDevices };
+    }
+
+    case "UPDATE_VOLUME_DEVICES": {
+      const { volumeDevices } = action.payload;
+      return { ...state, volumeDevices };
     }
 
     case "UPDATE_ENCRYPTION_METHODS": {
@@ -103,6 +109,10 @@ export default function ProposalPage() {
 
   const loadAvailableDevices = useCallback(async () => {
     return await cancellablePromise(client.proposal.getAvailableDevices());
+  }, [client, cancellablePromise]);
+
+  const loadVolumeDevices = useCallback(async () => {
+    return await cancellablePromise(client.proposal.getVolumeDevices());
   }, [client, cancellablePromise]);
 
   const loadEncryptionMethods = useCallback(async () => {
@@ -153,6 +163,9 @@ export default function ProposalPage() {
     const availableDevices = await loadAvailableDevices();
     dispatch({ type: "UPDATE_AVAILABLE_DEVICES", payload: { availableDevices } });
 
+    const volumeDevices = await loadVolumeDevices();
+    dispatch({ type: "UPDATE_VOLUME_DEVICES", payload: { volumeDevices } });
+
     const encryptionMethods = await loadEncryptionMethods();
     dispatch({ type: "UPDATE_ENCRYPTION_METHODS", payload: { encryptionMethods } });
 
@@ -169,7 +182,7 @@ export default function ProposalPage() {
     dispatch({ type: "UPDATE_ERRORS", payload: { errors } });
 
     if (result !== undefined) dispatch({ type: "STOP_LOADING" });
-  }, [calculateProposal, cancellablePromise, client, loadAvailableDevices, loadDevices, loadEncryptionMethods, loadErrors, loadProposalResult, loadVolumeTemplates]);
+  }, [calculateProposal, cancellablePromise, client, loadAvailableDevices, loadVolumeDevices, loadDevices, loadEncryptionMethods, loadErrors, loadProposalResult, loadVolumeTemplates]);
 
   const calculate = useCallback(async (settings) => {
     dispatch({ type: "START_LOADING" });
@@ -231,6 +244,7 @@ export default function ProposalPage() {
       />
       <ProposalSettingsSection
         availableDevices={state.availableDevices}
+        volumeDevices={state.volumeDevices}
         encryptionMethods={state.encryptionMethods}
         volumeTemplates={state.volumeTemplates}
         settings={state.settings}

--- a/web/src/components/storage/ProposalPage.test.jsx
+++ b/web/src/components/storage/ProposalPage.test.jsx
@@ -151,6 +151,7 @@ beforeEach(() => {
     // @ts-expect-error Some methods have to be private to avoid type complaint.
     proposal: {
       getAvailableDevices: jest.fn().mockResolvedValue([vda, vdb]),
+      getVolumeDevices: jest.fn().mockResolvedValue([vda, vdb]),
       getEncryptionMethods: jest.fn().mockResolvedValue([]),
       getProductMountPoints: jest.fn().mockResolvedValue([]),
       getResult: jest.fn().mockResolvedValue(proposalResult),

--- a/web/src/components/storage/ProposalResultSection.jsx
+++ b/web/src/components/storage/ProposalResultSection.jsx
@@ -25,10 +25,10 @@ import React, { useState } from "react";
 import { Button, Skeleton } from "@patternfly/react-core";
 import { sprintf } from "sprintf-js";
 import { _, n_ } from "~/i18n";
-import { deviceChildren, deviceSize } from "~/components/storage/utils";
 import DevicesManager from "~/components/storage/DevicesManager";
-import { If, Section, Reminder, Tag, TreeTable } from "~/components/core";
-import { ProposalActionsDialog, FilesystemLabel } from "~/components/storage";
+import { If, Section, Reminder } from "~/components/core";
+import { ProposalActionsDialog } from "~/components/storage";
+import ProposalResultTable from "~/components/storage/ProposalResultTable";
 
 /**
  * @typedef {import ("~/client/storage").Action} Action
@@ -99,109 +99,6 @@ const ActionsInfo = ({ actions }) => {
 };
 
 /**
- * Renders a TreeTable rendering the devices proposal result.
- * @component
- *
- * @param {object} props
- * @param {DevicesManager} props.devicesManager
- */
-const DevicesTreeTable = ({ devicesManager }) => {
-  const renderDeviceName = (item) => {
-    let name = item.sid && item.name;
-    // NOTE: returning a fragment here to avoid a weird React complaint when using a PF/Table +
-    // treeRow props.
-    if (!name) return <></>;
-
-    if (["partition", "lvmLv"].includes(item.type))
-      name = name.split("/").pop();
-
-    return (
-      <div className="split">
-        <span>{name}</span>
-      </div>
-    );
-  };
-
-  const renderNewLabel = (item) => {
-    if (!item.sid) return;
-
-    // FIXME New PVs over a disk is not detected as new.
-    if (!devicesManager.existInSystem(item) || devicesManager.hasNewFilesystem(item))
-      return <Tag variant="teal">{_("New")}</Tag>;
-  };
-
-  const renderContent = (item) => {
-    if (!item.sid)
-      return _("Unused space");
-    if (!item.partitionTable && item.systems?.length > 0)
-      return item.systems.join(", ");
-
-    return item.description;
-  };
-
-  const renderPTableType = (item) => {
-    // TODO: Create a map for partition table types.
-    const type = item.partitionTable?.type;
-    if (type) return <Tag><b>{type.toUpperCase()}</b></Tag>;
-  };
-
-  const renderDetails = (item) => {
-    return (
-      <>
-        <div>{renderNewLabel(item)}</div>
-        <div>{renderContent(item)} <FilesystemLabel device={item} /> {renderPTableType(item)}</div>
-      </>
-    );
-  };
-
-  const renderResizedLabel = (item) => {
-    if (!item.sid || !devicesManager.isShrunk(item)) return;
-
-    const sizeBefore = devicesManager.systemDevice(item.sid).size;
-
-    return (
-      <Tag variant="orange">
-        {
-          // TRANSLATORS: Label to indicate the device size before resizing, where %s is replaced by
-          // the original size (e.g., 3.00 GiB).
-          sprintf(_("Before %s"), deviceSize(sizeBefore))
-        }
-      </Tag>
-    );
-  };
-
-  const renderSize = (item) => {
-    return (
-      <div className="split">
-        {renderResizedLabel(item)}
-        {deviceSize(item.size)}
-      </div>
-    );
-  };
-
-  const renderMountPoint = (item) => item.sid && <em>{item.filesystem?.mountPath}</em>;
-  const devices = devicesManager.usedDevices();
-
-  return (
-    <TreeTable
-      columns={[
-        { title: _("Device"), content: renderDeviceName },
-        { title: _("Mount Point"), content: renderMountPoint },
-        { title: _("Details"), content: renderDetails, classNames: "details-column" },
-        { title: _("Size"), content: renderSize, classNames: "sizes-column" }
-      ]}
-      items={devices}
-      expandedItems={devices}
-      itemChildren={d => deviceChildren(d)}
-      rowClassNames={(item) => {
-        if (!item.sid) return "dimmed-row";
-      }}
-      className="proposal-result"
-    />
-  );
-};
-
-/**
  * @todo Create a component for rendering a customized skeleton
  */
 const ResultSkeleton = () => {
@@ -236,7 +133,7 @@ const SectionContent = ({ system, staging, actions, errors }) => {
         systems={devicesManager.deletedSystems()}
       />
       <ActionsInfo actions={actions} />
-      <DevicesTreeTable devicesManager={devicesManager} />
+      <ProposalResultTable devicesManager={devicesManager} />
     </>
   );
 };
@@ -245,12 +142,14 @@ const SectionContent = ({ system, staging, actions, errors }) => {
  * Section holding the proposal result and actions to perform in the system
  * @component
  *
- * @param {object} props
- * @param {StorageDevice[]} [props.system=[]]
- * @param {StorageDevice[]} [props.staging=[]]
- * @param {Action[]} [props.actions=[]]
- * @param {ValidationError[]} [props.errors=[]] - Validation errors
- * @param {boolean} [props.isLoading=false] - Whether the section content should be rendered as loading
+ * @typedef {object} ProposalResultSectionProps
+ * @property {StorageDevice[]} [system=[]]
+ * @property {StorageDevice[]} [staging=[]]
+ * @property {Action[]} [actions=[]]
+ * @property {ValidationError[]} [errors=[]] - Validation errors
+ * @property {boolean} [isLoading=false] - Whether the section content should be rendered as loading
+ *
+ * @param {ProposalResultSectionProps} props
  */
 export default function ProposalResultSection({
   system = [],

--- a/web/src/components/storage/ProposalResultSection.test.jsx
+++ b/web/src/components/storage/ProposalResultSection.test.jsx
@@ -19,14 +19,21 @@
  * find current contact information at www.suse.com.
  */
 
+// @ts-check
+
 import React from "react";
 import { screen, within } from "@testing-library/react";
 import { plainRender } from "~/test-utils";
 import { ProposalResultSection } from "~/components/storage";
 import { devices, actions } from "./test-data/full-result-example";
 
+/**
+ * @typedef {import("./ProposalResultSection").ProposalResultSectionProps} ProposalResultSectionProps
+ */
+
 const errorMessage = "Something went wrong, proposal not possible";
 const errors = [{ severity: 0, message: errorMessage }];
+/** @type {ProposalResultSectionProps} */
 const defaultProps = { system: devices.system, staging: devices.staging, actions };
 
 describe("ProposalResultSection", () => {
@@ -74,7 +81,7 @@ describe("ProposalResultSection", () => {
       // affected systems are rendered in the warning summary
       const props = {
         ...defaultProps,
-        actions: [{ device: 79, delete: true }]
+        actions: [{ device: 79, subvol: false, delete: true, text: "" }]
       };
 
       plainRender(<ProposalResultSection {...props} />);

--- a/web/src/components/storage/ProposalResultTable.jsx
+++ b/web/src/components/storage/ProposalResultTable.jsx
@@ -109,36 +109,28 @@ const DeviceCustomSize = ({ item, devicesManager }) => {
 
 /** @type {(devicesManager: DevicesManager) => TreeTableColumn[] } */
 const columns = (devicesManager) => {
-  /** @type {() => (item: TableItem) => React.ReactNode} */
-  const deviceRender = () => {
-    return (item) => <DeviceName item={item} />;
-  };
+  /** @type {(item: TableItem) => React.ReactNode} */
+  const renderDevice = (item) => <DeviceName item={item} />;
 
-  /** @type {() => (item: TableItem) => React.ReactNode} */
-  const mountPointRender = () => {
-    return (item) => <MountPoint item={item} />;
-  };
+  /** @type {(item: TableItem) => React.ReactNode} */
+  const renderMountPoint = (item) => <MountPoint item={item} />;
 
-  /** @type {() => (item: TableItem) => React.ReactNode} */
-  const detailsRender = () => {
-    return (item) => <DeviceCustomDetails item={item} devicesManager={devicesManager} />;
-  };
+  /** @type {(item: TableItem) => React.ReactNode} */
+  const renderDetails = (item) => <DeviceCustomDetails item={item} devicesManager={devicesManager} />;
 
-  /** @type {() => (item: TableItem) => React.ReactNode} */
-  const sizeRender = () => {
-    return (item) => <DeviceCustomSize item={item} devicesManager={devicesManager} />;
-  };
+  /** @type {(item: TableItem) => React.ReactNode} */
+  const renderSize = (item) => <DeviceCustomSize item={item} devicesManager={devicesManager} />;
 
   return [
-    { name: _("Device"), value: deviceRender() },
-    { name: _("Mount Point"), value: mountPointRender() },
-    { name: _("Details"), value: detailsRender(), classNames: "details-column" },
-    { name: _("Size"), value: sizeRender(), classNames: "sizes-column" }
+    { name: _("Device"), value: renderDevice },
+    { name: _("Mount Point"), value: renderMountPoint },
+    { name: _("Details"), value: renderDetails, classNames: "details-column" },
+    { name: _("Size"), value: renderSize, classNames: "sizes-column" }
   ];
 };
 
 /**
- * Renders a TreeTable rendering the devices proposal result.
+ * Renders the proposal result.
  * @component
  *
  * @typedef {object} ProposalResultTableProps

--- a/web/src/components/storage/ProposalResultTable.jsx
+++ b/web/src/components/storage/ProposalResultTable.jsx
@@ -58,7 +58,7 @@ const MountPoint = ({ item }) => {
  * @param {TableItem} props.item
  * @param {DevicesManager} props.devicesManager
  */
-const ExtendedDeviceDetails = ({ item, devicesManager }) => {
+const DeviceCustomDetails = ({ item, devicesManager }) => {
   const isNew = () => {
     const device = toStorageDevice(item);
     if (!device) return false;
@@ -83,7 +83,7 @@ const ExtendedDeviceDetails = ({ item, devicesManager }) => {
  * @param {TableItem} props.item
  * @param {DevicesManager} props.devicesManager
  */
-const ExtendedDeviceSize = ({ item, devicesManager }) => {
+const DeviceCustomSize = ({ item, devicesManager }) => {
   const device = toStorageDevice(item);
   const isResized = device && devicesManager.isShrunk(device);
   const sizeBefore = isResized ? devicesManager.systemDevice(device.sid).size : item.size;
@@ -121,12 +121,12 @@ const columns = (devicesManager) => {
 
   /** @type {() => (item: TableItem) => React.ReactNode} */
   const detailsRender = () => {
-    return (item) => <ExtendedDeviceDetails item={item} devicesManager={devicesManager} />;
+    return (item) => <DeviceCustomDetails item={item} devicesManager={devicesManager} />;
   };
 
   /** @type {() => (item: TableItem) => React.ReactNode} */
   const sizeRender = () => {
-    return (item) => <ExtendedDeviceSize item={item} devicesManager={devicesManager} />;
+    return (item) => <DeviceCustomSize item={item} devicesManager={devicesManager} />;
   };
 
   return [

--- a/web/src/components/storage/ProposalResultTable.jsx
+++ b/web/src/components/storage/ProposalResultTable.jsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// @ts-check
+
+import React from "react";
+import { sprintf } from "sprintf-js";
+import { _ } from "~/i18n";
+import {
+  DeviceName, DeviceDetails, DeviceSize, toStorageDevice
+} from "~/components/storage/device-utils";
+import { deviceChildren, deviceSize } from "~/components/storage/utils";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import DevicesManager from "~/components/storage/DevicesManager";
+import { If, Tag, TreeTable } from "~/components/core";
+
+/**
+ * @typedef {import("~/client/storage").PartitionSlot} PartitionSlot
+ * @typedef {import ("~/client/storage").StorageDevice} StorageDevice
+ * @typedef {import("../core/TreeTable").TreeTableColumn} TreeTableColumn
+ * @typedef {StorageDevice | PartitionSlot} TableItem
+ */
+
+/**
+ * @component
+ * @param {object} props
+ * @param {TableItem} props.item
+ */
+const MountPoint = ({ item }) => {
+  const device = toStorageDevice(item);
+
+  if (!(device && device.filesystem?.mountPath)) return null;
+
+  return <em>{device.filesystem.mountPath}</em>;
+};
+
+/**
+ * @component
+ * @param {object} props
+ * @param {TableItem} props.item
+ * @param {DevicesManager} props.devicesManager
+ */
+const ExtendedDeviceDetails = ({ item, devicesManager }) => {
+  const isNew = () => {
+    const device = toStorageDevice(item);
+    if (!device) return false;
+
+    // FIXME New PVs over a disk is not detected as new.
+    return !devicesManager.existInSystem(device) || devicesManager.hasNewFilesystem(device);
+  };
+
+  return (
+    <>
+      <div>
+        <If condition={isNew()} then={<Tag variant="teal">{_("New")}</Tag>} />
+      </div>
+      <DeviceDetails item={item} />
+    </>
+  );
+};
+
+/**
+ * @component
+ * @param {object} props
+ * @param {TableItem} props.item
+ * @param {DevicesManager} props.devicesManager
+ */
+const ExtendedDeviceSize = ({ item, devicesManager }) => {
+  const device = toStorageDevice(item);
+  const isResized = device && devicesManager.isShrunk(device);
+  const sizeBefore = isResized ? devicesManager.systemDevice(device.sid).size : item.size;
+
+  return (
+    <div className="split">
+      <If
+        condition={isResized}
+        then={
+          <Tag variant="orange">
+            {
+              // TRANSLATORS: Label to indicate the device size before resizing, where %s is
+              // replaced by the original size (e.g., 3.00 GiB).
+              sprintf(_("Before %s"), deviceSize(sizeBefore))
+            }
+          </Tag>
+        }
+      />
+      <DeviceSize item={item} />
+    </div>
+  );
+};
+
+/** @type {(devicesManager: DevicesManager) => TreeTableColumn[] } */
+const columns = (devicesManager) => {
+  /** @type {() => (item: TableItem) => React.ReactNode} */
+  const deviceRender = () => {
+    return (item) => <DeviceName item={item} />;
+  };
+
+  /** @type {() => (item: TableItem) => React.ReactNode} */
+  const mountPointRender = () => {
+    return (item) => <MountPoint item={item} />;
+  };
+
+  /** @type {() => (item: TableItem) => React.ReactNode} */
+  const detailsRender = () => {
+    return (item) => <ExtendedDeviceDetails item={item} devicesManager={devicesManager} />;
+  };
+
+  /** @type {() => (item: TableItem) => React.ReactNode} */
+  const sizeRender = () => {
+    return (item) => <ExtendedDeviceSize item={item} devicesManager={devicesManager} />;
+  };
+
+  return [
+    { name: _("Device"), value: deviceRender() },
+    { name: _("Mount Point"), value: mountPointRender() },
+    { name: _("Details"), value: detailsRender(), classNames: "details-column" },
+    { name: _("Size"), value: sizeRender(), classNames: "sizes-column" }
+  ];
+};
+
+/**
+ * Renders a TreeTable rendering the devices proposal result.
+ * @component
+ *
+ * @typedef {object} ProposalResultTableProps
+ * @property {DevicesManager} devicesManager
+ *
+ * @param {ProposalResultTableProps} props
+ */
+export default function ProposalResultTable({ devicesManager }) {
+  const devices = devicesManager.usedDevices();
+
+  return (
+    <TreeTable
+      columns={columns(devicesManager)}
+      items={devices}
+      expandedItems={devices}
+      itemChildren={deviceChildren}
+      rowClassNames={(item) => {
+        if (!item.sid) return "dimmed-row";
+      }}
+      className="proposal-result"
+    />
+  );
+}

--- a/web/src/components/storage/ProposalSettingsSection.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.jsx
@@ -47,6 +47,7 @@ import SpacePolicyField from "~/components/storage/SpacePolicyField";
  * @typedef {object} ProposalSettingsSectionProps
  * @property {ProposalSettings} settings
  * @property {StorageDevice[]} availableDevices
+ * @property {StorageDevice[]} volumeDevices
  * @property {String[]} encryptionMethods
  * @property {Volume[]} volumeTemplates
  * @property {boolean} [isLoading=false]
@@ -57,6 +58,7 @@ import SpacePolicyField from "~/components/storage/SpacePolicyField";
 export default function ProposalSettingsSection({
   settings,
   availableDevices,
+  volumeDevices,
   encryptionMethods,
   volumeTemplates,
   isLoading = false,
@@ -112,6 +114,8 @@ export default function ProposalSettingsSection({
   const defaultBootDevice = findDevice(settings.defaultBootDevice);
   const spacePolicy = SPACE_POLICIES.find(p => p.id === settings.spacePolicy);
 
+  const targetDevices = compact([targetDevice, ...targetPVDevices]);
+
   return (
     <>
       <Section title={_("Settings")}>
@@ -133,9 +137,10 @@ export default function ProposalSettingsSection({
         <PartitionsField
           volumes={volumes}
           templates={volumeTemplates}
-          devices={availableDevices}
+          availableDevices={availableDevices}
+          volumeDevices={volumeDevices}
           target={settings.target}
-          targetDevice={targetDevice}
+          targetDevices={targetDevices}
           configureBoot={settings.configureBoot}
           bootDevice={bootDevice}
           defaultBootDevice={defaultBootDevice}

--- a/web/src/components/storage/ProposalSettingsSection.test.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.test.jsx
@@ -106,6 +106,7 @@ beforeEach(() => {
       installationDevices: [sda, sdb]
     },
     availableDevices: [],
+    volumeDevices: [],
     encryptionMethods: [],
     volumeTemplates: [],
     onChange: jest.fn()

--- a/web/src/components/storage/SpacePolicyDialog.jsx
+++ b/web/src/components/storage/SpacePolicyDialog.jsx
@@ -68,17 +68,19 @@ const SpacePolicyPicker = ({ currentPolicy, onChange = noop }) => {
  * Renders a dialog that allows the user to select the space policy and actions.
  * @component
  *
- * @param {object} props
- * @param {SpacePolicy} props.policy
- * @param {SpaceAction[]} props.actions
- * @param {StorageDevice[]} props.devices
- * @param {boolean} [props.isOpen=false]
- * @param {() => void} [props.onCancel=noop]
- * @param {(spaceConfig: SpaceConfig) => void} [props.onAccept=noop]
+ * @typedef {object} SpacePolicyDialogProps
+ * @property {SpacePolicy} policy
+ * @property {SpaceAction[]} actions
+ * @property {StorageDevice[]} devices
+ * @property {boolean} [isOpen=false]
+ * @property {() => void} [onCancel=noop]
+ * @property {(spaceConfig: SpaceConfig) => void} [onAccept=noop]
  *
  * @typedef {object} SpaceConfig
  * @property {SpacePolicy} spacePolicy
  * @property {SpaceAction[]} spaceActions
+ *
+ * @param {SpacePolicyDialogProps} props
  */
 export default function SpacePolicyDialog({
   policy: defaultPolicy,

--- a/web/src/components/storage/SpacePolicyDialog.test.jsx
+++ b/web/src/components/storage/SpacePolicyDialog.test.jsx
@@ -19,12 +19,20 @@
  * find current contact information at www.suse.com.
  */
 
+// @ts-check
+
 import React from "react";
 import { screen, within } from "@testing-library/react";
 import { plainRender, resetLocalStorage } from "~/test-utils";
 import { SPACE_POLICIES } from "~/components/storage/utils";
 import { SpacePolicyDialog } from "~/components/storage";
 
+/**
+ * @typedef {import ("~/client/storage").StorageDevice} StorageDevice
+ * @typedef {import("./SpacePolicyDialog").SpacePolicyDialogProps} SpacePolicyDialogProps
+ */
+
+/** @type {StorageDevice} */
 const sda = {
   sid: 59,
   isDrive: true,
@@ -39,6 +47,7 @@ const sda = {
   sdCard: true,
   active: true,
   name: "/dev/sda",
+  description: "",
   size: 1024,
   recoverableSize: 0,
   systems : [],
@@ -46,12 +55,14 @@ const sda = {
   udevPaths: ["pci-0000:00-12", "pci-0000:00-12-ata"],
 };
 
+/** @type {StorageDevice} */
 const sda1 = {
   sid: 60,
   isDrive: false,
   type: "partition",
   active: true,
   name: "/dev/sda1",
+  description: "",
   size: 512,
   recoverableSize: 128,
   systems : [],
@@ -59,12 +70,14 @@ const sda1 = {
   udevPaths: []
 };
 
+/** @type {StorageDevice} */
 const sda2 = {
   sid: 61,
   isDrive: false,
   type: "partition",
   active: true,
   name: "/dev/sda2",
+  description: "",
   size: 512,
   recoverableSize: 0,
   systems : [],
@@ -79,6 +92,7 @@ sda.partitionTable = {
   unpartitionedSize: 512
 };
 
+/** @type {StorageDevice} */
 const sdb = {
   sid: 62,
   isDrive: true,
@@ -93,6 +107,7 @@ const sdb = {
   sdCard: false,
   active: true,
   name: "/dev/sdb",
+  description: "",
   size: 2048,
   recoverableSize: 0,
   systems : [],
@@ -105,6 +120,7 @@ const resizePolicy = SPACE_POLICIES.find(p => p.id === "resize");
 const keepPolicy = SPACE_POLICIES.find(p => p.id === "keep");
 const customPolicy = SPACE_POLICIES.find(p => p.id === "custom");
 
+/** @type {SpacePolicyDialogProps} */
 let props;
 
 const expandRow = async (user, name) => {

--- a/web/src/components/storage/VolumeDialog.jsx
+++ b/web/src/components/storage/VolumeDialog.jsx
@@ -63,14 +63,6 @@ import { Popup } from '~/components/core';
  * @property {string|null} missingSize
  * @property {string|null} missingMinSize
  * @property {string|null} invalidMaxSize
- *
- * @typedef {object} VolumeDialogProps
- * @property {Volume} volume
- * @property {Volume[]} volumes
- * @property {Volume[]} templates
- * @property {boolean} [isOpen=false]
- * @property {() => void} onCancel
- * @property {(volume: Volume) => void} onAccept
  */
 
 /**
@@ -92,18 +84,29 @@ const renderTitle = (volume, volumes) => {
   return isNewVolume ? _("Add file system") : _("Edit file system");
 };
 
+/**
+ * @component
+ *
+ * @param {object} props
+ * @param {Volume} props.volume
+ */
 const VolumeAlert = ({ volume }) => {
   let alert;
 
   if (mountFilesystem(volume)) {
     alert = {
+      // TRANSLATORS: Warning when editing a file system.
       title: _("The type and size of the file system cannot be edited."),
+      // TRANSLATORS: Description of a warning. The first %s is replaced by a device name (e.g.,
+      // /dev/vda) and the second %s is replaced by a mount path (e.g., /home).
       text: sprintf(_("The current file system on %s is selected to be mounted at %s."),
                     volume.targetDevice.name, volume.mountPath)
     };
   } else if (reuseDevice(volume)) {
     alert = {
+      // TRANSLATORS: Warning when editing a file system.
       title: _("The size of the file system cannot be edited"),
+      // TRANSLATORS: Description of a warning. %s is replaced by a device name (e.g., /dev/vda).
       text: sprintf(_("The file system is allocated at the device %s."),
                     volume.targetDevice.name)
     };
@@ -625,6 +628,14 @@ const reducer = (state, action) => {
 /**
  * Renders a dialog that allows the user to add or edit a file system.
  * @component
+ *
+ * @typedef {object} VolumeDialogProps
+ * @property {Volume} volume
+ * @property {Volume[]} volumes
+ * @property {Volume[]} templates
+ * @property {boolean} [isOpen=false]
+ * @property {() => void} onCancel
+ * @property {(volume: Volume) => void} onAccept
  *
  * @param {VolumeDialogProps} props
  */

--- a/web/src/components/storage/VolumeDialog.jsx
+++ b/web/src/components/storage/VolumeDialog.jsx
@@ -757,8 +757,8 @@ export default function VolumeDialog({
   return (
     /** @fixme blockSize medium is too big and small is too small. */
     <Popup title={title} isOpen={isOpen} blockSize="medium" inlineSize="medium">
-      <VolumeAlert volume={state.volume} />
       <Form id="volume-form" onSubmit={submitForm}>
+        <VolumeAlert volume={state.volume} />
         <MountPathField
           value={mountPath}
           isReadOnly={!isMountPathEditable()}

--- a/web/src/components/storage/VolumeLocationDialog.jsx
+++ b/web/src/components/storage/VolumeLocationDialog.jsx
@@ -150,49 +150,51 @@ export default function VolumeLocationDialog({
           />
         </FormReadOnlyField>
         <FormGroup label={_("Select how to allocate the file system")}>
-          <Radio
-            id="new_partition"
-            name="target"
-            label={_("Create a new partition")}
-            description={_("The file system will be allocated as a new partition at the selected \
-disk.")}
-            isChecked={target === "NEW_PARTITION"}
-            isDisabled={!targets.includes("NEW_PARTITION")}
-            onChange={() => setTarget("NEW_PARTITION")}
-          />
-          <Radio
-            id="dedicated_lvm"
-            name="target"
-            label={_("Create a dedicated LVM volume group")}
-            description={_("A new volume group will be allocated in the selected disk and the \
-file system will be created as a logical volume.")}
-            isChecked={target === "NEW_VG"}
-            isDisabled={!targets.includes("NEW_VG")}
-            onChange={() => setTarget("NEW_VG")}
-          />
-          <Radio
-            id="format"
-            name="target"
-            label={_("Format the device")}
-            description={
-              // TRANSLATORS: %s is replaced by a file system type (e.g., Ext4).
-              sprintf(_("The selected device will be formatted as %s file system."),
-                volume.fsType)
-            }
-            isChecked={target === "DEVICE"}
-            isDisabled={!targets.includes("DEVICE")}
-            onChange={() => setTarget("DEVICE")}
-          />
-          <Radio
-            id="mount"
-            name="target"
-            label={_("Mount the file system")}
-            description={_("The current file system on the selected device will be mounted \
-without formatting the device.")}
-            isChecked={target === "FILESYSTEM"}
-            isDisabled={!targets.includes("FILESYSTEM")}
-            onChange={() => setTarget("FILESYSTEM")}
-          />
+          <div className="stack small">
+            <Radio
+              id="new_partition"
+              name="target"
+              label={_("Create a new partition")}
+              description={_("The file system will be allocated as a new partition at the selected \
+  disk.")}
+              isChecked={target === "NEW_PARTITION"}
+              isDisabled={!targets.includes("NEW_PARTITION")}
+              onChange={() => setTarget("NEW_PARTITION")}
+            />
+            <Radio
+              id="dedicated_lvm"
+              name="target"
+              label={_("Create a dedicated LVM volume group")}
+              description={_("A new volume group will be allocated in the selected disk and the \
+  file system will be created as a logical volume.")}
+              isChecked={target === "NEW_VG"}
+              isDisabled={!targets.includes("NEW_VG")}
+              onChange={() => setTarget("NEW_VG")}
+            />
+            <Radio
+              id="format"
+              name="target"
+              label={_("Format the device")}
+              description={
+                // TRANSLATORS: %s is replaced by a file system type (e.g., Ext4).
+                sprintf(_("The selected device will be formatted as %s file system."),
+                  volume.fsType)
+              }
+              isChecked={target === "DEVICE"}
+              isDisabled={!targets.includes("DEVICE")}
+              onChange={() => setTarget("DEVICE")}
+            />
+            <Radio
+              id="mount"
+              name="target"
+              label={_("Mount the file system")}
+              description={_("The current file system on the selected device will be mounted \
+  without formatting the device.")}
+              isChecked={target === "FILESYSTEM"}
+              isDisabled={!targets.includes("FILESYSTEM")}
+              onChange={() => setTarget("FILESYSTEM")}
+            />
+          </div>
         </FormGroup>
       </Form>
       <Popup.Actions>

--- a/web/src/components/storage/VolumeLocationDialog.jsx
+++ b/web/src/components/storage/VolumeLocationDialog.jsx
@@ -142,7 +142,9 @@ export default function VolumeLocationDialog({
       {...props}
     >
       <Form id="volume-location-form" onSubmit={onSubmit}>
-        <FormReadOnlyField label={_("Select in which device to allocate the file system")}>
+        { /** FIXME: Rename FormReadOnlyField */}
+        <FormReadOnlyField label={_("Select in which device to allocate the file system")} />
+        <div className="scrollbox">
           <VolumeLocationSelectorTable
             aria-label={_("Select a location")}
             devices={volumeDevices}
@@ -155,7 +157,7 @@ export default function VolumeLocationDialog({
             initialExpandedKeys={volumeDevices.map(d => d.sid)}
             variant="compact"
           />
-        </FormReadOnlyField>
+        </div>
         <FormGroup label={_("Select how to allocate the file system")}>
           <div className="stack">
             <Radio

--- a/web/src/components/storage/VolumeLocationDialog.jsx
+++ b/web/src/components/storage/VolumeLocationDialog.jsx
@@ -37,6 +37,7 @@ import VolumeLocationSelectorTable from "~/components/storage/VolumeLocationSele
  * @typedef {import ("~/client/storage").VolumeTarget} VolumeTarget
  */
 
+// TRANSLATORS: Description of the dialog for changing the location of a file system.
 const DIALOG_DESCRIPTION = _("The file systems are allocated at the installation device by \
 default. Indicate a custom location to create the file system at a specific device.");
 
@@ -115,10 +116,6 @@ export default function VolumeLocationDialog({
     onAccept(newVolume);
   };
 
-  const isAcceptDisabled = () => {
-    return false;
-  };
-
   /** @type {(device: StorageDevice) => boolean} */
   const isDeviceSelectable = (device) => {
     return device.isDrive || ["md", "partition", "lvmLv"].includes(device.type);
@@ -128,6 +125,8 @@ export default function VolumeLocationDialog({
 
   return (
     <Popup
+      // TRANSLATORS: Title of the dialog for changing the location of a file system. %s is replaced
+      // by a mount path (e.g., /home).
       title={sprintf(_("Location for %s file system"), volumeLabel(volume))}
       description={DIALOG_DESCRIPTION}
       inlineSize="large"
@@ -155,8 +154,8 @@ export default function VolumeLocationDialog({
               id="new_partition"
               name="target"
               label={_("Create a new partition")}
-              description={_("The file system will be allocated as a new partition at the \
-selected disk.")}
+              description={_("The file system will be allocated as a new partition at the selected \
+disk.")}
               isChecked={target === "NEW_PARTITION"}
               isDisabled={!targets.includes("NEW_PARTITION")}
               onChange={() => setTarget("NEW_PARTITION")}
@@ -175,7 +174,11 @@ file system will be created as a logical volume.")}
               id="format"
               name="target"
               label={_("Format the device")}
-              description={sprintf(_("The selected device will be formatted as %s file system."), volume.fsType)}
+              description={
+                // TRANSLATORS: %s is replaced by a file system type (e.g., Ext4).
+                sprintf(_("The selected device will be formatted as %s file system."),
+                        volume.fsType)
+              }
               isChecked={target === "DEVICE"}
               isDisabled={!targets.includes("DEVICE")}
               onChange={() => setTarget("DEVICE")}
@@ -184,7 +187,8 @@ file system will be created as a logical volume.")}
               id="mount"
               name="target"
               label={_("Mount the file system")}
-              description={_("The current file system on the selected device will be mounted without formatting the device.")}
+              description={_("The current file system on the selected device will be mounted \
+without formatting the device.")}
               isChecked={target === "FILESYSTEM"}
               isDisabled={!targets.includes("FILESYSTEM")}
               onChange={() => setTarget("FILESYSTEM")}
@@ -193,7 +197,7 @@ file system will be created as a logical volume.")}
         </div>
       </Form>
       <Popup.Actions>
-        <Popup.Confirm form="volume-location-form" type="submit" isDisabled={isAcceptDisabled()} />
+        <Popup.Confirm form="volume-location-form" type="submit" />
         <Popup.Cancel onClick={onCancel} />
       </Popup.Actions>
     </Popup>

--- a/web/src/components/storage/VolumeLocationDialog.jsx
+++ b/web/src/components/storage/VolumeLocationDialog.jsx
@@ -178,7 +178,7 @@ export default function VolumeLocationDialog({
               description={
                 // TRANSLATORS: %s is replaced by a file system type (e.g., Ext4).
                 sprintf(_("The selected device will be formatted as %s file system."),
-                  volume.fsType)
+                        volume.fsType)
               }
               isChecked={target === "DEVICE"}
               isDisabled={!targets.includes("DEVICE")}

--- a/web/src/components/storage/VolumeLocationDialog.jsx
+++ b/web/src/components/storage/VolumeLocationDialog.jsx
@@ -27,7 +27,7 @@ import { sprintf } from "sprintf-js";
 
 import { _ } from "~/i18n";
 import { deviceChildren } from "~/components/storage/utils";
-import { Popup } from "~/components/core";
+import { FormReadOnlyField, Popup } from "~/components/core";
 import VolumeLocationSelectorTable from "~/components/storage/VolumeLocationSelectorTable";
 
 /**
@@ -36,6 +36,9 @@ import VolumeLocationSelectorTable from "~/components/storage/VolumeLocationSele
  * @typedef {import ("~/client/storage").Volume} Volume
  * @typedef {import ("~/client/storage").VolumeTarget} VolumeTarget
  */
+
+const DIALOG_DESCRIPTION = _("The file systems are allocated at the installation device by \
+default. Indicate a custom location to create the file system at a specific device.");
 
 /** @type {(device: StorageDevice) => VolumeTarget} */
 const defaultTarget = (device) => {
@@ -128,31 +131,33 @@ export default function VolumeLocationDialog({
   return (
     <Popup
       title={sprintf(_("Location for %s file system"), volume.mountPath)}
-      description={_("Select in which device to allocate the file system.")}
+      description={DIALOG_DESCRIPTION}
       inlineSize="large"
       isOpen={isOpen}
       {...props}
     >
       <Form id="volume-location-form" onSubmit={onSubmit}>
         <div className="stack">
-          <VolumeLocationSelectorTable
-            aria-label={_("Select a device for placing the file system")}
-            devices={volumeDevices}
-            selectedDevices={[targetDevice]}
-            targetDevices={targetDevices}
-            volumes={volumes}
-            itemChildren={deviceChildren}
-            itemSelectable={isDeviceSelectable}
-            onSelectionChange={changeTargetDevice}
-            initialExpandedKeys={volumeDevices.map(d => d.sid)}
-            variant="compact"
-          />
-          <FormGroup label={sprintf(_("Select how to allocate the %s file system"), volume.mountPath)}>
+          <FormReadOnlyField label={_("Select in which device to allocate the file system")}>
+            <VolumeLocationSelectorTable
+              aria-label={_("Select a location")}
+              devices={volumeDevices}
+              selectedDevices={[targetDevice]}
+              targetDevices={targetDevices}
+              volumes={volumes}
+              itemChildren={deviceChildren}
+              itemSelectable={isDeviceSelectable}
+              onSelectionChange={changeTargetDevice}
+              initialExpandedKeys={volumeDevices.map(d => d.sid)}
+              variant="compact"
+            />
+          </FormReadOnlyField>
+          <FormGroup label={_("Select how to allocate the file system")}>
             <Radio
               id="new_partition"
               name="target"
               label={_("Create a new partition")}
-              description={_("The new file system will be allocated as a new partition at the \
+              description={_("The file system will be allocated as a new partition at the \
 selected disk.")}
               isChecked={target === "NEW_PARTITION"}
               isDisabled={!targets.includes("NEW_PARTITION")}
@@ -172,8 +177,7 @@ file system will be created as a logical volume.")}
               id="format"
               name="target"
               label={_("Format the device")}
-              description={sprintf(_("The selected device will be formatted as %s file system and \
-mounted at %s."), volume.fsType, volume.mountPath)}
+              description={sprintf(_("The selected device will be formatted as %s file system."), volume.fsType)}
               isChecked={target === "DEVICE"}
               isDisabled={!targets.includes("DEVICE")}
               onChange={() => setTarget("DEVICE")}
@@ -181,8 +185,8 @@ mounted at %s."), volume.fsType, volume.mountPath)}
             <Radio
               id="mount"
               name="target"
-              label={_("Mount file system")}
-              description={sprintf(_("The selected device will be mounted at %s."), volume.mountPath)}
+              label={_("Mount the file system")}
+              description={_("The current file system on the selected device will be mounted without formatting the device.")}
               isChecked={target === "FILESYSTEM"}
               isDisabled={!targets.includes("FILESYSTEM")}
               onChange={() => setTarget("FILESYSTEM")}

--- a/web/src/components/storage/VolumeLocationDialog.jsx
+++ b/web/src/components/storage/VolumeLocationDialog.jsx
@@ -130,6 +130,7 @@ export default function VolumeLocationDialog({
       title={sprintf(_("Location for %s file system"), volumeLabel(volume))}
       description={DIALOG_DESCRIPTION}
       inlineSize="large"
+      blockSize="large"
       isOpen={isOpen}
       className="location-layout"
       {...props}
@@ -150,7 +151,7 @@ export default function VolumeLocationDialog({
           />
         </FormReadOnlyField>
         <FormGroup label={_("Select how to allocate the file system")}>
-          <div className="stack small">
+          <div className="stack">
             <Radio
               id="new_partition"
               name="target"

--- a/web/src/components/storage/VolumeLocationDialog.jsx
+++ b/web/src/components/storage/VolumeLocationDialog.jsx
@@ -26,7 +26,7 @@ import { Radio, Form, FormGroup } from "@patternfly/react-core";
 import { sprintf } from "sprintf-js";
 
 import { _ } from "~/i18n";
-import { deviceChildren } from "~/components/storage/utils";
+import { deviceChildren, volumeLabel } from "~/components/storage/utils";
 import { FormReadOnlyField, Popup } from "~/components/core";
 import VolumeLocationSelectorTable from "~/components/storage/VolumeLocationSelectorTable";
 
@@ -128,7 +128,7 @@ export default function VolumeLocationDialog({
 
   return (
     <Popup
-      title={sprintf(_("Location for %s file system"), volume.mountPath)}
+      title={sprintf(_("Location for %s file system"), volumeLabel(volume))}
       description={DIALOG_DESCRIPTION}
       inlineSize="large"
       isOpen={isOpen}

--- a/web/src/components/storage/VolumeLocationDialog.jsx
+++ b/web/src/components/storage/VolumeLocationDialog.jsx
@@ -57,9 +57,7 @@ const availableTargets = (volume, device) => {
     targets.push("NEW_VG");
   }
 
-  /** @fixme define type for possible fstypes */
-  const fsTypes = volume.outline.fsTypes.map(f => f.toLowerCase());
-  if (device.filesystem && fsTypes.includes(device.filesystem.type))
+  if (device.filesystem && volume.outline.fsTypes.includes(device.filesystem.type))
     targets.push("FILESYSTEM");
 
   return targets;

--- a/web/src/components/storage/VolumeLocationDialog.jsx
+++ b/web/src/components/storage/VolumeLocationDialog.jsx
@@ -131,70 +131,69 @@ export default function VolumeLocationDialog({
       description={DIALOG_DESCRIPTION}
       inlineSize="large"
       isOpen={isOpen}
+      className="location-layout"
       {...props}
     >
       <Form id="volume-location-form" onSubmit={onSubmit}>
-        <div className="stack">
-          <FormReadOnlyField label={_("Select in which device to allocate the file system")}>
-            <VolumeLocationSelectorTable
-              aria-label={_("Select a location")}
-              devices={volumeDevices}
-              selectedDevices={[targetDevice]}
-              targetDevices={targetDevices}
-              volumes={volumes}
-              itemChildren={deviceChildren}
-              itemSelectable={isDeviceSelectable}
-              onSelectionChange={changeTargetDevice}
-              initialExpandedKeys={volumeDevices.map(d => d.sid)}
-              variant="compact"
-            />
-          </FormReadOnlyField>
-          <FormGroup label={_("Select how to allocate the file system")}>
-            <Radio
-              id="new_partition"
-              name="target"
-              label={_("Create a new partition")}
-              description={_("The file system will be allocated as a new partition at the selected \
+        <FormReadOnlyField label={_("Select in which device to allocate the file system")}>
+          <VolumeLocationSelectorTable
+            aria-label={_("Select a location")}
+            devices={volumeDevices}
+            selectedDevices={[targetDevice]}
+            targetDevices={targetDevices}
+            volumes={volumes}
+            itemChildren={deviceChildren}
+            itemSelectable={isDeviceSelectable}
+            onSelectionChange={changeTargetDevice}
+            initialExpandedKeys={volumeDevices.map(d => d.sid)}
+            variant="compact"
+          />
+        </FormReadOnlyField>
+        <FormGroup label={_("Select how to allocate the file system")}>
+          <Radio
+            id="new_partition"
+            name="target"
+            label={_("Create a new partition")}
+            description={_("The file system will be allocated as a new partition at the selected \
 disk.")}
-              isChecked={target === "NEW_PARTITION"}
-              isDisabled={!targets.includes("NEW_PARTITION")}
-              onChange={() => setTarget("NEW_PARTITION")}
-            />
-            <Radio
-              id="dedicated_lvm"
-              name="target"
-              label={_("Create a dedicated LVM volume group")}
-              description={_("A new volume group will be allocated in the selected disk and the \
+            isChecked={target === "NEW_PARTITION"}
+            isDisabled={!targets.includes("NEW_PARTITION")}
+            onChange={() => setTarget("NEW_PARTITION")}
+          />
+          <Radio
+            id="dedicated_lvm"
+            name="target"
+            label={_("Create a dedicated LVM volume group")}
+            description={_("A new volume group will be allocated in the selected disk and the \
 file system will be created as a logical volume.")}
-              isChecked={target === "NEW_VG"}
-              isDisabled={!targets.includes("NEW_VG")}
-              onChange={() => setTarget("NEW_VG")}
-            />
-            <Radio
-              id="format"
-              name="target"
-              label={_("Format the device")}
-              description={
-                // TRANSLATORS: %s is replaced by a file system type (e.g., Ext4).
-                sprintf(_("The selected device will be formatted as %s file system."),
-                        volume.fsType)
-              }
-              isChecked={target === "DEVICE"}
-              isDisabled={!targets.includes("DEVICE")}
-              onChange={() => setTarget("DEVICE")}
-            />
-            <Radio
-              id="mount"
-              name="target"
-              label={_("Mount the file system")}
-              description={_("The current file system on the selected device will be mounted \
+            isChecked={target === "NEW_VG"}
+            isDisabled={!targets.includes("NEW_VG")}
+            onChange={() => setTarget("NEW_VG")}
+          />
+          <Radio
+            id="format"
+            name="target"
+            label={_("Format the device")}
+            description={
+              // TRANSLATORS: %s is replaced by a file system type (e.g., Ext4).
+              sprintf(_("The selected device will be formatted as %s file system."),
+                volume.fsType)
+            }
+            isChecked={target === "DEVICE"}
+            isDisabled={!targets.includes("DEVICE")}
+            onChange={() => setTarget("DEVICE")}
+          />
+          <Radio
+            id="mount"
+            name="target"
+            label={_("Mount the file system")}
+            description={_("The current file system on the selected device will be mounted \
 without formatting the device.")}
-              isChecked={target === "FILESYSTEM"}
-              isDisabled={!targets.includes("FILESYSTEM")}
-              onChange={() => setTarget("FILESYSTEM")}
-            />
-          </FormGroup>
-        </div>
+            isChecked={target === "FILESYSTEM"}
+            isDisabled={!targets.includes("FILESYSTEM")}
+            onChange={() => setTarget("FILESYSTEM")}
+          />
+        </FormGroup>
       </Form>
       <Popup.Actions>
         <Popup.Confirm form="volume-location-form" type="submit" />

--- a/web/src/components/storage/VolumeLocationSelectorTable.jsx
+++ b/web/src/components/storage/VolumeLocationSelectorTable.jsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// @ts-check
+
+import React from "react";
+import { Chip } from '@patternfly/react-core';
+
+import { _ } from "~/i18n";
+import {
+  DeviceName, DeviceDetails, DeviceSize, toStorageDevice
+} from "~/components/storage/device-utils";
+import { ExpandableSelector } from "~/components/core";
+
+/**
+ * @typedef {import("../core/ExpandableSelector").ExpandableSelectorColumn} ExpandableSelectorColumn
+ * @typedef {import("../core/ExpandableSelector").ExpandableSelectorProps} ExpandableSelectorProps
+ * @typedef {import ("~/client/storage").StorageDevice} StorageDevice
+ * @typedef {import ("~/client/storage").Volume} Volume
+ */
+
+const deviceUsers = (item, targetDevices, volumes) => {
+  const device = toStorageDevice(item);
+  if (!device) return [];
+
+  const isTargetDevice = !!targetDevices.find(d => d.name === device.name);
+  const volumeUsers = volumes.filter(v => v.targetDevice?.name === device.name);
+
+  const users = [];
+  if (isTargetDevice) users.push(_("Installation device"));
+
+  return users.concat(volumeUsers.map(v => v.mountPath));
+};
+
+const DeviceUsage = ({ users }) => {
+  return users.map((user, index) => <Chip key={index} isReadOnly>{user}</Chip>);
+};
+
+/**
+ * Table for selecting the location for a volume.
+ * @component
+ *
+ * @typedef {object} VolumeLocationSelectorTableBaseProps
+ * @property {StorageDevice[]} devices
+ * @property {StorageDevice[]} selectedDevices
+ * @property {StorageDevice[]} targetDevices
+ * @property {Volume[]} volumes
+ *
+ * @typedef {VolumeLocationSelectorTableBaseProps & ExpandableSelectorProps} VolumeLocationSelectorTable
+ *
+ * @param {VolumeLocationSelectorTable} props
+ */
+export default function VolumeLocationSelectorTable({
+  devices,
+  selectedDevices,
+  targetDevices,
+  volumes,
+  ...props
+}) {
+  /** @type {ExpandableSelectorColumn[]} */
+  const columns = [
+    { name: _("Device"), value: (item) => <DeviceName item={item} /> },
+    { name: _("Details"), value: (item) => <DeviceDetails item={item} /> },
+    { name: _("Usage"), value: (item) => <DeviceUsage users={deviceUsers(item, targetDevices, volumes)} /> },
+    { name: _("Size"), value: (item) => <DeviceSize item={item} />, classNames: "sizes-column" }
+  ];
+
+  return (
+    <ExpandableSelector
+      columns={columns}
+      items={devices}
+      itemIdKey="sid"
+      itemClassNames={(device) => {
+        if (!device.sid) {
+          return "dimmed-row";
+        }
+      }}
+      itemsSelected={selectedDevices}
+      className="devices-table"
+      {...props}
+    />
+  );
+}

--- a/web/src/components/storage/VolumeLocationSelectorTable.jsx
+++ b/web/src/components/storage/VolumeLocationSelectorTable.jsx
@@ -33,10 +33,20 @@ import { ExpandableSelector } from "~/components/core";
 /**
  * @typedef {import("../core/ExpandableSelector").ExpandableSelectorColumn} ExpandableSelectorColumn
  * @typedef {import("../core/ExpandableSelector").ExpandableSelectorProps} ExpandableSelectorProps
+ * @typedef {import ("~/client/storage").PartitionSlot} PartitionSlot
  * @typedef {import ("~/client/storage").StorageDevice} StorageDevice
  * @typedef {import ("~/client/storage").Volume} Volume
  */
 
+/**
+ * Returns what (volumes, installation device) is using a device.
+ * @function
+ *
+ * @param {PartitionSlot|StorageDevice} item
+ * @param {StorageDevice[]} targetDevices
+ * @param {Volume[]} volumes
+ * @returns {string[]}
+ */
 const deviceUsers = (item, targetDevices, volumes) => {
   const device = toStorageDevice(item);
   if (!device) return [];
@@ -50,6 +60,12 @@ const deviceUsers = (item, targetDevices, volumes) => {
   return users.concat(volumeUsers.map(v => v.mountPath));
 };
 
+/**
+ * @component
+ *
+ * @param {object} props
+ * @param {string[]} props.users
+ */
 const DeviceUsage = ({ users }) => {
   return users.map((user, index) => <Chip key={index} isReadOnly>{user}</Chip>);
 };
@@ -64,9 +80,9 @@ const DeviceUsage = ({ users }) => {
  * @property {StorageDevice[]} targetDevices
  * @property {Volume[]} volumes
  *
- * @typedef {VolumeLocationSelectorTableBaseProps & ExpandableSelectorProps} VolumeLocationSelectorTable
+ * @typedef {VolumeLocationSelectorTableBaseProps & ExpandableSelectorProps} VolumeLocationSelectorTableProps
  *
- * @param {VolumeLocationSelectorTable} props
+ * @param {VolumeLocationSelectorTableProps} props
  */
 export default function VolumeLocationSelectorTable({
   devices,

--- a/web/src/components/storage/VolumeLocationSelectorTable.jsx
+++ b/web/src/components/storage/VolumeLocationSelectorTable.jsx
@@ -67,7 +67,11 @@ const deviceUsers = (item, targetDevices, volumes) => {
  * @param {string[]} props.users
  */
 const DeviceUsage = ({ users }) => {
-  return users.map((user, index) => <Chip key={index} isReadOnly>{user}</Chip>);
+  return (
+    <div className="wrapped split">
+      {users.map((user, index) => <Chip key={index} isReadOnly>{user}</Chip>)}
+    </div>
+  );
 };
 
 /**

--- a/web/src/components/storage/VolumeLocationSelectorTable.jsx
+++ b/web/src/components/storage/VolumeLocationSelectorTable.jsx
@@ -31,8 +31,8 @@ import {
 import { ExpandableSelector } from "~/components/core";
 
 /**
- * @typedef {import("../core/ExpandableSelector").ExpandableSelectorColumn} ExpandableSelectorColumn
- * @typedef {import("../core/ExpandableSelector").ExpandableSelectorProps} ExpandableSelectorProps
+ * @typedef {import ("~/components/core/ExpandableSelector").ExpandableSelectorColumn} ExpandableSelectorColumn
+ * @typedef {import ("~/components/core/ExpandableSelector").ExpandableSelectorProps} ExpandableSelectorProps
  * @typedef {import ("~/client/storage").PartitionSlot} PartitionSlot
  * @typedef {import ("~/client/storage").StorageDevice} StorageDevice
  * @typedef {import ("~/client/storage").Volume} Volume

--- a/web/src/components/storage/device-utils.jsx
+++ b/web/src/components/storage/device-utils.jsx
@@ -33,7 +33,7 @@ import { deviceBaseName, deviceSize } from "~/components/storage/utils";
  */
 
 /**
- * Conversion to StorageDevice.
+ * Ensures the given item is a StorageDevice.
  * @function
  *
  * @param {PartitionSlot|StorageDevice} item

--- a/web/src/components/storage/device-utils.jsx
+++ b/web/src/components/storage/device-utils.jsx
@@ -22,24 +22,40 @@
 // @ts-check
 
 import React from "react";
-import { sprintf } from "sprintf-js";
 
 import { _ } from "~/i18n";
-import { Icon } from "~/components/layout";
-import { If, Tag } from "~/components/core";
-import { deviceBaseName } from "~/components/storage/utils";
+import { Tag } from "~/components/core";
+import { deviceBaseName, deviceSize } from "~/components/storage/utils";
 
 /**
+ * @typedef {import ("~/client/storage").PartitionSlot} PartitionSlot
  * @typedef {import ("~/client/storage").StorageDevice} StorageDevice
  */
+
+/**
+ * Conversion to StorageDevice.
+ * @function
+ *
+ * @param {PartitionSlot|StorageDevice} item
+ * @returns {StorageDevice|undefined}
+ */
+const toStorageDevice = (item) => {
+  const { sid } = /** @type {object} */ (item);
+  if (!sid) return undefined;
+
+  return /** @type {StorageDevice} */ (item);
+};
 
 /**
  * @component
  *
  * @param {object} props
- * @param {StorageDevice} props.device
+ * @param {PartitionSlot|StorageDevice} props.item
  */
-const FilesystemLabel = ({ device }) => {
+const FilesystemLabel = ({ item }) => {
+  const device = toStorageDevice(item);
+  if (!device) return null;
+
   const label = device.filesystem?.label;
   if (label) return <Tag variant="gray-highlight"><b>{label}</b></Tag>;
 };
@@ -48,92 +64,41 @@ const FilesystemLabel = ({ device }) => {
  * @component
  *
  * @param {object} props
- * @param {StorageDevice} props.device
+ * @param {PartitionSlot|StorageDevice} props.item
  */
-const DeviceExtendedInfo = ({ device }) => {
-  const DeviceName = () => {
-    if (device.name === undefined) return null;
+const DeviceName = ({ item }) => {
+  const device = toStorageDevice(item);
+  if (!device) return null;
 
-    return <div>{device.name}</div>;
+  if (["partition", "lvmLv"].includes(device.type)) return deviceBaseName(device);
+
+  return device.name;
+};
+
+/**
+ * @component
+ *
+ * @param {object} props
+ * @param {PartitionSlot|StorageDevice} props.item
+ */
+const DeviceDetails = ({ item }) => {
+  const device = toStorageDevice(item);
+  if (!device) return _("Unused space");
+
+  const renderContent = (device) => {
+    if (!device.partitionTable && device.systems?.length > 0)
+      return device.systems.join(", ");
+
+    return device.description;
   };
 
-  const DeviceType = () => {
-    let type;
-
-    switch (device.type) {
-      case "multipath": {
-        // TRANSLATORS: multipath device type
-        type = _("Multipath");
-        break;
-      }
-      case "dasd": {
-        // TRANSLATORS: %s is replaced by the device bus ID
-        type = sprintf(_("DASD %s"), device.busId);
-        break;
-      }
-      case "md": {
-        // TRANSLATORS: software RAID device, %s is replaced by the RAID level, e.g. RAID-1
-        type = sprintf(_("Software %s"), device.level.toUpperCase());
-        break;
-      }
-      case "disk": {
-        if (device.sdCard) {
-          type = _("SD Card");
-        } else {
-          const technology = device.transport || device.bus;
-          type = technology
-            // TRANSLATORS: %s is substituted by the type of disk like "iSCSI" or "SATA"
-            ? sprintf(_("%s disk"), technology)
-            : _("Disk");
-        }
-      }
-    }
-
-    return <If condition={type} then={<div>{type}</div>} />;
-  };
-
-  const DeviceModel = () => {
-    if (!device.model || device.model === "") return null;
-
-    return <div>{device.model}</div>;
-  };
-
-  const MDInfo = () => {
-    if (device.type !== "md" || !device.devices) return null;
-
-    const members = device.devices.map(deviceBaseName);
-
-    // TRANSLATORS: RAID details, %s is replaced by list of devices used by the array
-    return <div>{sprintf(_("Members: %s"), members.sort().join(", "))}</div>;
-  };
-
-  const RAIDInfo = () => {
-    if (device.type !== "raid") return null;
-
-    const devices = device.devices.map(deviceBaseName);
-
-    // TRANSLATORS: RAID details, %s is replaced by list of devices used by the array
-    return <div>{sprintf(_("Devices: %s"), devices.sort().join(", "))}</div>;
-  };
-
-  const MultipathInfo = () => {
-    if (device.type !== "multipath") return null;
-
-    const wires = device.wires.map(deviceBaseName);
-
-    // TRANSLATORS: multipath details, %s is replaced by list of connections used by the device
-    return <div>{sprintf(_("Wires: %s"), wires.sort().join(", "))}</div>;
+  const renderPTableType = (device) => {
+    const type = device.partitionTable?.type;
+    if (type) return <Tag><b>{type.toUpperCase()}</b></Tag>;
   };
 
   return (
-    <div>
-      <DeviceName />
-      <DeviceType />
-      <DeviceModel />
-      <MDInfo />
-      <RAIDInfo />
-      <MultipathInfo />
-    </div>
+    <div>{renderContent(device)} <FilesystemLabel item={device} /> {renderPTableType(device)}</div>
   );
 };
 
@@ -141,59 +106,10 @@ const DeviceExtendedInfo = ({ device }) => {
  * @component
  *
  * @param {object} props
- * @param {StorageDevice} props.device
+ * @param {PartitionSlot|StorageDevice} props.item
  */
-const DeviceContentInfo = ({ device }) => {
-  const PTable = () => {
-    if (device.partitionTable === undefined) return null;
-
-    const type = device.partitionTable.type.toUpperCase();
-    const numPartitions = device.partitionTable.partitions.length;
-
-    // TRANSLATORS: disk partition info, %s is replaced by partition table
-    // type (MS-DOS or GPT), %d is the number of the partitions
-    const text = sprintf(_("%s with %d partitions"), type, numPartitions);
-
-    return (
-      <div>
-        <Icon name="folder" size="14" /> {text}
-      </div>
-    );
-  };
-
-  const Systems = () => {
-    if (!device.systems || device.systems.length === 0) return null;
-
-    const System = ({ system }) => {
-      const logo = /windows/i.test(system) ? "windows_logo" : "linux_logo";
-
-      return <div><Icon name={logo} size="14" /> {system}</div>;
-    };
-
-    return device.systems.map((s, i) => <System key={i} system={s} />);
-  };
-
-  // TODO: there is a lot of room for improvement here, but first we would need
-  // device.description (comes from YaST) to be way more granular
-  const Description = () => {
-    if (device.partitionTable) return null;
-
-    if (!device.sid || (!!device.model && device.model === device.description)) {
-      // TRANSLATORS: status message, no existing content was found on the disk,
-      // i.e. the disk is completely empty
-      return <div><Icon name="folder_off" size="14" /> {_("No content found")}</div>;
-    }
-
-    return <div>{device.description} <FilesystemLabel device={device} /></div>;
-  };
-
-  return (
-    <div>
-      <PTable />
-      <Description />
-      <Systems />
-    </div>
-  );
+const DeviceSize = ({ item }) => {
+  return deviceSize(item.size);
 };
 
-export { DeviceContentInfo, DeviceExtendedInfo, FilesystemLabel };
+export { toStorageDevice, DeviceName, DeviceDetails, DeviceSize, FilesystemLabel };

--- a/web/src/components/storage/device-utils.jsx
+++ b/web/src/components/storage/device-utils.jsx
@@ -57,7 +57,9 @@ const FilesystemLabel = ({ item }) => {
   if (!device) return null;
 
   const label = device.filesystem?.label;
-  if (label) return <Tag variant="gray-highlight"><b>{label}</b></Tag>;
+  if (!label) return null;
+
+  return <Tag variant="gray-highlight"><b>{label}</b></Tag>;
 };
 
 /**

--- a/web/src/components/storage/device-utils.test.jsx
+++ b/web/src/components/storage/device-utils.test.jsx
@@ -20,7 +20,6 @@
  */
 
 // @ts-check
-// cspell:ignore dasda ddgdcbibhd
 
 import React from "react";
 import { screen } from "@testing-library/react";

--- a/web/src/components/storage/index.js
+++ b/web/src/components/storage/index.js
@@ -31,7 +31,6 @@ export { default as DASDFormatProgress } from "./DASDFormatProgress";
 export { default as ZFCPPage } from "./ZFCPPage";
 export { default as ZFCPDiskForm } from "./ZFCPDiskForm";
 export { default as ISCSIPage } from "./ISCSIPage";
-export { DeviceContentInfo, DeviceExtendedInfo, FilesystemLabel } from "./device-utils";
 export { default as BootSelectionDialog } from "./BootSelectionDialog";
 export { default as DeviceSelectionDialog } from "./DeviceSelectionDialog";
 export { default as DeviceSelectorTable } from "./DeviceSelectorTable";

--- a/web/src/components/storage/utils.js
+++ b/web/src/components/storage/utils.js
@@ -285,6 +285,12 @@ const isTransactionalSystem = (volumes = []) => {
   return volumes.find(v => isTransactionalRoot(v)) !== undefined;
 };
 
+const mountFilesystem = (volume) => volume.target === "FILESYSTEM";
+
+const reuseDevice = (volume) => volume.target === "FILESYSTEM" || volume.target === "DEVICE";
+
+const volumeLabel = (volume) => volume.mountPath === "/" ? "root" : volume.mountPath;
+
 export {
   DEFAULT_SIZE_UNIT,
   SIZE_METHODS,
@@ -299,5 +305,8 @@ export {
   hasFS,
   hasSnapshots,
   isTransactionalRoot,
-  isTransactionalSystem
+  isTransactionalSystem,
+  mountFilesystem,
+  reuseDevice,
+  volumeLabel
 };

--- a/web/src/components/storage/utils.js
+++ b/web/src/components/storage/utils.js
@@ -22,6 +22,13 @@
 // @ts-check
 // cspell:ignore xbytes
 
+/**
+ * @fixme This file implements utils for the storage components and it also offers several functions
+ * to get information from a Volume (e.g., #hasSnapshots, #isTransactionalRoot, etc). It would be
+ * better to use another approach to encapsulate the volume information. For example, by creating
+ * a Volume class or by providing a kind of interface for volumes.
+ */
+
 import xbytes from "xbytes";
 
 import { N_ } from "~/i18n";
@@ -285,10 +292,31 @@ const isTransactionalSystem = (volumes = []) => {
   return volumes.find(v => isTransactionalRoot(v)) !== undefined;
 };
 
+/**
+ * Checks whether the given volume is configured to mount an existing file system.
+ * @function
+ *
+ * @param {Volume} volume
+ * @returns {boolean}
+ */
 const mountFilesystem = (volume) => volume.target === "FILESYSTEM";
 
+/**
+ * Checks whether the given volume is configured to reuse a device (format or mount a file system).
+ * @function
+ *
+ * @param {Volume} volume
+ * @returns {boolean}
+ */
 const reuseDevice = (volume) => volume.target === "FILESYSTEM" || volume.target === "DEVICE";
 
+/**
+ * Generates a label for the given volume.
+ * @function
+ *
+ * @param {Volume} volume
+ * @returns {string}
+ */
 const volumeLabel = (volume) => volume.mountPath === "/" ? "root" : volume.mountPath;
 
 export {


### PR DESCRIPTION
Implement feature for reusing an existing device (i.e., allow formatting a block device or mounting a file system). Main changes:

* Redesign the dialog for changing location:
  *  Shows a table with all the devices that can be selected as location for the volumes.
  * Allows selecting how to allocate the file system at selected device (create partition, create dedicated LVM, format, mount).
* Add a menu option in the table of volumes for resetting the location (i.e., to use the installation device instead of a custom location).

Note: We have detected some problems with the UI for changing location implemented in this PR:

* The table is scrollable. If there are too many devices, then there is a chance of overlooking some devices if you don't realize about the scroll.
* Having a table and group of radios at the end looks quite overwhelming. The very same information could be provided in a simpler way.
* Ideally, this change location option should be integrated in the form of the volume.

Check some ideas in the thread of this PR and at https://github.com/openSUSE/agama/discussions/1176.

<details>
<summary>Toggle screenshots</summary> 
 
![localhost_8080_ (44)](https://github.com/openSUSE/agama/assets/1112304/e93882df-a8ab-4c48-8df9-63154011adb0)

![localhost_8080_ (45)](https://github.com/openSUSE/agama/assets/1112304/f9cd0c6f-484c-4903-8961-94169fffe9b4)

</details>