### PR TITLE
Fixed wrongly used plural form

### DIFF
--- a/web/src/components/overview/StorageSection.jsx
+++ b/web/src/components/overview/StorageSection.jsx
@@ -29,8 +29,7 @@ import { useInstallerClient } from "~/context/installer";
 import { BUSY } from "~/client/status";
 import { deviceLabel } from "~/components/storage/utils";
 import { Em, ProgressText, Section } from "~/components/core";
-import { sprintf } from "sprintf-js";
-import { _, n_ } from "~/i18n";
+import { _ } from "~/i18n";
 
 /**
  * @typedef {import ("~/client/storage").ProposalResult} ProposalResult
@@ -40,6 +39,57 @@ import { _, n_ } from "~/i18n";
  * @property {StorageDevice[]} availableDevices
  * @property {ProposalResult} result
  */
+
+/**
+ * Build a translated summary string for installing on an LVM with multiple
+ * physical partitions/disks
+ * @param {String} policy Find space policy
+ * @returns {String} Translated description
+ */
+const msgLvmMultipleDisks = (policy) => {
+  switch (policy) {
+    case "resize":
+      // TRANSLATORS: installing on an LVM with multiple physical partitions/disks
+      return _("Install in a new Logical Volume Manager (LVM) volume group shrinking existing partitions at the underlying devices as needed");
+    case "keep":
+      // TRANSLATORS: installing on an LVM with multiple physical partitions/disks
+      return _("Install in a new Logical Volume Manager (LVM) volume group without modifying the partitions at the underlying devices");
+    case "delete":
+      // TRANSLATORS: installing on an LVM with multiple physical partitions/disks
+      return _("Install in a new Logical Volume Manager (LVM) volume group deleting all the content of the underlying devices");
+    case "custom":
+      // TRANSLATORS: installing on an LVM with multiple physical partitions/disks
+      return _("Install in a new Logical Volume Manager (LVM) volume group using a custom strategy to find the needed space at the underlying devices");
+  }
+};
+
+/**
+ * Build a translated summary string for installing on an LVM with a single
+ * physical partition/disk
+ * @param {String} policy Find space policy
+ * @returns {String} Translated description with %s placeholder for the device
+ * name
+ */
+const msgLvmSingleDisk = (policy) => {
+  switch (policy) {
+    case "resize":
+      // TRANSLATORS: installing on an LVM with a single physical partition/disk,
+      // %s will be replaced by a device name and its size (eg. "/dev/sda, 20 GiB")
+      return _("Install in a new Logical Volume Manager (LVM) volume group on %s shrinking existing partitions as needed");
+    case "keep":
+      // TRANSLATORS: installing on an LVM with a single physical partition/disk,
+      // %s will be replaced by a device name and its size (eg. "/dev/sda, 20 GiB")
+      return _("Install in a new Logical Volume Manager (LVM) volume group on %s without modifying existing partitions");
+    case "delete":
+      // TRANSLATORS: installing on an LVM with a single physical partition/disk,
+      // %s will be replaced by a device name and its size (eg. "/dev/sda, 20 GiB")
+      return _("Install in a new Logical Volume Manager (LVM) volume group on %s deleting all its content");
+    case "custom":
+      // TRANSLATORS: installing on an LVM with a single physical partition/disk,
+      // %s will be replaced by a device name and its size (eg. "/dev/sda, 20 GiB")
+      return _("Install in a new Logical Volume Manager (LVM) volume group on %s using a custom strategy to find the needed space");
+  }
+};
 
 /**
  * Text explaining the storage proposal
@@ -59,52 +109,12 @@ const ProposalSummary = ({ proposal }) => {
   };
 
   if (result.settings.target === "NEW_LVM_VG") {
-    // TRANSLATORS: Part of the message describing where the system will be installed.
-    const vg = _("Logical Volume Manager (LVM) volume group");
     const pvDevices = result.settings.targetPVDevices;
-    const fullMsg = (policy, num_pvs) => {
-      switch (policy) {
-        case "resize":
-          // TRANSLATORS: %1$s will be replaced by "LVM volume group" (already translated and with some markup)
-          // %2$s (if present) will be replaced by a device name and its size (eg. "/dev/sda, 20 GiB")
-          return n_(
-            "Install in a new %1$s on %2$s shrinking existing partitions as needed",
-            "Install in a new %1$s shrinking existing partitions at the underlying devices as needed",
-            num_pvs
-          );
-        case "keep":
-          // TRANSLATORS: %1$s will be replaced by "LVM volume group" (already translated and with some markup)
-          // %2$s (if present) will be replaced by a device name and its size (eg. "/dev/sda, 20 GiB")
-          return n_(
-            "Install in a new %1$s on %2$s without modifying existing partitions",
-            "Install in a new %1$s without modifying the partitions at the underlying devices",
-            num_pvs
-          );
-        case "delete":
-          // TRANSLATORS: %1$s will be replaced by "LVM volume group" (already translated and with some markup)
-          // %2$s (if present) will be replaced by a device name and its size (eg. "/dev/sda, 20 GiB")
-          return n_(
-            "Install in a new %1$s on %2$s deleting all its content",
-            "Install in a new %1$s deleting all the content of the underlying devices",
-            num_pvs
-          );
-        case "custom":
-          // TRANSLATORS: %1$s will be replaced by "LVM volume group" (already translated and with some markup)
-          // %2$s (if present) will be replaced by a device name and its size (eg. "/dev/sda, 20 GiB")
-          return n_(
-            "Install in a new %1$s on %2$s using a custom strategy to find the needed space",
-            "Install in a new %1$s using a custom strategy to find the needed space at the underlying devices",
-            num_pvs
-          );
-      }
-    };
-
-    const msg = sprintf(fullMsg(result.settings.spacePolicy, pvDevices.length), vg, "%dev%");
 
     if (pvDevices.length > 1) {
-      return (<span>{msg}</span>);
+      return (<span>{msgLvmMultipleDisks(result.settings.spacePolicy)}</span>);
     } else {
-      const [msg1, msg2] = msg.split("%dev%");
+      const [msg1, msg2] = msgLvmSingleDisk(result.settings.spacePolicy).split("%s");
 
       return (
         <Text>


### PR DESCRIPTION
## Problem

- Merging the translation from Weblate failed with
  ```
  web/po/ca.po:836: number of format specifications in 'msgid_plural' and 'msgstr[0]' does not match
  web/po/ca.po:848: number of format specifications in 'msgid_plural' and 'msgstr[0]' does not match
  web/po/ca.po:8[5](https://github.com/openSUSE/agama/actions/runs/8797558854/job/24142706299#step:9:6)9: number of format specifications in 'msgid_plural' and 'msgstr[0]' does not match
  web/po/ca.po:872: number of format specifications in 'msgid_plural' and 'msgstr[0]' does not match
  msgfmt: found 4 fatal errors
  ```
- See https://github.com/openSUSE/agama/actions/runs/8797558854/job/24142706299#step:9:10

## Details

There are actually two problems.

### Building Translated Texts

Building translated strings should be avoided. Example:

```
const vg = _("Logical Volume Manager (LVM) volume group");
if (...) {return sprintf(n_( "Install in a new %1$s..."), vg)};
if (...) {return sprintf(n_( "Install in a new %1$s..."), vg)};
```

The problem is that the translator does not see the whole text and the translated parts then might not fit well together.
Another problem is that the text around might change the context and the injected message might need a different translation. But in this case that is not possible.

It is better to always use the full texts. It might seem annoying to have several similar strings but more important is that the translator has full control for the final text and each of them can be translated slightly differently if needed.

### Wrongly Used Plural Form

This is a more serious problem. The code displays a different text for LVM with a single PV and a different text for LVM with multiple PV. That makes sense, if there is one PV we can display it in the text, but there can be a dozen of PVs and then the text would be too long.

But the problem is that it used a gettext plural form `n_()` function for that logic.

```
n_("Install in a new %1$s on %2$s shrinking...", "Install in a new %1$s shrinking...", num)
```

Then gettext complains about the different number of format specifiers. But the real problem is elsewhere. 

:warning: **There are languages which do not differ between singular and plural forms, they have one form for both. For example Japanese or Vietnamese. In that case you will always get the singular form even for `num` >= 2!!** :warning: 

When using `n_()` function both texts should be the same, the only difference should be singular/plural form for some words!

## Solution

Refactor the code to use the simple `_()` translation and put the logic into the code.

## Testing

- Tested manually

## Screenshots

![storage_summary](https://github.com/openSUSE/agama/assets/907998/a05494a7-22c3-452e-a86c-0520a441a42e)


