### PR TITLE
Do not crash if the file-based locales database is empty

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 15 14:08:26 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash if the /etc/agama.d/locales file does not contain
+  any valid locale (gh#openSUSE/agama#1213).
+
+-------------------------------------------------------------------
 Tue May 14 12:39:49 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - If present, read the locales list from the /etc/agama.d/locales


### PR DESCRIPTION
Improve #1205 so that it does not crash if there are no valid locales in the `/etc/agama.d/locales` file.