### PR TITLE
Fix download logs button

### DIFF
--- a/web/src/client/manager.js
+++ b/web/src/client/manager.js
@@ -86,6 +86,10 @@ class ManagerBaseClient {
    */
   async fetchLogs() {
     const response = await fetch(`${this.client.baseUrl}/manager/logs`);
+    if (!response.ok) {
+      throw new Error("Could not fetch the logs");
+    }
+
     return response;
   }
 

--- a/web/src/components/core/LogsButton.jsx
+++ b/web/src/components/core/LogsButton.jsx
@@ -77,18 +77,12 @@ const LogsButton = ({ ...props }) => {
     setError(null);
     setIsCollecting(true);
     cancellablePromise(
-      client.manager.fetchLogs().then((response) => {
-        if (!response.ok) {
-          setError(true);
-        }
-        response.blob().then((blob) => {
-          const url = URL.createObjectURL(blob);
-          autoDownload(url);
-        });
-      }),
+      client.manager.fetchLogs().then((response) => response.blob()),
     )
-      .catch((e) => {
-        console.error(e);
+      .then(URL.createObjectURL)
+      .then(autoDownload)
+      .catch((error) => {
+        console.error(error);
         setError(true);
       })
       .finally(() => setIsCollecting(false));

--- a/web/src/components/core/LogsButton.jsx
+++ b/web/src/components/core/LogsButton.jsx
@@ -77,11 +77,20 @@ const LogsButton = ({ ...props }) => {
     setError(null);
     setIsCollecting(true);
     cancellablePromise(
-      client.manager.fetchLogs().then((response) => response.blob()),
+      client.manager.fetchLogs().then((response) => {
+        if (!response.ok) {
+          setError(true);
+        }
+        response.blob().then((blob) => {
+          const url = URL.createObjectURL(blob);
+          autoDownload(url);
+        });
+      }),
     )
-      .then(URL.createObjectURL)
-      .then(autoDownload)
-      .catch(setError)
+      .catch((e) => {
+        console.error(e);
+        setError(true);
+      })
       .finally(() => setIsCollecting(false));
   };
 

--- a/web/src/components/core/LogsButton.jsx
+++ b/web/src/components/core/LogsButton.jsx
@@ -76,7 +76,10 @@ const LogsButton = ({ ...props }) => {
   const collectAndDownload = () => {
     setError(null);
     setIsCollecting(true);
-    cancellablePromise(client.manager.fetchLogs().then(response => URL.createObjectURL(response.blob())))
+    cancellablePromise(
+      client.manager.fetchLogs().then((response) => response.blob()),
+    )
+      .then(URL.createObjectURL)
       .then(autoDownload)
       .catch(setError)
       .finally(() => setIsCollecting(false));


### PR DESCRIPTION
## Problem

The button to download logs does not work. There are two problems:

* `response.blob()` is an asynchronous function, so `createObjectURL` receives a promise instead of a Blob.
* Fetch returns a successful promise even if the response is not OK. So the `catch` call does not handle that kind of problem. And, what is worse, it is hiding the real issue.

## Solution

Wait for `response.blob()` before using its result and log errors in `catch`.