### PR TITLE
Fix PATCH/DELETE calls

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 14 11:17:45 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix DELETE and PATCH calls in the HTTPClient
+  (gh#openSUSE/agama#1204).
+
+-------------------------------------------------------------------
 Mon May 13 09:01:29 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Adapt the iSCSI UI to use the new HTTP API instead of D-Bus

--- a/web/src/client/http.js
+++ b/web/src/client/http.js
@@ -145,7 +145,7 @@ class HTTPClient {
    * @return {Promise<Response>} Server response.
    */
   async delete(url) {
-    const response = await fetch(`${this.baseUrl}/${url}`, {
+    const response = await fetch(`${this.baseUrl}${url}`, {
       method: "DELETE",
     });
 
@@ -158,7 +158,7 @@ class HTTPClient {
    * @return {Promise<Response>} Server response.
    */
   async patch(url, data) {
-    const response = await fetch(`${this.baseUrl}/${url}`, {
+    const response = await fetch(`${this.baseUrl}${url}`, {
       method: "PATCH",
       body: JSON.stringify(data),
       headers: {

--- a/web/src/client/users.js
+++ b/web/src/client/users.js
@@ -115,7 +115,7 @@ class UsersBaseClient {
    * @return {Promise<boolean>} whether the operation was successful or not
    */
   async setRootPassword(password) {
-    const response = await this.client.patch("/users/root", { password, password_encrypted: false });
+    const response = await this.client.patch("/users/root", { password, passwordEncrypted: false });
     return response.ok;
   }
 

--- a/web/src/client/users.test.js
+++ b/web/src/client/users.test.js
@@ -169,7 +169,7 @@ describe("#setRootPassword", () => {
     const result = await client.setRootPassword("12345");
     expect(mockPatchFn).toHaveBeenCalledWith("/users/root", {
       password: "12345",
-      password_encrypted: false,
+      passwordEncrypted: false,
     });
     expect(result).toEqual(true);
   });
@@ -183,7 +183,7 @@ describe("#setRootPassword", () => {
       const result = await client.setRootPassword("12345");
       expect(mockPatchFn).toHaveBeenCalledWith("/users/root", {
         password: "12345",
-        password_encrypted: false,
+        passwordEncrypted: false,
       });
       expect(result).toEqual(false);
     });
@@ -199,7 +199,7 @@ describe("#removeRootPassword", () => {
     const result = await client.removeRootPassword();
     expect(mockPatchFn).toHaveBeenCalledWith("/users/root", {
       password: "",
-      password_encrypted: false,
+      passwordEncrypted: false,
     });
     expect(result).toEqual(true);
   });
@@ -213,7 +213,7 @@ describe("#removeRootPassword", () => {
       const result = await client.removeRootPassword();
       expect(mockPatchFn).toHaveBeenCalledWith("/users/root", {
         password: "",
-        password_encrypted: false,
+        passwordEncrypted: false,
       });
       expect(result).toEqual(false);
     });


### PR DESCRIPTION
Performing DELETE/PATCH calls were not working correctly because the URL was wrong. It does not happen in development if you are using the proxy.