### PR TITLE
Use the default Web sockets implementation for HMR

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -108,11 +108,6 @@ module.exports = {
         secure: false,
       }
     ],
-    server: "http",
-    // hot replacement does not support wss:// transport when running over https://,
-    // as a workaround use sockjs (which uses standard https:// protocol)
-    webSocketServer: "sockjs",
-
     // special handling for the "po.js" requests specially
     setupMiddlewares: (middlewares, devServer) => {
       devServer.app.get("/po.js", po_handler);


### PR DESCRIPTION
## Changes

- Use the default web sockets implementation for the hot reload / hot module replacement when running the Webpack development server
- Removed `server: "http"` option, that's the default, this setting is not need anymore (it was needed for using `https` with Cockpit)

## Details

Cockpit requires web socket with SSL when talking to the server and that required to run the Webpack server with SSL as well. But in that case hot reload did not work because it also uses a web socket but it does not support SSL.

As a workaround the hot reload was switched to the `sockjs` implementation which emulates web sockets using plain http/https connection. Using web sockets for hot reload is more used and tested (it's the default) so I guess it could be more reliable than that sockjs emulation. So this might (or might not...) fix some problems with hot reload getting stuck in some cases.
