### PR TITLE
Extract the _constraints file in OBS

### DIFF
--- a/rust/package/_service
+++ b/rust/package/_service
@@ -9,6 +9,7 @@
     <param name="without-version">enable</param>
     <param name="extract">package/agama.changes</param>
     <param name="extract">package/agama.spec</param>
+    <param name="extract">package/_constraints</param>
   </service>
   <service name="cargo_vendor" mode="manual">
     <param name="srcdir">agama/rust</param>


### PR DESCRIPTION
- Related to #1183
- I forgot to update the `_service` file, without it the `_constraints` is never created/updated in OBS