### PR TITLE
Install missing "find" for submitting agama-live

### DIFF
--- a/.github/workflows/obs-staging-live.yml
+++ b/.github/workflows/obs-staging-live.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install tools
         run: zypper --non-interactive install --no-recommends
-             git make osc
+             findutils git make osc
 
       - name: Git Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

- the Live ISO does not build
- The archives are not correctly created in CI because of missing `find`

## Solution

- Install missing `find`