### PR TITLE
fix: Avoid implicit storage probing

### DIFF
--- a/service/lib/agama/storage/proposal.rb
+++ b/service/lib/agama/storage/proposal.rb
@@ -66,7 +66,7 @@ module Agama
       #
       # @return [Array<Y2Storage::Device>]
       def available_devices
-        disk_analyzer.candidate_disks
+        disk_analyzer&.candidate_disks || []
       end
 
       # Calculates a new proposal.
@@ -74,6 +74,8 @@ module Agama
       # @param settings [Agamal::Storage::ProposalSettings] settings to calculate the proposal.
       # @return [Boolean] whether the proposal was correctly calculated.
       def calculate(settings)
+        return false unless storage_manager.probed?
+
         select_target_device(settings) if missing_target_device?(settings)
 
         calculate_proposal(settings)
@@ -170,15 +172,19 @@ module Agama
         storage_manager.proposal = proposal
       end
 
-      # @return [Y2Storage::DiskAnalyzer]
+      # @return [Y2Storage::DiskAnalyzer, nil]
       def disk_analyzer
+        return nil unless storage_manager.probed?
+
         storage_manager.probed_disk_analyzer
       end
 
       # Devicegraph representing the system
       #
-      # @return [Y2Storage::Devicegraph]
+      # @return [Y2Storage::Devicegraph, nil]
       def probed_devicegraph
+        return nil unless storage_manager.probed?
+
         storage_manager.probed
       end
 

--- a/service/lib/agama/storage/proposal.rb
+++ b/service/lib/agama/storage/proposal.rb
@@ -172,7 +172,7 @@ module Agama
         storage_manager.proposal = proposal
       end
 
-      # @return [Y2Storage::DiskAnalyzer, nil]
+      # @return [Y2Storage::DiskAnalyzer, nil] nil if the system is not probed yet.
       def disk_analyzer
         return nil unless storage_manager.probed?
 
@@ -181,7 +181,7 @@ module Agama
 
       # Devicegraph representing the system
       #
-      # @return [Y2Storage::Devicegraph, nil]
+      # @return [Y2Storage::Devicegraph, nil] nil if the system is not probed yet.
       def probed_devicegraph
         return nil unless storage_manager.probed?
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu May 16 15:36:16 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Do not probe devices implictly (gh#openSUSE/agama#1226).
+
+-------------------------------------------------------------------
 Wed May 15 12:52:42 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Export the device name of the Multipath wires and RAID devices

--- a/service/test/agama/storage/proposal_test.rb
+++ b/service/test/agama/storage/proposal_test.rb
@@ -155,6 +155,34 @@ describe Agama::Storage::Proposal do
         end
       end
     end
+
+    context "if the system has not been probed yet" do
+      before do
+        allow(Y2Storage::StorageManager.instance).to receive(:probed?).and_return(false)
+      end
+
+      it "does not calculate a proposal" do
+        subject.calculate(achievable_settings)
+        expect(Y2Storage::StorageManager.instance.proposal).to be_nil
+      end
+
+      it "does not run the callbacks" do
+        callback1 = proc {}
+        callback2 = proc {}
+
+        subject.on_calculate(&callback1)
+        subject.on_calculate(&callback2)
+
+        expect(callback1).to_not receive(:call)
+        expect(callback2).to_not receive(:call)
+
+        subject.calculate(achievable_settings)
+      end
+
+      it "returns false" do
+        expect(subject.calculate(achievable_settings)).to eq(false)
+      end
+    end
   end
 
   describe "#settings" do


### PR DESCRIPTION
## Problem

Storage devices were implictly probed. As side effect, the UI logs some errors when it asks for the available devices for first time.

Trace:

* The *Storage* service starts and exports the D-Bus object _/org/opensuse/Agama/Storage1_.
* The method `#available_devices` is called in order to populate the corresponding D-Bus property.
* The system is automatically probed as side effect of calling to `Y2Storage::DiskAnalizer`.
* The SIDs of the reported available devices will not exist anymore once the storage probing is explicitly requested by the *Manager* service. 

## Solution

Avoid implicit probing.
