### PR TITLE
Fixed endless loop in hot module reloading

### DIFF
--- a/web/src/components/storage/DASDPage.jsx
+++ b/web/src/components/storage/DASDPage.jsx
@@ -23,7 +23,8 @@ import React, { useEffect, useReducer } from "react";
 
 import { _ } from "~/i18n";
 import { If, Page } from "~/components/core";
-import { DASDFormatProgress, DASDTable } from "~/components/storage";
+import DASDFormatProgress from "~/components/storage/DASDFormatProgress";
+import DASDTable from "~/components/storage/DASDTable";
 import { useCancellablePromise } from "~/utils";
 import { useInstallerClient } from "~/context/installer";
 


### PR DESCRIPTION
## Problem

- Fixes endless loop when touching the `client/storage.js` file

## Details

- The hot module replacement checks the module dependencies
- I'm not 100% sure with the solution but it seems that there is a dependency cycle `storage/index.js` -> `storage/DASDPage.jsx` -> `storage/index.js`

## Solution

- Break the dependency cycle by directly loading the files, not via the `storage/index.js` module

## Testing

- Tested manually, works fine
