### PR TITLE
Tumbleweed configuration: more sensible min for generic volumes

### DIFF
--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -191,6 +191,7 @@ storage:
     - filesystem: xfs
       size:
         auto: false
+        min: 1 GiB
       outline:
         required: false
         filesystems:


### PR DESCRIPTION
The min size for the generic volume (the one without mount point) is only relevant to populate the initial value at the UI form when the user clicks on "Add file system -> Other".

![zero](https://github.com/openSUSE/agama/assets/3638289/5bf66ccb-8767-414f-a3d7-ce98f01cbb14)

Zero is a weird value for that because is not even a valid min. All the other minimums in the product (/, /home, swap...) are in the scale of Gigabytes. So 1GiB looks more sensible as starting point for the user to adjust it.

![onegib](https://github.com/openSUSE/agama/assets/3638289/3a1dc44b-24dc-47f8-8afa-0871ee37ff5e)