### PR TITLE
Improve logging in the Rust part

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "hyper 1.2.0",
  "hyper-util",
  "jsonwebtoken",
+ "libsystemd",
  "log",
  "macaddr",
  "once_cell",
@@ -123,8 +124,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
- "simplelog",
- "systemd-journal-logger",
  "thiserror",
  "tokio",
  "tokio-openssl",
@@ -1925,14 +1924,14 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libsystemd"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b9597a67aa1c81a6624603e6bd0bcefb9e0f94c9c54970ec53771082104b4e"
+checksum = "c592dc396b464005f78a5853555b9f240bc5378bf5221acc4e129910b2678869"
 dependencies = [
  "hmac",
  "libc",
  "log",
- "nix 0.26.4",
+ "nix 0.27.1",
  "nom",
  "once_cell",
  "serde",
@@ -1999,9 +1998,6 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "macaddr"
@@ -2132,6 +2128,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
  "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -2248,15 +2245,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
  "libc",
 ]
 
@@ -3231,17 +3219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simplelog"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
-dependencies = [
- "log",
- "termcolor",
- "time",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3362,16 +3339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "systemd-journal-logger"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356b5cb52ce54916cbfaee19b07d305c7ea8ce5435a088c58743d4a0211f3eff"
-dependencies = [
- "libsystemd",
- "log",
-]
-
-[[package]]
 name = "temp-dir"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,15 +3354,6 @@ dependencies = [
  "fastrand 2.0.1",
  "rustix 0.38.32",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -3446,9 +3404,7 @@ checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -3943,12 +3899,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "value-bag"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4072,15 +4022,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -11,8 +11,6 @@ anyhow = "1.0"
 agama-locale-data = { path = "../agama-locale-data" }
 agama-lib = { path = "../agama-lib" }
 log = "0.4"
-simplelog = "0.12.1"
-systemd-journal-logger = "1.0"
 zbus = { version = "3", default-features = false, features = ["tokio"] }
 zbus_macros = "3"
 uuid = { version = "1.3.4", features = ["v4"] }
@@ -53,7 +51,10 @@ openssl = "0.10.64"
 hyper = "1.2.0"
 hyper-util = "0.1.3"
 tokio-openssl = "0.6.4"
-futures-util = { version = "0.3.30", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3.30", default-features = false, features = [
+  "alloc",
+] }
+libsystemd = "0.7.0"
 
 [[bin]]
 name = "agama-dbus-server"

--- a/rust/agama-server/src/agama-dbus-server.rs
+++ b/rust/agama-server/src/agama-dbus-server.rs
@@ -1,6 +1,6 @@
 use agama_server::{
     l10n::{self, helpers},
-    logs::start_logging,
+    logs::init_logging,
     questions,
 };
 
@@ -14,7 +14,7 @@ const SERVICE_NAME: &str = "org.opensuse.Agama1";
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let locale = helpers::init_locale()?;
-    start_logging().context("Could not initialize the logger")?;
+    init_logging().context("Could not initialize the logger")?;
 
     let connection = connection_to(ADDRESS)
         .await

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -10,6 +10,7 @@ use std::{
 use agama_lib::connection_to;
 use agama_server::{
     l10n::helpers,
+    logs::start_logging,
     web::{self, generate_token, run_monitor},
 };
 use anyhow::Context;
@@ -292,6 +293,7 @@ async fn start_server(address: String, service: Router, ssl_acceptor: SslAccepto
 /// Start serving the API.
 /// `options`: command-line arguments.
 async fn serve_command(args: ServeArgs) -> anyhow::Result<()> {
+    start_logging().context("Could not initialize the logger")?;
     let journald = tracing_journald::layer().context("could not connect to journald")?;
     tracing_subscriber::registry().with(journald).init();
 

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -10,7 +10,7 @@ use std::{
 use agama_lib::connection_to;
 use agama_server::{
     l10n::helpers,
-    logs::start_logging,
+    logs::init_logging,
     web::{self, generate_token, run_monitor},
 };
 use anyhow::Context;
@@ -292,7 +292,7 @@ async fn start_server(address: String, service: Router, ssl_acceptor: SslAccepto
 /// Start serving the API.
 /// `options`: command-line arguments.
 async fn serve_command(args: ServeArgs) -> anyhow::Result<()> {
-    start_logging().context("Could not initialize the logger")?;
+    init_logging().context("Could not initialize the logger")?;
 
     let (tx, _) = channel(16);
     run_monitor(tx.clone()).await?;

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -28,7 +28,6 @@ use openssl::ssl::{Ssl, SslAcceptor, SslFiletype, SslMethod};
 use tokio::sync::broadcast::channel;
 use tokio_openssl::SslStream;
 use tower::Service;
-use tracing_subscriber::prelude::*;
 use utoipa::OpenApi;
 
 const DEFAULT_WEB_UI_DIR: &str = "/usr/share/agama/web_ui";
@@ -294,8 +293,6 @@ async fn start_server(address: String, service: Router, ssl_acceptor: SslAccepto
 /// `options`: command-line arguments.
 async fn serve_command(args: ServeArgs) -> anyhow::Result<()> {
     start_logging().context("Could not initialize the logger")?;
-    let journald = tracing_journald::layer().context("could not connect to journald")?;
-    tracing_subscriber::registry().with(journald).init();
 
     let (tx, _) = channel(16);
     run_monitor(tx.clone()).await?;

--- a/rust/agama-server/src/lib.rs
+++ b/rust/agama-server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cert;
 pub mod dbus;
 pub mod error;
 pub mod l10n;
+pub mod logs;
 pub mod manager;
 pub mod network;
 pub mod questions;

--- a/rust/agama-server/src/logs.rs
+++ b/rust/agama-server/src/logs.rs
@@ -1,17 +1,18 @@
-use log::{self, LevelFilter, SetLoggerError};
+//! Functions to work with logs.
 
-pub fn start_logging() -> Result<(), SetLoggerError> {
-    if systemd_journal_logger::connected_to_journal() {
-        // unwrap here is intentional as we are sure no other logger is active yet
-        systemd_journal_logger::JournalLog::default().install()?;
-        log::set_max_level(LevelFilter::Info); // log only info for journal logger
+use anyhow::Context;
+use libsystemd::logging;
+use tracing_subscriber::prelude::*;
+
+/// Initializes the logging mechanism.
+///
+/// It is based on [Tracing](https://github.com/tokio-rs/tracing), part of the Tokio ecosystem.
+pub fn start_logging() -> anyhow::Result<()> {
+    if logging::connected_to_journal() {
+        let journald = tracing_journald::layer().context("could not connect to journald")?;
+        tracing_subscriber::registry().with(journald).init();
     } else {
-        simplelog::TermLogger::init(
-            LevelFilter::Info, // lets use info, trace provides too much output from libraries
-            simplelog::Config::default(),
-            simplelog::TerminalMode::Stderr, // only stderr output for easier filtering
-            simplelog::ColorChoice::Auto,
-        )?;
+        tracing_subscriber::fmt::init();
     }
     Ok(())
 }

--- a/rust/agama-server/src/logs.rs
+++ b/rust/agama-server/src/logs.rs
@@ -12,7 +12,12 @@ pub fn start_logging() -> anyhow::Result<()> {
         let journald = tracing_journald::layer().context("could not connect to journald")?;
         tracing_subscriber::registry().with(journald).init();
     } else {
-        tracing_subscriber::fmt::init();
+        let subscriber = tracing_subscriber::fmt()
+            .with_file(true)
+            .with_line_number(true)
+            .compact()
+            .finish();
+        tracing::subscriber::set_global_default(subscriber)?;
     }
     Ok(())
 }

--- a/rust/agama-server/src/logs.rs
+++ b/rust/agama-server/src/logs.rs
@@ -1,0 +1,17 @@
+use log::{self, LevelFilter, SetLoggerError};
+
+pub fn start_logging() -> Result<(), SetLoggerError> {
+    if systemd_journal_logger::connected_to_journal() {
+        // unwrap here is intentional as we are sure no other logger is active yet
+        systemd_journal_logger::JournalLog::default().install()?;
+        log::set_max_level(LevelFilter::Info); // log only info for journal logger
+    } else {
+        simplelog::TermLogger::init(
+            LevelFilter::Info, // lets use info, trace provides too much output from libraries
+            simplelog::Config::default(),
+            simplelog::TerminalMode::Stderr, // only stderr output for easier filtering
+            simplelog::ColorChoice::Auto,
+        )?;
+    }
+    Ok(())
+}

--- a/rust/agama-server/src/logs.rs
+++ b/rust/agama-server/src/logs.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::prelude::*;
 /// Initializes the logging mechanism.
 ///
 /// It is based on [Tracing](https://github.com/tokio-rs/tracing), part of the Tokio ecosystem.
-pub fn start_logging() -> anyhow::Result<()> {
+pub fn init_logging() -> anyhow::Result<()> {
     if logging::connected_to_journal() {
         let journald = tracing_journald::layer().context("could not connect to journald")?;
         tracing_subscriber::registry().with(journald).init();


### PR DESCRIPTION
* `agama-web-server` writes now to the stdout if it is not connected to journald.
* `agama-dbus-server` uses [tracing](https://github.com/tokio-rs/tracing).
* The stdout logger now includes the file/line. They were already included in the journal logs.

```
2024-05-15T15:30:42.816878Z  WARN agama_server::network::nm::client: agama-server/src/network/nm/client.rs:155: Ignoring network device on path /org/freedesktop/NetworkManager/Devices/1
2024-05-15T15:30:42.845629Z  INFO agama_server::web::service: agama-server/src/web/service.rs:91: Serving static files from /usr/share/agama/web_ui
2024-05-15T15:30:42.901972Z  INFO agama_web_server: agama-server/src/agama-web-server.rs:253: Starting Agama web server at 0.0.0.0:443
2024-05-15T15:30:42.901993Z  INFO agama_web_server: agama-server/src/agama-web-server.rs:253: Starting Agama web server at 0.0.0.0:80
```
