### PR TITLE
Do not fail when the storage proposal is missing

### DIFF
--- a/rust/agama-lib/src/storage/client.rs
+++ b/rust/agama-lib/src/storage/client.rs
@@ -133,7 +133,7 @@ impl<'a> StorageClient<'a> {
     /// DEPRECATED, use proposal_settings instead
     pub async fn lvm(&self) -> Result<Option<bool>, ServiceError> {
         let settings = self.proposal_settings().await?;
-        Ok(Some(matches!(settings.target, ProposalTarget::Disk)))
+        Ok(Some(!matches!(settings.target, ProposalTarget::Disk)))
     }
 
     /// Returns the encryption password proposal setting

--- a/rust/agama-lib/src/storage/store.rs
+++ b/rust/agama-lib/src/storage/store.rs
@@ -17,7 +17,11 @@ impl<'a> StorageStore<'a> {
     }
 
     pub async fn load(&self) -> Result<StorageSettings, ServiceError> {
-        let boot_device = self.storage_client.boot_device().await?;
+        // If it is not possible to get the settings (e.g., there are no settings yet), return
+        // the default.
+        let Ok(boot_device) = self.storage_client.boot_device().await else {
+            return Ok(StorageSettings::default());
+        };
         let lvm = self.storage_client.lvm().await?;
         let encryption_password = self.storage_client.encryption_password().await?;
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 16 10:31:38 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- The CLI does not fail when the storage proposal is missing
+  (gh#openSUSE/agama#1220).
+- Properly detect whether LVM is activated.
+
+-------------------------------------------------------------------
 Thu May 16 06:19:36 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Change the web server to listen on port 80 by default


### PR DESCRIPTION
* The CLI does not fails when there is not storage proposal.
* Properly detect when LVM is activated (from the CLI).