### PR TITLE
Live ISO: Keep xkeyboard-config translations

### DIFF
--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -82,7 +82,7 @@ ls -1 "${IGNORE_OPTS[@]}" -I en_US /usr/share/locale/ | xargs -I% sh -c "echo 'R
 ls -1 "${IGNORE_OPTS[@]}" -I "en_US*" -I "C.*" /usr/lib/locale/ | xargs -I% sh -c "echo 'Removing locale %...' && rm -rf /usr/lib/locale/%"
 
 # delete unused translations (MO files)
-for t in zypper gettext-runtime p11-kit polkit-1 xkeyboard-config; do
+for t in zypper gettext-runtime p11-kit; do
     rm /usr/share/locale/*/LC_MESSAGES/$t.mo
 done
 du -h -s /usr/{share,lib}/locale/


### PR DESCRIPTION
## Problem

- The X keyboard translations were missing

## Solution

- Keep the MO files in the Live ISO

## Notes

- The polkit-1 translations are not installed anymore (it was a Cockpit dependency)
- This fixes the `rm: cannot remove '/usr/share/locale/*/LC_MESSAGES/polkit-1.mo': No such file or directory` error in Kiwi log
