### PR TITLE
ci: disable npm typedoc:component

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -52,7 +52,7 @@ jobs:
         run: cd web && npm ci
 
       - name: Build Web UI documentation
-        run: cd web && npm run typedoc && mv typedoc.out/ ../doc/dist/web-ui
+        run: cd web && npm run typedoc:client && mv typedoc.out/ ../doc/dist/web-ui
 
       - name: Setup Pages
         uses: actions/configure-pages@v3


### PR DESCRIPTION
Generating the documentation for the React components does not work.

```
TypeDoc exiting with unexpected error:
TypeError: Cannot read properties of undefined (reading 'kindOf')
    at /home/runner/work/agama/agama/web/node_modules/typedoc/dist/lib/models/types.js:687:63
    at Array.find (<anonymous>)
    at get reflection [as reflection] (/home/runner/work/agama/agama/web/node_modules/typedoc/dist/lib/models/types.js:687:43)
    at _classThis.resolveLinks (/home/runner/work/agama/agama/web/node_modules/typedoc/dist/lib/converter/plugins/LinkResolverPlugin.js:117:27)
    at _classThis.onResolve (/home/runner/work/agama/agama/web/node_modules/typedoc/dist/lib/converter/plugins/LinkResolverPlugin.js:81:18)
    at triggerEvents (/home/runner/work/agama/agama/web/node_modules/typedoc/dist/lib/utils/events.js:192:43)
    at triggerApi (/home/runner/work/agama/agama/web/node_modules/typedoc/dist/lib/utils/events.js:168:13)
    at eventsApi (/home/runner/work/agama/agama/web/node_modules/typedoc/dist/lib/utils/events.js:61:18)
    at _classThis.trigger (/home/runner/work/agama/agama/web/node_modules/typedoc/dist/lib/utils/events.js:390:13)
    at _classThis.resolve (/home/runner/work/agama/agama/web/node_modules/typedoc/dist/lib/converter/converter.js:354:18)
Try turning off --skipErrorChecking. If TypeDoc still crashes, please report a bug.
Error: Process completed with exit code 6.
```

It seems caused by lines like [this](https://github.com/openSUSE/agama/blame/master/web/src/components/core/TreeTable.jsx#L54). The type is OK, so it might be a typedoc bug.

Anyway, as we are in the middle of a UI rewrite, we will disable the generation of the components documentation by now (but we will keep generating the documentation for the clients).