### PR TITLE
Emulate "localectl list-locales" in Live ISO build

### DIFF
--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -68,7 +68,9 @@ du -h -s /usr/{share,lib}/locale/
 # Agama then reads this file instead of running the "localectl list-locales"
 # command.
 mkdir -p /etc/agama.d
-localectl list-locales > /etc/agama.d/locales
+# emulate "localectl list-locales" call, it cannot be used here because it
+# insists on running systemd as PID 1 :-/
+ls -1 -d /usr/lib/locale/*.utf8 | sed -e "s#/usr/lib/locale/##" -e "s#utf8#UTF-8#" > /etc/agama.d/locales
 
 # delete translations and unusupported languages (makes ISO about 22MiB smaller)
 # build list of ignore options for "ls" with supported languages like "-I cs* -I de* -I es* ..."


### PR DESCRIPTION
## Problem

- The generated `/etc/agama.d/locales` file in Live ISO is empty
- The build log contains "System has not been booted with systemd as init system (PID 1). Can't operate." error message

## Solution

- Unfortunately `localectl` insists on running systemd as PID 1 so it cannot be used here :worried: 
- But it does a pretty trivial thing so I have re-implemented that in shell

## Testing

- Tested manually, I'm getting the same output as running `localectl list-locales` in my system
