### PR TITLE
web: Use PF Thead#noWrap prop

### DIFF
--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -263,11 +263,6 @@ ul {
   border-block-end: 0;
 }
 
-.pf-v5-c-table tr:where(.pf-v5-c-table__tr) > th {
-  white-space: normal;
-  vertical-align: middle;
-}
-
 .pf-v5-c-radio {
   align-items: center;
 }

--- a/web/src/components/core/ExpandableSelector.jsx
+++ b/web/src/components/core/ExpandableSelector.jsx
@@ -57,7 +57,7 @@ import { Table, Thead, Tr, Th, Tbody, Td, ExpandableRowContent, RowSelectVariant
  * @param {ExpandableSelectorColumn[]} props.columns
  */
 const TableHeader = ({ columns }) => (
-  <Thead>
+  <Thead noWrap>
     <Tr>
       <Th />
       <Th />

--- a/web/src/components/core/TreeTable.jsx
+++ b/web/src/components/core/TreeTable.jsx
@@ -136,7 +136,7 @@ export default function TreeTable({
       isTreeTable
       data-type="agama/tree-table"
     >
-      <Thead>
+      <Thead noWrap>
         <Tr>
           { columns.map((c, i) => <Th key={i} className={c.classNames}>{c.name}</Th>) }
         </Tr>

--- a/web/src/components/storage/PartitionsField.jsx
+++ b/web/src/components/storage/PartitionsField.jsx
@@ -496,7 +496,7 @@ const VolumesTable = ({
 
   return (
     <Table aria-label={_("Table with mount points")} variant="compact" borders>
-      <Thead>
+      <Thead noWrap>
         <Tr>
           <Th>{columns.mountPath}</Th>
           <Th>{columns.details}</Th>


### PR DESCRIPTION
Few weeks ago we overlooked the [`noWrap`](https://www.patternfly.org/components/table#custom-row-wrapper-header-tooltips--popovers) PF/Table/Thead prop and introduced a CSS hack. This PR changes it and somehow reverts  https://github.com/openSUSE/agama/pull/1153


| Using the CSS override | Using the `noWrap` prop |
|-|-|
| ![Screenshot from 2024-05-06 11-43-27](https://github.com/openSUSE/agama/assets/1691872/be3318db-c0d6-4d85-86bc-1cd0e135cac2) | ![Screenshot from 2024-05-06 12-03-22](https://github.com/openSUSE/agama/assets/1691872/f5ff8a9a-576b-488d-a3de-7333ae9d1a54) |
