### PR TITLE
Added rust/package/_constraints

### DIFF
--- a/rust/package/_constraints
+++ b/rust/package/_constraints
@@ -1,0 +1,7 @@
+<constraints>
+  <hardware>
+    <disk>
+      <size unit="G">20</size>
+    </disk>
+  </hardware>
+</constraints>


### PR DESCRIPTION
## Problem

- OBS build might fail with an `No space left on device` error

## Solution

- Added `rust/package/_constraints` file to require at least 20GB disk space for build
- On x86_64 the build peak was about 18GB, hopefully this will be enough also for the other archs