### PR TITLE
web: Handle HTTP failures in storage

### DIFF
--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -116,6 +116,33 @@ async fn run_events_monitor(dbus: zbus::Connection, events: EventsSender) -> Res
         stream.insert(id, software_stream);
     }
     stream.insert(
+        "storage-status",
+        service_status_stream(
+            dbus.clone(),
+            "org.opensuse.Agama.Storage1",
+            "/org/opensuse/Agama/Storage1",
+        )
+        .await?,
+    );
+    stream.insert(
+        "storage-progress",
+        progress_stream(
+            dbus.clone(),
+            "org.opensuse.Agama.Storage1",
+            "/org/opensuse/Agama/Storage1",
+        )
+        .await?,
+    );
+    stream.insert(
+        "storage-issues",
+        issues_stream(
+            dbus.clone(),
+            "org.opensuse.Agama.Storage1",
+            "/org/opensuse/Agama/Storage1",
+        )
+        .await?,
+    );
+    stream.insert(
         "software-status",
         service_status_stream(
             dbus.clone(),

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 14 12:24:23 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Make storage UI to work again when there is no device
+  (gh#openSUSE/agama#1203).
+
+-------------------------------------------------------------------
 Tue May 14 11:17:45 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix DELETE and PATCH calls in the HTTPClient

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Tue May 14 12:24:23 UTC 2024 - José Iván López González <jlopez@suse.com>
 
-- Make storage UI to work again when there is no device
+- Make storage UI work again when there are no devices
   (gh#openSUSE/agama#1203).
 
 -------------------------------------------------------------------

--- a/web/src/client/mixins.js
+++ b/web/src/client/mixins.js
@@ -82,9 +82,9 @@ const buildIssue = ({ description, details, source, severity }) => {
  * @template {!WithHTTPClient} T
  * @param {T} superclass - superclass to extend
  * @param {string} issues_path - validation resource path (e.g., "/manager/issues").
- * @param {string} dbus_path - service name (e.g., "/org/opensuse/Agama/Software1/product").
+ * @param {string} service_name - service name (e.g., "org.opensuse.Agama.Manager1").
  */
-const WithIssues = (superclass, issues_path, dbus_path) =>
+const WithIssues = (superclass, issues_path, service_name) =>
   class extends superclass {
     /**
      * Returns the issues
@@ -119,8 +119,8 @@ const WithIssues = (superclass, issues_path, dbus_path) =>
      * @return {import ("./http").RemoveFn} function to disable the callback
      */
     onIssuesChange(handler) {
-      return this.client.onEvent("IssuesChanged", ({ path, issues }) => {
-        if (path === dbus_path) {
+      return this.client.onEvent("IssuesChanged", ({ service, issues }) => {
+        if (service === service_name) {
           handler(issues.map(buildIssue));
         }
       });

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -198,25 +198,6 @@ const EncryptionMethods = Object.freeze({
 });
 
 /**
- * Removes properties with undefined value
- *
- * @example
- * removeUndefinedCockpitProperties({
- *  property1: { t: "s", v: "foo" },
- *  property2: { t: b, v: false },
- *  property3: { t: "s", v: undefined }
- * });
- * //returns { property1: { t: "s", v: "foo" }, property2: { t: "b", v: false } }
- *
- * @param {object} cockpitObject
- * @returns {object}
- */
-const removeUndefinedCockpitProperties = (cockpitObject) => {
-  const filtered = Object.entries(cockpitObject).filter(([, { v }]) => v !== undefined);
-  return Object.fromEntries(filtered);
-};
-
-/**
  * Gets the basename of a D-Bus path
  *
  * @example

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -354,6 +354,7 @@ class DevicesManager {
     const response = await this.client.get(`/storage/devices/${this.rootPath}`);
     if (!response.ok) {
       console.warn("Failed to get storage devices: ", response);
+      return [];
     }
     const jsonDevices = await response.json();
     return jsonDevices.map(d => buildDevice(d, jsonDevices));
@@ -392,6 +393,7 @@ class ProposalManager {
     const response = await this.client.get("/storage/proposal/usable_devices");
     if (!response.ok) {
       console.warn("Failed to get usable devices: ", response);
+      return [];
     }
     const usable_devices = await response.json();
     return usable_devices.map(name => findDevice(systemDevices, name)).filter(d => d);
@@ -440,6 +442,7 @@ class ProposalManager {
     const response = await this.client.get("/storage/product/params");
     if (!response.ok) {
       console.warn("Failed to get product params: ", response);
+      return [];
     }
 
     return response.json().then(params => params.mountPoints);
@@ -454,6 +457,7 @@ class ProposalManager {
     const response = await this.client.get("/storage/product/params");
     if (!response.ok) {
       console.warn("Failed to get product params: ", response);
+      return [];
     }
 
     return response.json().then(params => params.encryptionMethods);
@@ -463,13 +467,14 @@ class ProposalManager {
    * Obtains the default volume for the given mount path
    *
    * @param {string} mountPath
-   * @returns {Promise<Volume>}
+   * @returns {Promise<Volume|undefined>}
    */
   async defaultVolume(mountPath) {
     const param = encodeURIComponent(mountPath);
     const response = await this.client.get(`/storage/product/volume_for?mount_path=${param}`);
     if (!response.ok) {
       console.warn("Failed to get product volume: ", response);
+      return undefined;
     }
 
     const systemDevices = await this.system.getDevices();
@@ -1295,7 +1300,7 @@ class ISCSIManager {
   /**
    * Gets the iSCSI initiator
    *
-   * @return {Promise<ISCSIInitiator>}
+   * @return {Promise<ISCSIInitiator|undefined>}
    *
    * @typedef {object} ISCSIInitiator
    * @property {string} name
@@ -1305,6 +1310,7 @@ class ISCSIManager {
     const response = await this.client.get("/storage/iscsi/initiator");
     if (!response.ok) {
       console.error("Failed to get the iSCSI initiator", response);
+      return undefined;
     }
 
     return response.json();
@@ -1338,6 +1344,7 @@ class ISCSIManager {
     const response = await this.client.get("/storage/iscsi/nodes");
     if (!response.ok) {
       console.error("Failed to get the list of iSCSI nodes", response);
+      return [];
     }
 
     return response.json();
@@ -1555,6 +1562,7 @@ class StorageBaseClient {
     const response = await this.client.get("/storage/devices/dirty");
     if (!response.ok) {
       console.warn("Failed to get storage devices dirty: ", response);
+      return false;
     }
     return response.json();
   }

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -26,12 +26,11 @@ import { compact, hex, uniq } from "~/utils";
 import { WithIssues, WithProgress, WithStatus } from "./mixins";
 import { HTTPClient } from "./http";
 
+const SERVICE_NAME = "org.opensuse.Agama.Storage1";
 const STORAGE_OBJECT = "/org/opensuse/Agama/Storage1";
 const STORAGE_JOBS_NAMESPACE = "/org/opensuse/Agama/Storage1/jobs";
 const STORAGE_JOB_IFACE = "org.opensuse.Agama.Storage1.Job";
-const ISCSI_INITIATOR_IFACE = "org.opensuse.Agama.Storage1.ISCSI.Initiator";
 const ISCSI_NODES_NAMESPACE = "/storage/iscsi/nodes";
-const ISCSI_NODE_IFACE = "org.opensuse.Agama.Storage1.ISCSI.Node";
 const DASD_MANAGER_IFACE = "org.opensuse.Agama.Storage1.DASD.Manager";
 const DASD_DEVICES_NAMESPACE = "/org/opensuse/Agama/Storage1/dasds";
 const DASD_DEVICE_IFACE = "org.opensuse.Agama.Storage1.DASD.Device";
@@ -1589,8 +1588,8 @@ class StorageBaseClient {
  */
 class StorageClient extends WithIssues(
   WithProgress(
-    WithStatus(StorageBaseClient, "/storage/status", STORAGE_OBJECT), "/storage/progress", STORAGE_OBJECT
-  ), "/storage/issues", STORAGE_OBJECT
+    WithStatus(StorageBaseClient, "/storage/status", SERVICE_NAME), "/storage/progress", SERVICE_NAME
+  ), "/storage/issues", SERVICE_NAME
 ) { }
 
 export { StorageClient, EncryptionMethods };

--- a/web/src/components/core/IssuesDialog.jsx
+++ b/web/src/components/core/IssuesDialog.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2023] SUSE LLC
+ * Copyright (c) [2023-2024] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -35,13 +35,11 @@ import { _ } from "~/i18n";
  * @param {import ("~/client/mixins").Issue} props.issue
  */
 const IssueItem = ({ issue }) => {
-  const hasDetails = issue.details.length > 0;
-
   return (
     <li>
       {issue.description}
       <If
-        condition={hasDetails}
+        condition={issue.details}
         then={<pre>{issue.details}</pre>}
       />
     </li>

--- a/web/src/components/core/IssuesDialog.test.jsx
+++ b/web/src/components/core/IssuesDialog.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2023] SUSE LLC
+ * Copyright (c) [2023-2024] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -38,7 +38,7 @@ const issues = {
   product: [],
   storage: [
     { description: "storage issue 1", details: "Details 1", source: "system", severity: "warn" },
-    { description: "storage issue 2", details: "Details 2", source: "config", severity: "error" }
+    { description: "storage issue 2", details: null, source: "config", severity: "error" }
   ],
   software: [
     { description: "software issue 1", details: "Details 1", source: "system", severity: "warn" }
@@ -62,6 +62,7 @@ it("loads the issues", async () => {
   installerRender(<IssuesDialog isOpen sectionId="storage" title="Storage issues" />);
 
   await screen.findByText(/storage issue 1/);
+  await screen.findByText(/storage issue 2/);
 });
 
 it('calls onClose callback when close button is clicked', async () => {


### PR DESCRIPTION
## Problem

The UI is broken in a diskless system. It started failing after migrating storage to the new architecture (see https://github.com/openSUSE/agama/pull/1175).

## Solution

Return correct default values if a HTTP call fails, fix the issues dialog and fix storage events.

## Testing

* Added new unit tests
* Tested manually

## Screenshots

<details>
<summary>Toggle</summary>

![localhost_8080_](https://github.com/openSUSE/agama/assets/1112304/6d671cd3-9d12-481f-b27d-8ab4afe63e3f)

![localhost_8080_ (1)](https://github.com/openSUSE/agama/assets/1112304/58a3f0b3-3425-4657-aa0b-7a7c938fef40)

![localhost_8080_ (2)](https://github.com/openSUSE/agama/assets/1112304/3d0d9831-c345-462d-86d3-87f2b7a7fd6c)

</details>
