### PR TITLE
fix: Emit signal when storage propeties change

### DIFF
--- a/service/lib/agama/dbus/clients/base.rb
+++ b/service/lib/agama/dbus/clients/base.rb
@@ -97,8 +97,8 @@ module Agama
           return if callbacks.size > 1
 
           interface_proxy = dbus_object[interface]
-          interface_proxy.on_signal(signal) do |iface, changes, invalid|
-            callbacks.each { |c| c.call(iface, changes, invalid) }
+          interface_proxy.on_signal(signal) do |*args|
+            callbacks.each { |c| c.call(*args) }
           end
         end
 

--- a/service/lib/agama/dbus/clients/software.rb
+++ b/service/lib/agama/dbus/clients/software.rb
@@ -36,7 +36,7 @@ module Agama
         TYPES = [:package, :pattern].freeze
         private_constant :TYPES
 
-        # @note This client is sigleton because ruby-dbus does not work properly with several
+        # @note This client is singleton because ruby-dbus does not work properly with several
         #   instances of the same client.
         def self.instance
           @instance ||= new

--- a/service/lib/agama/dbus/clients/software.rb
+++ b/service/lib/agama/dbus/clients/software.rb
@@ -169,15 +169,19 @@ module Agama
 
         # Registers a callback to run when the product changes
         #
-        # @note Signal subscription is done only once. Otherwise, the latest subscription overrides
-        #   the previous one.
-        #
         # @param block [Proc] Callback to run when a product is selected
         def on_product_selected(&block)
           on_properties_change(dbus_product) do |_, changes, _|
             product = changes["SelectedProduct"]
             block.call(product) unless product.nil?
           end
+        end
+
+        # Registers a callback to run when the software is probed.
+        #
+        # @param block [Proc]
+        def on_probe_finished(&block)
+          subscribe(dbus_object, "org.opensuse.Agama.Software1", "ProbeFinished", &block)
         end
 
       private

--- a/service/lib/agama/dbus/clients/software.rb
+++ b/service/lib/agama/dbus/clients/software.rb
@@ -36,17 +36,10 @@ module Agama
         TYPES = [:package, :pattern].freeze
         private_constant :TYPES
 
-        def initialize
-          super
-
-          @dbus_object = service["/org/opensuse/Agama/Software1"]
-          @dbus_object.introspect
-
-          @dbus_product = service["/org/opensuse/Agama/Software1/Product"]
-          @dbus_product.introspect
-
-          @dbus_proposal = service["/org/opensuse/Agama/Software1/Proposal"]
-          @dbus_proposal.introspect
+        # @note This client is sigleton because ruby-dbus does not work properly with several
+        #   instances of the same client.
+        def self.instance
+          @instance ||= new
         end
 
         # @return [String]
@@ -197,6 +190,19 @@ module Agama
 
         # @return [::DBus::Object]
         attr_reader :dbus_proposal
+
+        def initialize
+          super
+
+          @dbus_object = service["/org/opensuse/Agama/Software1"]
+          @dbus_object.introspect
+
+          @dbus_product = service["/org/opensuse/Agama/Software1/Product"]
+          @dbus_product.introspect
+
+          @dbus_proposal = service["/org/opensuse/Agama/Software1/Proposal"]
+          @dbus_proposal.introspect
+        end
       end
     end
   end

--- a/service/lib/agama/dbus/software/manager.rb
+++ b/service/lib/agama/dbus/software/manager.rb
@@ -107,6 +107,8 @@ module Agama
 
           dbus_method(:UsedDiskSpace, "out SpaceSize:s") { backend.used_disk_space }
 
+          dbus_signal(:ProbeFinished)
+
           dbus_method(:Probe) { probe }
           dbus_method(:Propose) { propose }
           dbus_method(:Install) { install }
@@ -115,6 +117,7 @@ module Agama
 
         def probe
           busy_while { backend.probe }
+          self.ProbeFinished
         end
 
         def propose

--- a/service/lib/agama/dbus/y2dir/manager/modules/Package.rb
+++ b/service/lib/agama/dbus/y2dir/manager/modules/Package.rb
@@ -26,7 +26,7 @@ module Yast
   class PackageClass < Module
     def main
       puts "Loading mocked module #{__FILE__}"
-      @client = Agama::DBus::Clients::Software.new
+      @client = Agama::DBus::Clients::Software.instance
     end
 
     # Determines whether a package is available.

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022-2023] SUSE LLC
+# Copyright (c) [2022-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -157,7 +157,7 @@ module Agama
       #
       # @return [Agama::DBus::Clients::Software]
       def software
-        @software ||= DBus::Clients::Software.new
+        @software ||= DBus::Clients::Software.instance
       end
 
     private

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 21 05:32:46 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Emit a PropertiesChanged signal for ProductMountPoints and
+  EncryptionMethods properties when the product changes
+  (gh#openSUSE/agama#1236).
+
+-------------------------------------------------------------------
 Fri May 17 09:52:25 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 8

--- a/service/test/agama/dbus/clients/software_test.rb
+++ b/service/test/agama/dbus/clients/software_test.rb
@@ -213,6 +213,31 @@ describe Agama::DBus::Clients::Software do
     end
   end
 
+  describe "#on_probe_finished" do
+    before do
+      allow(dbus_object).to receive(:path).and_return("/org/opensuse/Agama/Test")
+      allow(software_iface).to receive(:on_signal)
+    end
+
+    context "if there are no callbacks for the signal" do
+      it "subscribes to the signal" do
+        expect(software_iface).to receive(:on_signal)
+        subject.on_probe_finished { "test" }
+      end
+    end
+
+    context "if there already are callbacks for the signal" do
+      before do
+        subject.on_probe_finished { "test" }
+      end
+
+      it "does not subscribe to the signal again" do
+        expect(software_iface).to_not receive(:on_signal)
+        subject.on_probe_finished { "test" }
+      end
+    end
+  end
+
   include_examples "issues"
   include_examples "service status"
   include_examples "progress"

--- a/service/test/agama/dbus/software/manager_test.rb
+++ b/service/test/agama/dbus/software/manager_test.rb
@@ -87,10 +87,11 @@ describe Agama::DBus::Software::Manager do
   end
 
   describe "#probe" do
-    it "runs the probing, setting the service as busy meanwhile" do
+    it "runs the probing, setting the service as busy meanwhile, and emits a signal" do
       expect(subject.service_status).to receive(:busy)
       expect(backend).to receive(:probe)
       expect(subject.service_status).to receive(:idle)
+      expect(subject).to receive(:ProbeFinished)
 
       subject.probe
     end

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -68,7 +68,11 @@ describe Agama::DBus::Storage::Manager do
       on_sessions_change: nil)
   end
 
-  let(:software) { instance_double(Agama::DBus::Clients::Software, on_product_selected: nil) }
+  let(:software) do
+    instance_double(Agama::DBus::Clients::Software,
+      on_product_selected: nil,
+      on_probe_finished:   nil)
+  end
 
   before do
     allow(Yast::Arch).to receive(:s390).and_return false

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -44,10 +44,8 @@ describe Agama::Storage::Manager do
 
   before do
     allow(Agama::DBus::Clients::Questions).to receive(:new).and_return(questions_client)
-    allow(Agama::DBus::Clients::Software).to receive(:new)
-      .and_return(software)
-    allow(Bootloader::FinishClient).to receive(:new)
-      .and_return(bootloader_finish)
+    allow(Agama::DBus::Clients::Software).to receive(:instance).and_return(software)
+    allow(Bootloader::FinishClient).to receive(:new).and_return(bootloader_finish)
     allow(Agama::Security).to receive(:new).and_return(security)
   end
 


### PR DESCRIPTION
### Problem

The value of the D-Bus properties *ProductMountPoints* and *EncryptionMethods* from the interface *org.opensuse.Agama.Storage1.Proposal.Calculator* depend on the selected product. Nevertheless, the *PropertiesChanged* signal is not emitted when the product changes. Therefore, proxies clients never update such values.

This implies that the option for FDE (Full Disk Encryption) might not be shown. See https://github.com/openSUSE/agama/pull/1004.

### Solution

* For the *ProductMountPoints* property: emit a *PropertiesChanged* signal when the product changes.
* For the *EncryptionMethods* property: emit a *PropertiesChaged* signal when software is probed. Note that the availability of certain packages is checked in order to know whether FDE is a possible encryption method. 
