### PR TITLE
fix: Clippy warnings

### DIFF
--- a/rust/agama-cli/src/auth.rs
+++ b/rust/agama-cli/src/auth.rs
@@ -199,7 +199,7 @@ async fn get_jwt(url: String, password: String) -> anyhow::Result<String> {
     let body = response
         .json::<std::collections::HashMap<String, String>>()
         .await?;
-    let value = body.get(&"token".to_string());
+    let value = body.get("token");
 
     if let Some(token) = value {
         return Ok(token.clone());

--- a/rust/agama-lib/src/dbus.rs
+++ b/rust/agama-lib/src/dbus.rs
@@ -102,16 +102,14 @@ mod tests {
 
     #[test]
     fn test_get_property_wrong_type() {
-        let data: HashMap<String, OwnedValue> =
-            HashMap::from([("Id".to_string(), 1_u8.into())]);
+        let data: HashMap<String, OwnedValue> = HashMap::from([("Id".to_string(), 1_u8.into())]);
         let result: Result<u16, _> = get_property(&data, "Id");
         assert_eq!(result, Err(zvariant::Error::IncorrectType));
     }
 
     #[test]
     fn test_get_optional_property() {
-        let data: HashMap<String, OwnedValue> =
-            HashMap::from([("Id".to_string(), 1_u8.into())]);
+        let data: HashMap<String, OwnedValue> = HashMap::from([("Id".to_string(), 1_u8.into())]);
         let id: Option<u8> = get_optional_property(&data, "Id").unwrap();
         assert_eq!(id, Some(1));
 

--- a/rust/agama-lib/src/dbus.rs
+++ b/rust/agama-lib/src/dbus.rs
@@ -62,9 +62,7 @@ macro_rules! property_from_dbus {
 pub fn to_owned_hash(source: &HashMap<&str, Value<'_>>) -> HashMap<String, OwnedValue> {
     let mut owned = HashMap::new();
     for (key, value) in source.iter() {
-        if let Ok(owned_value) = value.try_into() {
-            owned.insert(key.to_string(), owned_value);
-        }
+        owned.insert(key.to_string(), value.into());
     }
     owned
 }
@@ -74,7 +72,7 @@ pub fn to_owned_hash(source: &HashMap<&str, Value<'_>>) -> HashMap<String, Owned
 /// TODO: should we merge this feature with the "DeviceSid"?
 pub fn extract_id_from_path(path: &OwnedObjectPath) -> Result<u32, zvariant::Error> {
     path.as_str()
-        .rsplit_once("/")
+        .rsplit_once('/')
         .and_then(|(_, id)| id.parse::<u32>().ok())
         .ok_or_else(|| {
             zvariant::Error::Message(format!("Could not extract the ID from {}", path.as_str()))
@@ -92,7 +90,7 @@ mod tests {
     #[test]
     fn test_get_property() {
         let data: HashMap<String, OwnedValue> = HashMap::from([
-            ("Id".to_string(), (1 as u8).into()),
+            ("Id".to_string(), 1_u8.into()),
             ("Device".to_string(), Str::from_static("/dev/sda").into()),
         ]);
         let id: u8 = get_property(&data, "Id").unwrap();
@@ -105,7 +103,7 @@ mod tests {
     #[test]
     fn test_get_property_wrong_type() {
         let data: HashMap<String, OwnedValue> =
-            HashMap::from([("Id".to_string(), (1 as u8).into())]);
+            HashMap::from([("Id".to_string(), 1_u8.into())]);
         let result: Result<u16, _> = get_property(&data, "Id");
         assert_eq!(result, Err(zvariant::Error::IncorrectType));
     }
@@ -113,7 +111,7 @@ mod tests {
     #[test]
     fn test_get_optional_property() {
         let data: HashMap<String, OwnedValue> =
-            HashMap::from([("Id".to_string(), (1 as u8).into())]);
+            HashMap::from([("Id".to_string(), 1_u8.into())]);
         let id: Option<u8> = get_optional_property(&data, "Id").unwrap();
         assert_eq!(id, Some(1));
 

--- a/rust/agama-lib/src/software/client.rs
+++ b/rust/agama-lib/src/software/client.rs
@@ -92,7 +92,7 @@ impl<'a> SoftwareClient<'a> {
             .await?
             .into_iter()
             .filter_map(|(id, reason)| match SelectedBy::try_from(reason) {
-                Ok(reason) if reason == SelectedBy::User => Some(id),
+                Ok(SelectedBy::User) => Some(id),
                 Ok(_reason) => None,
                 Err(e) => {
                     log::warn!("Ignoring pattern {}. Error: {}", &id, e);

--- a/rust/agama-lib/src/storage/client/iscsi.rs
+++ b/rust/agama-lib/src/storage/client/iscsi.rs
@@ -163,7 +163,7 @@ impl<'a> ISCSIClient<'a> {
 
         let result = self
             .initiator_proxy
-            .discover(address, port as u32, options_ref)
+            .discover(address, port, options_ref)
             .await?;
         Ok(result == 0)
     }

--- a/rust/agama-lib/src/storage/model.rs
+++ b/rust/agama-lib/src/storage/model.rs
@@ -18,10 +18,9 @@ impl TryFrom<i32> for DeviceSid {
     type Error = zbus::zvariant::Error;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
-        u32::try_from(value).map(|v| v.into()).map_err(|_| Self::Error::Message(format!(
-                "Cannot convert sid from {}",
-                value
-            )))
+        u32::try_from(value)
+            .map(|v| v.into())
+            .map_err(|_| Self::Error::Message(format!("Cannot convert sid from {}", value)))
     }
 }
 
@@ -66,10 +65,9 @@ impl TryFrom<i64> for DeviceSize {
     type Error = zbus::zvariant::Error;
 
     fn try_from(value: i64) -> Result<Self, Self::Error> {
-        u64::try_from(value).map(|v| v.into()).map_err(|_| Self::Error::Message(format!(
-                "Cannot convert size from {}",
-                value
-            )))
+        u64::try_from(value)
+            .map(|v| v.into())
+            .map_err(|_| Self::Error::Message(format!("Cannot convert size from {}", value)))
     }
 }
 

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -351,6 +351,7 @@ fn write_token(path: &str, secret: &str) -> io::Result<()> {
     let token = generate_token(secret);
     let mut file = fs::OpenOptions::new()
         .create(true)
+        .truncate(true)
         .write(true)
         .mode(0o400)
         .open(path)?;

--- a/rust/agama-server/src/dbus.rs
+++ b/rust/agama-server/src/dbus.rs
@@ -150,7 +150,7 @@ impl DBusObjectChangesStream {
             .path(manager_path.clone())?
             .interface("org.freedesktop.DBus.ObjectManager")?
             .build();
-        let stream = MessageStream::for_match_rule(rule, &connection, None).await?;
+        let stream = MessageStream::for_match_rule(rule, connection, None).await?;
         Ok(stream)
     }
 
@@ -168,7 +168,7 @@ impl DBusObjectChangesStream {
             .interface("org.freedesktop.DBus.Properties")?
             .member("PropertiesChanged")?
             .build();
-        let stream = MessageStream::for_match_rule(rule, &connection, None).await?;
+        let stream = MessageStream::for_match_rule(rule, connection, None).await?;
         Ok(stream)
     }
 }
@@ -182,10 +182,10 @@ impl Stream for DBusObjectChangesStream {
             let item = ready!(pinned.inner.as_mut().poll_next(cx));
             let next_value = match item {
                 Some((PROPERTIES_CHANGED, message)) => {
-                    Self::handle_properties_changed(message, &pinned.interface)
+                    Self::handle_properties_changed(message, pinned.interface)
                 }
                 Some((OBJECTS_MANAGER, message)) => {
-                    Self::handle_added_or_removed(message, &pinned.interface)
+                    Self::handle_added_or_removed(message, pinned.interface)
                 }
                 _ => None,
             };
@@ -216,7 +216,7 @@ where
     }
 
     pub fn remove(&mut self, path: &OwnedObjectPath) -> Option<T> {
-        self.objects.remove(&path)
+        self.objects.remove(path)
     }
 }
 

--- a/rust/agama-server/src/l10n/dbus.rs
+++ b/rust/agama-server/src/l10n/dbus.rs
@@ -26,7 +26,7 @@ impl L10nInterface {
             ));
         }
         backend.set_locales(&locales).map_err(|e| {
-            zbus::fdo::Error::Failed(format!("Could not set the locales: {}", e.to_string()))
+            zbus::fdo::Error::Failed(format!("Could not set the locales: {}", e))
         })?;
         Ok(())
     }
@@ -60,7 +60,7 @@ impl L10nInterface {
             .map_err(|_e| zbus::fdo::Error::InvalidArgs("Cannot parse keymap ID".to_string()))?;
 
         backend.set_keymap(keymap_id).map_err(|e| {
-            zbus::fdo::Error::Failed(format!("Could not set the keymap: {}", e.to_string()))
+            zbus::fdo::Error::Failed(format!("Could not set the keymap: {}", e))
         })?;
 
         Ok(())
@@ -77,7 +77,7 @@ impl L10nInterface {
         let mut backend = self.backend.write().unwrap();
 
         backend.set_timezone(timezone).map_err(|e| {
-            zbus::fdo::Error::Failed(format!("Could not set the timezone: {}", e.to_string()))
+            zbus::fdo::Error::Failed(format!("Could not set the timezone: {}", e))
         })?;
         Ok(())
     }

--- a/rust/agama-server/src/l10n/dbus.rs
+++ b/rust/agama-server/src/l10n/dbus.rs
@@ -25,9 +25,9 @@ impl L10nInterface {
                 "The locales list cannot be empty".to_string(),
             ));
         }
-        backend.set_locales(&locales).map_err(|e| {
-            zbus::fdo::Error::Failed(format!("Could not set the locales: {}", e))
-        })?;
+        backend
+            .set_locales(&locales)
+            .map_err(|e| zbus::fdo::Error::Failed(format!("Could not set the locales: {}", e)))?;
         Ok(())
     }
 
@@ -59,9 +59,9 @@ impl L10nInterface {
             .parse()
             .map_err(|_e| zbus::fdo::Error::InvalidArgs("Cannot parse keymap ID".to_string()))?;
 
-        backend.set_keymap(keymap_id).map_err(|e| {
-            zbus::fdo::Error::Failed(format!("Could not set the keymap: {}", e))
-        })?;
+        backend
+            .set_keymap(keymap_id)
+            .map_err(|e| zbus::fdo::Error::Failed(format!("Could not set the keymap: {}", e)))?;
 
         Ok(())
     }
@@ -76,9 +76,9 @@ impl L10nInterface {
     pub fn set_timezone(&mut self, timezone: &str) -> Result<(), zbus::fdo::Error> {
         let mut backend = self.backend.write().unwrap();
 
-        backend.set_timezone(timezone).map_err(|e| {
-            zbus::fdo::Error::Failed(format!("Could not set the timezone: {}", e))
-        })?;
+        backend
+            .set_timezone(timezone)
+            .map_err(|e| zbus::fdo::Error::Failed(format!("Could not set the timezone: {}", e)))?;
         Ok(())
     }
 

--- a/rust/agama-server/src/l10n/l10n.rs
+++ b/rust/agama-server/src/l10n/l10n.rs
@@ -68,7 +68,7 @@ impl L10n {
                 return Err(LocaleError::UnknownLocale(loc.to_string()))?;
             }
         }
-        self.locales = locales.clone();
+        self.locales.clone_from(locales);
         Ok(())
     }
 
@@ -77,7 +77,7 @@ impl L10n {
         if !self.timezones_db.exists(&timezone.to_string()) {
             return Err(LocaleError::UnknownTimezone(timezone.to_string()))?;
         }
-        self.timezone = timezone.to_owned();
+        timezone.clone_into(&mut self.timezone);
         Ok(())
     }
 
@@ -92,7 +92,7 @@ impl L10n {
 
     // TODO: use LocaleError
     pub fn translate(&mut self, locale: &LocaleId) -> Result<(), Error> {
-        helpers::set_service_locale(&locale);
+        helpers::set_service_locale(locale);
         self.timezones_db.read(&locale.language)?;
         self.locales_db.read(&locale.language)?;
         self.ui_locale = locale.clone();

--- a/rust/agama-server/src/l10n/locale.rs
+++ b/rust/agama-server/src/l10n/locale.rs
@@ -109,7 +109,7 @@ impl LocalesDatabase {
         const LOCALES_LIST_PATH: &str = "/etc/agama.d/locales";
 
         let locales = fs::read_to_string(LOCALES_LIST_PATH)
-            .map(|content| Self::get_locales_from_string(content));
+            .map(Self::get_locales_from_string);
 
         if let Ok(locales) = locales {
             if !locales.is_empty() {
@@ -123,7 +123,7 @@ impl LocalesDatabase {
             .context("Failed to get the list of locales")?;
 
         let locales = String::from_utf8(result.stdout)
-            .map(|content| Self::get_locales_from_string(content))
+            .map(Self::get_locales_from_string)
             .context("Invalid UTF-8 sequence from list-locales")?;
 
         Ok(locales)

--- a/rust/agama-server/src/l10n/locale.rs
+++ b/rust/agama-server/src/l10n/locale.rs
@@ -108,8 +108,7 @@ impl LocalesDatabase {
     fn get_locales_list() -> Result<Vec<LocaleId>, Error> {
         const LOCALES_LIST_PATH: &str = "/etc/agama.d/locales";
 
-        let locales = fs::read_to_string(LOCALES_LIST_PATH)
-            .map(Self::get_locales_from_string);
+        let locales = fs::read_to_string(LOCALES_LIST_PATH).map(Self::get_locales_from_string);
 
         if let Ok(locales) = locales {
             if !locales.is_empty() {

--- a/rust/agama-server/src/l10n/web.rs
+++ b/rust/agama-server/src/l10n/web.rs
@@ -123,19 +123,19 @@ async fn set_config(
     let mut changes = LocaleConfig::default();
 
     if let Some(locales) = &value.locales {
-        data.set_locales(&locales)?;
-        changes.locales = value.locales.clone();
+        data.set_locales(locales)?;
+        changes.locales.clone_from(&value.locales);
     }
 
     if let Some(timezone) = &value.timezone {
         data.set_timezone(timezone)?;
-        changes.timezone = value.timezone.clone();
+        changes.timezone.clone_from(&value.timezone);
     }
 
     if let Some(keymap_id) = &value.keymap {
         let keymap_id = keymap_id.parse().map_err(LocaleError::InvalidKeymap)?;
         data.set_keymap(keymap_id)?;
-        changes.keymap = value.keymap.clone();
+        changes.keymap.clone_from(&value.keymap);
     }
 
     if let Some(ui_locale) = &value.ui_locale {
@@ -198,7 +198,7 @@ pub async fn update_dbus(
     }
 
     if let Some(timezone) = &config.timezone {
-        client.set_timezone(&timezone).await?;
+        client.set_timezone(timezone).await?;
     }
 
     if let Some(ui_locale) = &config.ui_locale {

--- a/rust/agama-server/src/network/model.rs
+++ b/rust/agama-server/src/network/model.rs
@@ -180,7 +180,7 @@ impl NetworkState {
     }
 
     pub fn remove_device(&mut self, name: &str) -> Result<(), NetworkStateError> {
-        let Some(position) = self.devices.iter().position(|d| &d.name == name) else {
+        let Some(position) = self.devices.iter().position(|d| d.name == name) else {
             return Err(NetworkStateError::UnknownDevice(name.to_string()));
         };
 

--- a/rust/agama-server/src/network/nm/dbus.rs
+++ b/rust/agama-server/src/network/nm/dbus.rs
@@ -155,17 +155,17 @@ pub fn connection_from_dbus(conn: OwnedNestedHash) -> Option<Connection> {
         return Some(connection);
     }
 
-    if conn.get(DUMMY_KEY).is_some() {
+    if conn.contains_key(DUMMY_KEY) {
         connection.config = ConnectionConfig::Dummy;
         return Some(connection);
     };
 
-    if conn.get(LOOPBACK_KEY).is_some() {
+    if conn.contains_key(LOOPBACK_KEY) {
         connection.config = ConnectionConfig::Loopback;
         return Some(connection);
     };
 
-    if conn.get(ETHERNET_KEY).is_some() {
+    if conn.contains_key(ETHERNET_KEY) {
         return Some(connection);
     };
 
@@ -240,9 +240,7 @@ pub fn cleanup_dbus_connection(conn: &mut NestedHash) {
 
 /// Ancillary function to get the controller for a given interface.
 pub fn controller_from_dbus(conn: &OwnedNestedHash) -> Option<String> {
-    let Some(connection) = conn.get("connection") else {
-        return None;
-    };
+    let connection = conn.get("connection")?;
 
     let master: &str = connection.get("master")?.downcast_ref()?;
     Some(master.to_string())
@@ -424,13 +422,9 @@ fn bridge_config_to_dbus(bridge: &BridgeConfig) -> HashMap<&str, zvariant::Value
 }
 
 fn bridge_config_from_dbus(conn: &OwnedNestedHash) -> Option<BridgeConfig> {
-    let Some(bridge) = conn.get(BRIDGE_KEY) else {
-        return None;
-    };
+    let bridge = conn.get(BRIDGE_KEY)?;
 
-    let Some(stp) = bridge.get("stp") else {
-        return None;
-    };
+    let stp = bridge.get("stp")?;
 
     let mut bc = BridgeConfig {
         stp: *stp.downcast_ref::<bool>()?,
@@ -474,9 +468,7 @@ fn bridge_port_config_to_dbus(bridge_port: &BridgePortConfig) -> HashMap<&str, z
 }
 
 fn bridge_port_config_from_dbus(conn: &OwnedNestedHash) -> Option<BridgePortConfig> {
-    let Some(bridge_port) = conn.get(BRIDGE_PORT_KEY) else {
-        return None;
-    };
+    let bridge_port = conn.get(BRIDGE_PORT_KEY)?;
 
     let mut bpc = BridgePortConfig::default();
 
@@ -508,9 +500,7 @@ fn infiniband_config_to_dbus(config: &InfinibandConfig) -> HashMap<&str, zvarian
 }
 
 fn infiniband_config_from_dbus(conn: &OwnedNestedHash) -> Option<InfinibandConfig> {
-    let Some(infiniband) = conn.get(INFINIBAND_KEY) else {
-        return None;
-    };
+    let infiniband = conn.get(INFINIBAND_KEY)?;
 
     let mut infiniband_config = InfinibandConfig::default();
 
@@ -551,9 +541,7 @@ fn match_config_to_dbus(match_config: &MatchConfig) -> HashMap<&str, zvariant::V
 }
 
 fn base_connection_from_dbus(conn: &OwnedNestedHash) -> Option<Connection> {
-    let Some(connection) = conn.get("connection") else {
-        return None;
-    };
+    let connection = conn.get("connection")?;
 
     let id: &str = connection.get("id")?.downcast_ref()?;
     let uuid: &str = connection.get("uuid")?.downcast_ref()?;
@@ -751,9 +739,7 @@ fn nameservers_from_dbus(dns_data: &OwnedValue) -> Option<Vec<IpAddr>> {
 }
 
 fn wireless_config_from_dbus(conn: &OwnedNestedHash) -> Option<WirelessConfig> {
-    let Some(wireless) = conn.get(WIRELESS_KEY) else {
-        return None;
-    };
+    let wireless = conn.get(WIRELESS_KEY)?;
 
     let mode: &str = wireless.get("mode")?.downcast_ref()?;
     let ssid = wireless.get("ssid")?;
@@ -832,9 +818,7 @@ fn wireless_config_from_dbus(conn: &OwnedNestedHash) -> Option<WirelessConfig> {
 }
 
 fn bond_config_from_dbus(conn: &OwnedNestedHash) -> Option<BondConfig> {
-    let Some(bond) = conn.get(BOND_KEY) else {
-        return None;
-    };
+    let bond = conn.get(BOND_KEY)?;
 
     let dict: &zvariant::Dict = bond.get("options")?.downcast_ref()?;
 
@@ -864,18 +848,12 @@ fn vlan_config_to_dbus(cfg: &VlanConfig) -> NestedHash {
 }
 
 fn vlan_config_from_dbus(conn: &OwnedNestedHash) -> Option<VlanConfig> {
-    let Some(vlan) = conn.get(VLAN_KEY) else {
-        return None;
-    };
+    let vlan = conn.get(VLAN_KEY)?;
 
-    let Some(id) = vlan.get("id") else {
-        return None;
-    };
+    let id = vlan.get("id")?;
     let id = id.downcast_ref::<u32>()?;
 
-    let Some(parent) = vlan.get("parent") else {
-        return None;
-    };
+    let parent = vlan.get("parent")?;
     let parent: &str = parent.downcast_ref()?;
 
     let protocol = match vlan.get("protocol") {
@@ -1152,7 +1130,7 @@ mod test {
         ]);
 
         let infiniband_section = HashMap::from([
-            ("p-key".to_string(), Value::new(0x8001 as i32).to_owned()),
+            ("p-key".to_string(), Value::new(0x8001_i32).to_owned()),
             ("parent".to_string(), Value::new("ib0").to_owned()),
             (
                 "transport-mode".to_string(),

--- a/rust/agama-server/src/storage/web/iscsi/stream.rs
+++ b/rust/agama-server/src/storage/web/iscsi/stream.rs
@@ -50,7 +50,7 @@ impl ISCSINodeStream {
 
         let (tx, rx) = unbounded_channel();
         let mut stream = DBusObjectChangesStream::new(
-            &dbus,
+            dbus,
             &ObjectPath::from_str_unchecked(MANAGER_PATH),
             &ObjectPath::from_str_unchecked(NAMESPACE),
             "org.opensuse.Agama.Storage1.ISCSI.Node",
@@ -84,8 +84,8 @@ impl ISCSINodeStream {
         path: &OwnedObjectPath,
         values: &HashMap<String, OwnedValue>,
     ) -> Result<&'a ISCSINode, ServiceError> {
-        let node = cache.find_or_create(&path);
-        node.id = extract_id_from_path(&path)?;
+        let node = cache.find_or_create(path);
+        node.id = extract_id_from_path(path)?;
         property_from_dbus!(node, target, "Target", values, str);
         property_from_dbus!(node, address, "Address", values, str);
         property_from_dbus!(node, interface, "Interface", values, str);
@@ -100,7 +100,7 @@ impl ISCSINodeStream {
         path: &OwnedObjectPath,
     ) -> Result<ISCSINode, ISCSINodeStreamError> {
         cache
-            .remove(&path)
+            .remove(path)
             .ok_or_else(|| ISCSINodeStreamError::UnknownNode(path.clone()))
     }
 
@@ -110,11 +110,11 @@ impl ISCSINodeStream {
     ) -> Result<Event, ISCSINodeStreamError> {
         match change {
             DBusObjectChange::Added(path, values) => {
-                let node = Self::update_node(cache, path, &values)?;
+                let node = Self::update_node(cache, path, values)?;
                 Ok(Event::ISCSINodeAdded { node: node.clone() })
             }
             DBusObjectChange::Changed(path, updated) => {
-                let node = Self::update_node(cache, path, &updated)?;
+                let node = Self::update_node(cache, path, updated)?;
                 Ok(Event::ISCSINodeChanged { node: node.clone() })
             }
             DBusObjectChange::Removed(path) => {

--- a/rust/agama-server/src/web/auth.rs
+++ b/rust/agama-server/src/web/auth.rs
@@ -57,14 +57,19 @@ impl TokenClaims {
     /// * `secret`: secret to decode the token.
     pub fn from_token(token: &str, secret: &str) -> Result<Self, AuthError> {
         let decoding = DecodingKey::from_secret(secret.as_ref());
-        let token_data = jsonwebtoken::decode(&token, &decoding, &Validation::default())?;
+        let token_data = jsonwebtoken::decode(token, &decoding, &Validation::default())?;
         Ok(token_data.claims)
     }
 }
 
 impl Default for TokenClaims {
     fn default() -> Self {
-        let exp = Utc::now() + Duration::days(1);
+        let mut exp = Utc::now();
+
+        if let Some(days) = Duration::try_days(1) {
+            exp += days;
+        }
+
         Self {
             exp: exp.timestamp(),
         }

--- a/rust/agama-server/tests/network_service.rs
+++ b/rust/agama-server/tests/network_service.rs
@@ -38,7 +38,7 @@ async fn build_state() -> NetworkState {
 async fn build_service(state: NetworkState) -> Result<Router, ServiceError> {
     let adapter = NetworkTestAdapter(state);
     let (tx, _rx) = broadcast::channel(16);
-    Ok(network_service(adapter, tx).await?)
+    network_service(adapter, tx).await
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Fix almost all clippy warnings (some of them were automatically fixed with `cargo clippy --fix`).

Note: there are still some warnings that require more work to get rid of them:

<details>
<summary><i>$ cargo clippy</i></summary>

~~~
cargo clippy
    Checking agama-server v0.1.0 (/home/ivan/projects/suse/code/agama/rust/agama-server)
warning: module has the same name as its containing module
 --> agama-server/src/l10n.rs:5:1
  |
5 | pub mod l10n;
  | ^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#module_inception
  = note: `#[warn(clippy::module_inception)]` on by default

warning: very complex type used. Consider factoring parts into `type` definitions
   --> agama-server/src/network/nm/proxies.rs:849:28
    |
849 |     fn addresses(&self) -> zbus::Result<Vec<(Vec<u8>, u32, Vec<u8>)>>;
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
    = note: `#[warn(clippy::type_complexity)]` on by default

warning: very complex type used. Consider factoring parts into `type` definitions
   --> agama-server/src/network/nm/proxies.rs:879:25
    |
879 |     fn routes(&self) -> zbus::Result<Vec<(Vec<u8>, u32, Vec<u8>, u32)>>;
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity

warning: `agama-server` (lib) generated 3 warnings
warning: current MSRV (Minimum Supported Rust Version) is `1.74.0` but this item is stable since `1.75.0`
   --> agama-server/src/agama-web-server.rs:233:22
    |
233 |         if addr.ip().to_canonical().is_loopback() {
    |                      ^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incompatible_msrv
    = note: `#[warn(clippy::incompatible_msrv)]` on by default
~~~

</details>
