### PR TITLE
Read the list of locales from /etc/agama.d

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 14 12:39:49 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- If present, read the locales list from the /etc/agama.d/locales
+  file (gh#openSUSE/agama#1205).
+
+-------------------------------------------------------------------
 Tue May 14 10:48:42 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
 - Dropped the network D-Bus service as it is not needed anymore


### PR DESCRIPTION
To reduce the size of the live image as much as possible, we remove the [locales data](https://github.com/openSUSE/agama/blob/master/live/src/config.sh#L61-L69). The only exceptions are those locales that contain Agama translations. As a consequence, Agama cannot find the list of locales.

After some discussion, we agreed to read a static list (in `/etc/agama.d/locales`). If the list is not there, it keeps running `localectl list-units`.