### PR TITLE
Minor improvements to HTTPS handling in Agama's web server

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
  "clap",
  "config",
  "futures-util",
+ "gethostname",
  "gettext-rs",
  "http-body-util",
  "hyper 1.2.0",
@@ -1382,6 +1383,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -56,6 +56,7 @@ futures-util = { version = "0.3.30", default-features = false, features = [
 ] }
 libsystemd = "0.7.0"
 subprocess = "0.2.9"
+gethostname = "0.4.3"
 
 [[bin]]
 name = "agama-dbus-server"

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -79,23 +79,14 @@ struct ServeArgs {
     #[arg(long, default_value = None)]
     address2: Option<String>,
 
-    #[arg(
-        long,
-        default_value = "/etc/agama.d/ssl/key.pem",
-    )]
+    #[arg(long, default_value = "/etc/agama.d/ssl/key.pem")]
     key: Option<PathBuf>,
 
-    #[arg(
-        long,
-        default_value = "/etc/agama.d/ssl/cert.pem",
-    )]
+    #[arg(long, default_value = "/etc/agama.d/ssl/cert.pem")]
     cert: Option<PathBuf>,
 
     // Agama D-Bus address
-    #[arg(
-        long,
-        default_value = "unix:path=/run/agama/bus",
-    )]
+    #[arg(long, default_value = "unix:path=/run/agama/bus")]
     dbus_address: String,
 
     // Directory containing the web UI code
@@ -132,12 +123,14 @@ impl ServeArgs {
             let _ = certificate.write();
 
             Ok(certificate)
-        }
+        };
     }
 }
 
 /// Builds an SSL acceptor using a provided SSL certificate or generates a self-signed one
-fn ssl_acceptor(certificate: &agama_server::cert::Certificate) -> Result<SslAcceptor, openssl::error::ErrorStack> {
+fn ssl_acceptor(
+    certificate: &agama_server::cert::Certificate,
+) -> Result<SslAcceptor, openssl::error::ErrorStack> {
     let mut tls_builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls_server())?;
 
     tls_builder.set_private_key(&certificate.key)?;

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -129,9 +129,7 @@ impl ServeArgs {
 }
 
 /// Builds an SSL acceptor using a provided SSL certificate or generates a self-signed one
-fn ssl_acceptor(
-    certificate: &Certificate,
-) -> Result<SslAcceptor, openssl::error::ErrorStack> {
+fn ssl_acceptor(certificate: &Certificate) -> Result<SslAcceptor, openssl::error::ErrorStack> {
     let mut tls_builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls_server())?;
 
     tls_builder.set_private_key(&certificate.key)?;

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -21,7 +21,7 @@ use futures_util::pin_mut;
 use hyper::body::Incoming;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder;
-use openssl::ssl::{Ssl, SslAcceptor, SslFiletype, SslMethod};
+use openssl::ssl::{Ssl, SslAcceptor, SslMethod};
 use tokio::sync::broadcast::channel;
 use tokio_openssl::SslStream;
 use tower::Service;
@@ -91,8 +91,11 @@ struct ServeArgs {
     )]
     cert: Option<String>,
 
-    /// The D-Bus address for connecting to the Agama service
-    #[arg(long, default_value = "unix:path=/run/agama/bus")]
+    // Agama D-Bus address
+    #[arg(
+        long,
+        default_value = "unix:path=/run/agama/bus",
+    )]
     dbus_address: String,
 
     // Directory containing the web UI code
@@ -101,39 +104,49 @@ struct ServeArgs {
 }
 
 impl ServeArgs {
-    /// Builds an SSL acceptor using a provided SSL certificate or generates a self-signed one
-    fn ssl_acceptor(&self) -> Result<SslAcceptor, openssl::error::ErrorStack> {
-        let mut tls_builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls_server())?;
-
-        // use default or explicitly provided certificate if any
-        if self.cert.clone().is_some_and(|c| Path::new(&c).exists()) && self.key.clone().is_some_and(|k| Path::new(&k).exists()) {
-            if let Some(cert) = &self.cert {
-                tracing::info!("Loading PEM certificate: {}", cert);
-                tls_builder.set_certificate_file(PathBuf::from(cert), SslFiletype::PEM)?;
-            }
-
-            if let Some(key) = &self.key {
-                tracing::info!("Loading PEM key: {}", key);
-                tls_builder.set_private_key_file(PathBuf::from(key), SslFiletype::PEM)?;
-            }
-        } else {
-            tracing::info!("Creating self-signed certificate");
-
-            // create a self-signed certificate if needed and store it for later use
-            let (cert, key) = agama_server::cert::create_certificate()?;
-
-            // tries to write generated self-signed certificate. Nobody cares if it fails
-            let _ = agama_server::cert::write_certificate(cert.clone(), key.clone());
-
-            tls_builder.set_private_key(&key)?;
-            tls_builder.set_certificate(&cert)?;
-        }
-
-        // check that the key belongs to the certificate
-        tls_builder.check_private_key()?;
-
-        Ok(tls_builder.build())
+    /// Returns true of given path to certificate points to an existing file
+    fn valid_cert_path(&self) -> bool {
+        self.cert.clone().is_some_and(|c| Path::new(&c).exists())
     }
+
+    /// Returns true of given path to key points to an existing file
+    fn valid_key_path(&self) -> bool {
+        self.key.clone().is_some_and(|k| Path::new(&k).exists())
+    }
+
+    /// Takes options provided by user and loads / creates Certificate struct according to them
+    fn to_certificate(&self) -> anyhow::Result<agama_server::cert::Certificate> {
+        return if self.valid_cert_path() && self.valid_key_path() {
+            let cert = self.cert.clone().unwrap();
+            let key = self.key.clone().unwrap();
+
+            // read the provided certificate
+            agama_server::cert::Certificate::read(cert.as_path(), key.as_path())
+        } else {
+            // ask for self-signed certificate
+            let certificate = agama_server::cert::Certificate::new()?;
+
+            // write the certificate for the later use
+            // for now do not care if writing self generated certificate failed or not, in the
+            // worst case we will generate new one ... which will surely be better
+            let _ = certificate.write();
+
+            Ok(certificate)
+        }
+    }
+}
+
+/// Builds an SSL acceptor using a provided SSL certificate or generates a self-signed one
+fn ssl_acceptor(certificate: &agama_server::cert::Certificate) -> Result<SslAcceptor, openssl::error::ErrorStack> {
+    let mut tls_builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls_server())?;
+
+    tls_builder.set_private_key(&certificate.key)?;
+    tls_builder.set_certificate(&certificate.cert)?;
+
+    // check that the key belongs to the certificate
+    tls_builder.check_private_key()?;
+
+    Ok(tls_builder.build())
 }
 
 /// Checks whether the connection uses SSL or not
@@ -320,7 +333,7 @@ async fn serve_command(args: ServeArgs) -> anyhow::Result<()> {
     let service = web::service(config, tx, dbus, web_ui_dir).await?;
     // TODO: Move elsewhere? Use a singleton? (It would be nice to use the same
     // generated self-signed certificate on both ports.)
-    let ssl_acceptor = if let Ok(ssl_acceptor) = args.ssl_acceptor() {
+    let ssl_acceptor = if let Ok(ssl_acceptor) = ssl_acceptor(&args.to_certificate()?) {
         ssl_acceptor
     } else {
         return Err(anyhow::anyhow!("SSL initialization failed"));

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -83,13 +83,13 @@ struct ServeArgs {
         long,
         default_value = "/etc/agama.d/ssl/key.pem",
     )]
-    key: Option<String>,
+    key: Option<PathBuf>,
 
     #[arg(
         long,
         default_value = "/etc/agama.d/ssl/cert.pem",
     )]
-    cert: Option<String>,
+    cert: Option<PathBuf>,
 
     // Agama D-Bus address
     #[arg(

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -106,12 +106,16 @@ impl ServeArgs {
         let mut tls_builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls_server())?;
 
         // use default or explicitly provided certificate if any
-        if let (Some(cert), Some(key)) = (self.cert.clone(), self.key.clone()) {
-            tracing::info!("Loading PEM certificate: {}", cert);
-            tls_builder.set_certificate_file(PathBuf::from(cert), SslFiletype::PEM)?;
+        if self.cert.clone().is_some_and(|c| Path::new(&c).exists()) && self.key.clone().is_some_and(|k| Path::new(&k).exists()) {
+            if let Some(cert) = &self.cert {
+                tracing::info!("Loading PEM certificate: {}", cert);
+                tls_builder.set_certificate_file(PathBuf::from(cert), SslFiletype::PEM)?;
+            }
 
-            tracing::info!("Loading PEM key: {}", key);
-            tls_builder.set_private_key_file(PathBuf::from(key), SslFiletype::PEM)?;
+            if let Some(key) = &self.key {
+                tracing::info!("Loading PEM key: {}", key);
+                tls_builder.set_private_key_file(PathBuf::from(key), SslFiletype::PEM)?;
+            }
         } else {
             tracing::info!("Creating self-signed certificate");
 

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -114,7 +114,8 @@ impl ServeArgs {
             // create a self-signed certificate if needed and store it for later use
             let (cert, key) = agama_server::cert::create_certificate()?;
 
-            agama_server::cert::write_certificate(cert.clone(), key.clone());
+            // tries to write generated self-signed certificate. Nobody cares if it fails
+            let _ = agama_server::cert::write_certificate(cert.clone(), key.clone());
 
             tls_builder.set_private_key(&key)?;
             tls_builder.set_certificate(&cert)?;

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -81,12 +81,13 @@ struct ServeArgs {
 
     #[arg(
         long,
-        default_value = "/run/agama/ssl/key.pem",
+        default_value = "/etc/agama.d/ssl/key.pem",
     )]
     key: Option<String>,
+
     #[arg(
         long,
-        default_value = "/run/agama/ssl/cert.pem",
+        default_value = "/etc/agama.d/ssl/cert.pem",
     )]
     cert: Option<String>,
 

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -79,12 +79,15 @@ struct ServeArgs {
     #[arg(long, default_value = None)]
     address2: Option<String>,
 
-    /// Path to the SSL private key file in PEM format
-    #[arg(long, default_value = None)]
+    #[arg(
+        long,
+        default_value = "/run/agama/ssl/key.pem",
+    )]
     key: Option<String>,
-
-    /// Path to the SSL certificate file in PEM format
-    #[arg(long, default_value = None)]
+    #[arg(
+        long,
+        default_value = "/run/agama/ssl/cert.pem",
+    )]
     cert: Option<String>,
 
     /// The D-Bus address for connecting to the Agama service

--- a/rust/agama-server/src/cert.rs
+++ b/rust/agama-server/src/cert.rs
@@ -27,16 +27,20 @@ use openssl::x509::{X509NameBuilder, X509};
 //     pub write(...)
 // }
 
-const DEFAULT_CERT_FILE: &str = "/run/agama/cert.pem";
-const DEFAULT_KEY_FILE: &str = "/run/agama/key.pem";
+const DEFAULT_CERT_DIR: &str = "/run/agama/ssl";
 
 /// Writes the certificate and the key to the well known location
 pub fn write_certificate(cert: X509, key: PKey<Private>) -> anyhow::Result<()> {
+    // check and create default dir if needed
+    if ! Path::new(DEFAULT_CERT_DIR).is_dir() {
+        std::fs::create_dir_all(DEFAULT_CERT_DIR)?;
+    }
+
     if let Ok(bytes) = cert.to_pem() {
-        fs::write(Path::new(DEFAULT_CERT_FILE), bytes)?;
+        fs::write(Path::new(DEFAULT_CERT_DIR).join("cert.pem"), bytes)?;
     }
     if let Ok(bytes) = key.public_key_to_pem() {
-        fs::write(Path::new(DEFAULT_KEY_FILE), bytes)?;
+        fs::write(Path::new(DEFAULT_CERT_DIR).join("key.pem"), bytes)?;
     }
 
     Ok(())

--- a/rust/agama-server/src/cert.rs
+++ b/rust/agama-server/src/cert.rs
@@ -1,9 +1,11 @@
+use anyhow;
 use openssl::asn1::Asn1Time;
 use openssl::bn::{BigNum, MsbOption};
 use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, Private};
 use openssl::rsa::Rsa;
+use std::{ fs, path::Path };
 use openssl::x509::extension::{BasicConstraints, SubjectAlternativeName, SubjectKeyIdentifier};
 use openssl::x509::{X509NameBuilder, X509};
 
@@ -23,6 +25,15 @@ use openssl::x509::{X509NameBuilder, X509};
 //     // dump to file
 //     pub write(...)
 // }
+
+const DEFAULT_CERT_FILE: &str = "/run/agama/certificate.pem";
+const DEFAULT_KEY_FILE: &str = "/run/agama/key.pem";
+
+pub fn write_certificate(cert: X509, key: PKey<Private>) {
+    if let Ok(bytes) = cert.to_pem() {
+        fs::write(Path::new(DEFAULT_CERT_FILE), bytes);
+    }
+}
 
 /// Generates a self-signed SSL certificate
 /// see https://github.com/sfackler/rust-openssl/blob/master/openssl/examples/mk_certs.rs

--- a/rust/agama-server/src/cert.rs
+++ b/rust/agama-server/src/cert.rs
@@ -2,7 +2,6 @@ use anyhow;
 use gethostname::gethostname;
 use openssl::asn1::Asn1Time;
 use openssl::bn::{BigNum, MsbOption};
-use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, Private};
 use openssl::rsa::Rsa;
@@ -10,98 +9,101 @@ use std::{fs, path::Path};
 use openssl::x509::extension::{BasicConstraints, SubjectAlternativeName, SubjectKeyIdentifier};
 use openssl::x509::{X509NameBuilder, X509};
 
-// TODO: move the certificate related functions into a struct
-//
-// struct Certificate {
-//     certificate: X509,
-//     key: PKey<Private>,
-// }
-//
-// impl Certificate {
-//     // read from file, support some default location
-//     // (like /etc/agama.d/ssl/{certificate,key}.pem ?)
-//     pub read(cert: &str, key: &str) -> Result<Self>;
-//     // generate a self-signed certificate
-//     pub new() -> Self
-//     // dump to file
-//     pub write(...)
-// }
+const DEFAULT_CERT_DIR: &str = "/etc/agama.d/ssl";
 
-pub const DEFAULT_CERT_DIR: &str = "/etc/agama.d/ssl";
-
-/// Writes the certificate and the key to the well known location
-pub fn write_certificate(cert: X509, key: PKey<Private>) -> anyhow::Result<()> {
-    // check and create default dir if needed
-    if ! Path::new(DEFAULT_CERT_DIR).is_dir() {
-        std::fs::create_dir_all(DEFAULT_CERT_DIR)?;
-    }
-
-    if let Ok(bytes) = cert.to_pem() {
-        fs::write(Path::new(DEFAULT_CERT_DIR).join("cert.pem"), bytes)?;
-    }
-    if let Ok(bytes) = key.public_key_to_pem() {
-        fs::write(Path::new(DEFAULT_CERT_DIR).join("key.pem"), bytes)?;
-    }
-
-    Ok(())
+pub struct Certificate {
+    pub cert: X509,
+    pub key: PKey<Private>,
 }
 
-/// Generates a self-signed SSL certificate
-/// see https://github.com/sfackler/rust-openssl/blob/master/openssl/examples/mk_certs.rs
-pub fn create_certificate() -> Result<(X509, PKey<Private>), ErrorStack> {
-    let rsa = Rsa::generate(2048)?;
-    let key = PKey::from_rsa(rsa)?;
+impl Certificate {
+    /// Writes cert, key to (for now well known) location(s)
+    pub fn write(&self) -> anyhow::Result<()> {
+        // check and create default dir if needed
+        if ! Path::new(DEFAULT_CERT_DIR).is_dir() {
+            std::fs::create_dir_all(DEFAULT_CERT_DIR)?;
+        }
 
-    let hostname = gethostname().into_string().unwrap_or(String::from("localhost"));
-    let mut x509_name = X509NameBuilder::new()?;
-    x509_name.append_entry_by_text("O", "Agama")?;
-    x509_name.append_entry_by_text("CN", hostname.as_str())?;
-    let x509_name = x509_name.build();
+        if let Ok(bytes) = self.cert.to_pem() {
+            fs::write(Path::new(DEFAULT_CERT_DIR).join("cert.pem"), bytes)?;
+        }
+        if let Ok(bytes) = self.key.private_key_to_pem_pkcs8() {
+            fs::write(Path::new(DEFAULT_CERT_DIR).join("key.pem"), bytes)?;
+        }
 
-    let mut builder = X509::builder()?;
-    builder.set_version(2)?;
-    let serial_number = {
-        let mut serial = BigNum::new()?;
-        serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
-        serial.to_asn1_integer()?
-    };
-    builder.set_serial_number(&serial_number)?;
-    builder.set_subject_name(&x509_name)?;
-    builder.set_issuer_name(&x509_name)?;
-    builder.set_pubkey(&key)?;
+        Ok(())
+    }
 
-    let not_before = Asn1Time::days_from_now(0)?;
-    builder.set_not_before(&not_before)?;
-    let not_after = Asn1Time::days_from_now(365)?;
-    builder.set_not_after(&not_after)?;
+    /// Reads cert from given path
+    pub fn read(cert: &Path, key: &Path) -> anyhow::Result<Self> {
+        let cert_bytes = std::fs::read(cert)?;
+        let key_bytes = std::fs::read(key)?;
 
-    builder.append_extension(BasicConstraints::new().critical().ca().build()?)?;
+        let cert = X509::from_pem(&cert_bytes.as_slice());
+        let key = PKey::private_key_from_pem(&key_bytes.as_slice());
 
-    builder.append_extension(
-        SubjectAlternativeName::new()
-            // use the default Agama host name
-            // TODO: use the gethostname crate and use the current real hostname
-            .dns("agama")
-            // use the default name for the mDNS/Avahi
-            // TODO: check which name is actually used by mDNS, to avoid
-            // conflicts it might actually use something like agama-2.local
-            .dns("agama.local")
-            .build(&builder.x509v3_context(None, None))?,
-    )?;
+        if let (Ok(c),Ok(k)) = (cert, key) {
+            Ok(Certificate {
+                cert: c,
+                key: k,
+            })
+        } else {
+            Err(anyhow::anyhow!("Failed to read certificate"))
+        }
+    }
 
-    let subject_key_identifier =
-        SubjectKeyIdentifier::new().build(&builder.x509v3_context(None, None))?;
-    builder.append_extension(subject_key_identifier)?;
+    /// Creates a self-signed certificate
+    pub fn new() -> anyhow::Result<Self> {
+        let rsa = Rsa::generate(2048)?;
+        let key = PKey::from_rsa(rsa)?;
 
-    builder.sign(&key, MessageDigest::sha256())?;
-    let cert = builder.build();
+        let hostname = gethostname().into_string().unwrap_or(String::from("localhost"));
+        let mut x509_name = X509NameBuilder::new()?;
+        x509_name.append_entry_by_text("O", "Agama")?;
+        x509_name.append_entry_by_text("CN", hostname.as_str())?;
+        let x509_name = x509_name.build();
 
-    // for debugging you might dump the certificate to a file:
-    // use std::io::Write;
-    // let mut cert_file = std::fs::File::create("agama_cert.pem").unwrap();
-    // let mut key_file = std::fs::File::create("agama_key.pem").unwrap();
-    // cert_file.write_all(cert.to_pem().unwrap().as_ref()).unwrap();
-    // key_file.write_all(key.private_key_to_pem_pkcs8().unwrap().as_ref()).unwrap();
+        let mut builder = X509::builder()?;
+        builder.set_version(2)?;
+        let serial_number = {
+            let mut serial = BigNum::new()?;
+            serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
+            serial.to_asn1_integer()?
+        };
+        builder.set_serial_number(&serial_number)?;
+        builder.set_subject_name(&x509_name)?;
+        builder.set_issuer_name(&x509_name)?;
+        builder.set_pubkey(&key)?;
 
-    Ok((cert, key))
+        let not_before = Asn1Time::days_from_now(0)?;
+        builder.set_not_before(&not_before)?;
+        let not_after = Asn1Time::days_from_now(365)?;
+        builder.set_not_after(&not_after)?;
+
+        builder.append_extension(BasicConstraints::new().critical().ca().build()?)?;
+
+        builder.append_extension(
+            SubjectAlternativeName::new()
+                // use the default Agama host name
+                // TODO: use the gethostname crate and use the current real hostname
+                .dns("agama")
+                // use the default name for the mDNS/Avahi
+                // TODO: check which name is actually used by mDNS, to avoid
+                // conflicts it might actually use something like agama-2.local
+                .dns("agama.local")
+                .build(&builder.x509v3_context(None, None))?,
+        )?;
+
+        let subject_key_identifier =
+            SubjectKeyIdentifier::new().build(&builder.x509v3_context(None, None))?;
+        builder.append_extension(subject_key_identifier)?;
+
+        builder.sign(&key, MessageDigest::sha256())?;
+        let cert = builder.build();
+
+        Ok(Certificate {
+            cert: cert,
+            key: key
+        })
+    }
 }

--- a/rust/agama-server/src/cert.rs
+++ b/rust/agama-server/src/cert.rs
@@ -6,7 +6,7 @@ use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, Private};
 use openssl::rsa::Rsa;
-use std::{ fs, path::Path };
+use std::{fs, path::Path};
 use openssl::x509::extension::{BasicConstraints, SubjectAlternativeName, SubjectKeyIdentifier};
 use openssl::x509::{X509NameBuilder, X509};
 

--- a/rust/agama-server/src/cert.rs
+++ b/rust/agama-server/src/cert.rs
@@ -11,6 +11,8 @@ use std::{fs, path::Path};
 
 const DEFAULT_CERT_DIR: &str = "/etc/agama.d/ssl";
 
+/// Structure to handle and store certificate and private key which is later
+/// used for establishing HTTPS connection
 pub struct Certificate {
     pub cert: X509,
     pub key: PKey<Private>,
@@ -34,18 +36,17 @@ impl Certificate {
         Ok(())
     }
 
-    /// Reads cert from given path
-    pub fn read(cert: &Path, key: &Path) -> anyhow::Result<Self> {
+    /// Reads certificate and corresponding private key from given paths
+    pub fn read<T: AsRef<Path>>(cert: T, key: T) -> anyhow::Result<Self> {
         let cert_bytes = std::fs::read(cert)?;
         let key_bytes = std::fs::read(key)?;
 
         let cert = X509::from_pem(&cert_bytes.as_slice());
         let key = PKey::private_key_from_pem(&key_bytes.as_slice());
 
-        if let (Ok(c), Ok(k)) = (cert, key) {
-            Ok(Certificate { cert: c, key: k })
-        } else {
-            Err(anyhow::anyhow!("Failed to read certificate"))
+        match (cert, key) {
+            (Ok(c), Ok(k)) => Ok(Certificate { cert: c, key: k }),
+            _ => Err(anyhow::anyhow!("Failed to read certificate")),
         }
     }
 

--- a/rust/agama-server/src/cert.rs
+++ b/rust/agama-server/src/cert.rs
@@ -5,9 +5,9 @@ use openssl::bn::{BigNum, MsbOption};
 use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, Private};
 use openssl::rsa::Rsa;
-use std::{fs, path::Path};
 use openssl::x509::extension::{BasicConstraints, SubjectAlternativeName, SubjectKeyIdentifier};
 use openssl::x509::{X509NameBuilder, X509};
+use std::{fs, path::Path};
 
 const DEFAULT_CERT_DIR: &str = "/etc/agama.d/ssl";
 
@@ -20,7 +20,7 @@ impl Certificate {
     /// Writes cert, key to (for now well known) location(s)
     pub fn write(&self) -> anyhow::Result<()> {
         // check and create default dir if needed
-        if ! Path::new(DEFAULT_CERT_DIR).is_dir() {
+        if !Path::new(DEFAULT_CERT_DIR).is_dir() {
             std::fs::create_dir_all(DEFAULT_CERT_DIR)?;
         }
 
@@ -42,11 +42,8 @@ impl Certificate {
         let cert = X509::from_pem(&cert_bytes.as_slice());
         let key = PKey::private_key_from_pem(&key_bytes.as_slice());
 
-        if let (Ok(c),Ok(k)) = (cert, key) {
-            Ok(Certificate {
-                cert: c,
-                key: k,
-            })
+        if let (Ok(c), Ok(k)) = (cert, key) {
+            Ok(Certificate { cert: c, key: k })
         } else {
             Err(anyhow::anyhow!("Failed to read certificate"))
         }
@@ -57,7 +54,9 @@ impl Certificate {
         let rsa = Rsa::generate(2048)?;
         let key = PKey::from_rsa(rsa)?;
 
-        let hostname = gethostname().into_string().unwrap_or(String::from("localhost"));
+        let hostname = gethostname()
+            .into_string()
+            .unwrap_or(String::from("localhost"));
         let mut x509_name = X509NameBuilder::new()?;
         x509_name.append_entry_by_text("O", "Agama")?;
         x509_name.append_entry_by_text("CN", hostname.as_str())?;
@@ -103,7 +102,7 @@ impl Certificate {
 
         Ok(Certificate {
             cert: cert,
-            key: key
+            key: key,
         })
     }
 }

--- a/rust/agama-server/src/cert.rs
+++ b/rust/agama-server/src/cert.rs
@@ -30,6 +30,7 @@ use openssl::x509::{X509NameBuilder, X509};
 const DEFAULT_CERT_FILE: &str = "/run/agama/cert.pem";
 const DEFAULT_KEY_FILE: &str = "/run/agama/key.pem";
 
+/// Writes the certificate and the key to the well known location
 pub fn write_certificate(cert: X509, key: PKey<Private>) {
     if let Ok(bytes) = cert.to_pem() {
         fs::write(Path::new(DEFAULT_CERT_FILE), bytes);
@@ -45,10 +46,10 @@ pub fn create_certificate() -> Result<(X509, PKey<Private>), ErrorStack> {
     let rsa = Rsa::generate(2048)?;
     let key = PKey::from_rsa(rsa)?;
 
-    let hostname = gethostname().into_string().map_err(|e| openssl::ssl::into_io_error()?)?;
+    let hostname = gethostname().into_string().unwrap_or(String::from("localhost"));
     let mut x509_name = X509NameBuilder::new()?;
     x509_name.append_entry_by_text("O", "Agama")?;
-    x509_name.append_entry_by_text("CN", hostname)?;
+    x509_name.append_entry_by_text("CN", hostname.as_str())?;
     let x509_name = x509_name.build();
 
     let mut builder = X509::builder()?;

--- a/rust/agama-server/src/cert.rs
+++ b/rust/agama-server/src/cert.rs
@@ -27,7 +27,7 @@ use openssl::x509::{X509NameBuilder, X509};
 //     pub write(...)
 // }
 
-pub const DEFAULT_CERT_DIR: &str = "/run/agama/ssl";
+pub const DEFAULT_CERT_DIR: &str = "/etc/agama.d/ssl";
 
 /// Writes the certificate and the key to the well known location
 pub fn write_certificate(cert: X509, key: PKey<Private>) -> anyhow::Result<()> {

--- a/rust/agama-server/src/cert.rs
+++ b/rust/agama-server/src/cert.rs
@@ -27,7 +27,7 @@ use openssl::x509::{X509NameBuilder, X509};
 //     pub write(...)
 // }
 
-const DEFAULT_CERT_DIR: &str = "/run/agama/ssl";
+pub const DEFAULT_CERT_DIR: &str = "/run/agama/ssl";
 
 /// Writes the certificate and the key to the well known location
 pub fn write_certificate(cert: X509, key: PKey<Private>) -> anyhow::Result<()> {

--- a/rust/agama-server/src/cert.rs
+++ b/rust/agama-server/src/cert.rs
@@ -31,13 +31,15 @@ const DEFAULT_CERT_FILE: &str = "/run/agama/cert.pem";
 const DEFAULT_KEY_FILE: &str = "/run/agama/key.pem";
 
 /// Writes the certificate and the key to the well known location
-pub fn write_certificate(cert: X509, key: PKey<Private>) {
+pub fn write_certificate(cert: X509, key: PKey<Private>) -> anyhow::Result<()> {
     if let Ok(bytes) = cert.to_pem() {
-        fs::write(Path::new(DEFAULT_CERT_FILE), bytes);
+        fs::write(Path::new(DEFAULT_CERT_FILE), bytes)?;
     }
     if let Ok(bytes) = key.public_key_to_pem() {
-        fs::write(Path::new(DEFAULT_KEY_FILE), bytes);
+        fs::write(Path::new(DEFAULT_KEY_FILE), bytes)?;
     }
+
+    Ok(())
 }
 
 /// Generates a self-signed SSL certificate

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Jun  7 05:58:48 UTC 2024 - Michal Filka <mfilka@suse.com>
+
+- Improvements in HTTPS setup
+  - self-signed certificate contains hostname
+  - self-signed certificate is stored into default location
+  - before creating new self-signed certificate a default location
+    (/etc/agama.d/ssl) is checked for a certificate 
+
+-------------------------------------------------------------------
 Wed Jun  5 13:53:59 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Process the legacyAutoyastStorage section of the profile

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -6,6 +6,7 @@ Fri Jun  7 05:58:48 UTC 2024 - Michal Filka <mfilka@suse.com>
   - self-signed certificate is stored into default location
   - before creating new self-signed certificate a default location
     (/etc/agama.d/ssl) is checked for a certificate 
+  - gh#openSUSE/agama#1228
 
 -------------------------------------------------------------------
 Wed Jun  5 13:53:59 UTC 2024 - José Iván López González <jlopez@suse.com>


### PR DESCRIPTION
## Problem

Purpose is to make https support more "user" friendly. Currently self-generated certificate contains only a generic name and is generated repeatedly on each start (if needed). Also need of explicit specification of user's own certificate on each (re)start is not much friendly.

## Solution

- real hostname is written into self-signed certificate
- generated self-signed certificate is stored for later use
- defined default location where to search for certificates on start

+ refactoring of some old pieces. Created struct to encapsulate Certificate related stuff.


## Testing

I (mvidner) have tested manually that the certificate (+key) is saved, and reused on service restart, and contains the host name.


## Screenshots

![agama-hostname-in-certificate](https://github.com/openSUSE/agama/assets/1579239/de9e3074-d8cb-4828-9093-0dc56f6b0c5c)


