### PR TITLE
Better AutoYaST import support

### DIFF
--- a/doc/autoyast.md
+++ b/doc/autoyast.md
@@ -372,6 +372,18 @@ About the `slp_discoverty` element, Agama does not support [SLP] at all?
 
 [SLP]: https://documentation.suse.com/sles/15-SP5/single-html/SLES-administration/#cha-slp
 
+| AutoYaST                         | Supported | Agama                     | Comment                                         |
+| -------------------------------- | --------- | ------------------------- | ----------------------------------------------- |
+| do_registration                  | Never     |                           | The system is registered if there is a reg code |
+| email                            | Yes       | product.registrationEmail |                                                 |
+| install_updates                  | Never     |                           |                                                 |
+| reg_code                         | Yes       | product.registrationCode  |                                                 |
+| reg_server                       | Planned   |                           |                                                 |
+| reg_server_cert                  | Undecided |                           | It is not clear how addons will work            |
+| reg_server_cert_fingerprint      | Planned   |                           |                                                 |
+| reg_server_cert_fingerprint_type | Planned   |                           |                                                 |
+| slp_discovery                    | Never     |                           |                                                 |
+
 ### `timezone`
 
 | AutoYaST | Supported | Agama         | Comment |

--- a/doc/autoyast.md
+++ b/doc/autoyast.md
@@ -4,8 +4,8 @@ Agama offers a mechanism to perform [unattended installations](../autoinstallati
 would like AutoYaST users to be able to use their AutoYaST profiles in Agama. This document
 describes how Agama could support, to some extent, such profiles.
 
-Bear in mind that this document is just a draft and our plans could change once we start working
-on the implementation.
+Bear in mind that this document is just a draft and our plans could change once we start working on
+the implementation.
 
 ## What to support
 
@@ -16,11 +16,11 @@ counterpart.
 
 Nevertheless, we want to cover:
 
-* Dynamic profiles, including rules/classes, ERB templates, pre-installation scripts and even "ask
-lists". See [Dynamic profiles](#dynamic-profiles).
-* Compatibility (partial or full) for the following sections: `networking`, `partitioning`,
-`language`, `timezone`, `keyboard`, `software`, `scripts`, `users`, `iscsi-client`, `proxy` and
-`suse_register`. See [Supported sections](#supported-sections).
+- Dynamic profiles, including rules/classes, ERB templates, pre-installation scripts and even "ask
+  lists". See [Dynamic profiles](#dynamic-profiles).
+- Compatibility (partial or full) for the following sections: `networking`, `partitioning`,
+  `language`, `timezone`, `keyboard`, `software`, `scripts`, `users`, `iscsi-client`, `proxy` and
+  `suse_register`. See [Supported sections](#supported-sections).
 
 We still need to decide how to handle other sections like `firewall`, `bootloader`, `report`,
 `general` or even some elements from `security` or `kdump`.
@@ -33,10 +33,10 @@ elements. See [Unsupported sections](#unsupported-sections).
 Many AutoYaST users rely on its dynamic capabilities to build adaptable profiles that they can use
 to install different systems. For that reason, we need Agama to support these features:
 
-* [Rules and classes][rules-classes].
-* [Embedded Ruby (ERB)][erb].
-* [Pre-installation scripts][pre-scripts].
-* [Ask lists]().
+- [Rules and classes][rules-classes].
+- [Embedded Ruby (ERB)][erb].
+- [Pre-installation scripts][pre-scripts].
+- [Ask lists]().
 
 The most realistic way to support those features in the mid-term is to use the AutoYaST code with
 some adaptations. The [import-autoyast-profiles branch][autoyast-branch] contains a proof-of-concept
@@ -56,18 +56,18 @@ You can even use the `agama-cli`:
 cd rust
 cargo build
 sudo PATH=$PWD/../service/bin:$PATH ./target/debug/agama profile download \
-  file:///$PWD/../service/test/fixtures/profiles/pre-scripts.xml 
+  file:///$PWD/../service/test/fixtures/profiles/pre-scripts.xml
 ```
 
 About "ask lists", there might need more work. Fortunately, the code to [parse][ask-list-reader] and
-[run][ask-list-runner] the process are there but we need to adapt the [user
-interface][ask-list-dialog], which is not trivial.
+[run][ask-list-runner] the process are there but we need to adapt the
+[user interface][ask-list-dialog], which is not trivial.
 
 [rules-classes]: https://doc.opensuse.org/documentation/leap/autoyast/html/book-autoyast/rulesandclass.html
 [erb]: https://doc.opensuse.org/documentation/leap/autoyast/html/book-autoyast/erb-templates.html
 [pre-scripts]: https://doc.opensuse.org/documentation/leap/autoyast/html/book-autoyast/cha-configuration-installation-options.html#pre-install-scripts
 [ask-lists]: https://doc.opensuse.org/documentation/leap/autoyast/html/book-autoyast/cha-configuration-installation-options.html#CreateProfile-Ask
-[autoyast-branch]: https://github.com/openSUSE/agama/tree/import-autoyast-profiles 
+[autoyast-branch]: https://github.com/openSUSE/agama/tree/import-autoyast-profiles
 [ask-list-reader]: https://github.com/yast/yast-autoinstallation/blob/c2dc34560df4ba890688a0c84caec94cc2718f14/src/lib/autoinstall/ask/profile_reader.rb#L29
 [ask-list-runner]: https://github.com/yast/yast-autoinstallation/blob/c2dc34560df4ba890688a0c84caec94cc2718f14/src/lib/autoinstall/ask/runner.rb#L50
 [ask-list-dialog]: https://github.com/yast/yast-autoinstallation/blob/c2dc34560df4ba890688a0c84caec94cc2718f14/src/lib/autoinstall/ask/dialog.rb#L23
@@ -95,9 +95,9 @@ Regarding users, Agama only allows defining the first user and setting the root 
 mechanism (password and/or SSH public key). However, AutoYaST allows to specify a list of users and
 groups plus some authentication settings. We have at least two options here:
 
-* Extract the root authentication data from the profile and try to infer which is the first user.
-This behavior is already implemented.
-* Import these sections as given because they are handled by the YaST code in Agama.
+- Extract the root authentication data from the profile and try to infer which is the first user.
+  This behavior is already implemented.
+- Import these sections as given because they are handled by the YaST code in Agama.
 
 ### `keyboard`, `language` and `timezone`
 
@@ -160,15 +160,15 @@ them through a systemd service.
 
 The `software` section is composed of several lists:
 
-* A list of products to install, although a single value is expected.
-* A list of patterns to install, a list of patterns to install in the 2nd stage and a list of
-patterns to remove.
-* A list of packages to install, a list of packages to install in the 2nd stage and a list of
-packages to remove.
+- A list of products to install, although a single value is expected.
+- A list of patterns to install, a list of patterns to install in the 2nd stage and a list of
+  patterns to remove.
+- A list of packages to install, a list of packages to install in the 2nd stage and a list of
+  packages to remove.
 
-Additionally, it is possible to force the installation of a specific kernel (`kernel`), perform
-an online update at the end of the installation (`do_online_update`) or enable/disable the
-installation of recommended packages (`install_recommended`).
+Additionally, it is possible to force the installation of a specific kernel (`kernel`), perform an
+online update at the end of the installation (`do_online_update`) or enable/disable the installation
+of recommended packages (`install_recommended`).
 
 Only the product and the list of products or patterns are available for Agama. We might consider
 adding support for the packages list and the `install_recommended` setting, although none are in the
@@ -176,8 +176,8 @@ web UI.
 
 ### `suse_register`
 
-Basic support for registering in the SUSE Customer Center is already in place, although
-there is no way to select the list of add-ons.
+Basic support for registering in the SUSE Customer Center is already in place, although there is no
+way to select the list of add-ons.
 
 It is arguable whether we should offer a `install_updates` element instead of just installing them
 (which is the use case for not installing them?).
@@ -188,32 +188,32 @@ About the `slp_discoverty` element, Agama does not support [SLP] at all?
 
 ## Unsupported sections
 
-* `FCoE`
-* `add-on`
-* `audit-laf`
-* `auth-client`
-* `configuration_management`
-* `deploy_image`
-* `dhcp-server`
-* `dns-server`
-* `files`
-* `firstboot`
-* `ftp-server`
-* `groups`
-* `host`
-* `http-server`
-* `mail`
-* `nfs`
-* `nfs_server`
-* `nis`
-* `nis_server`
-* `ntp-client`
-* `printer`
-* `samba-client`
-* `services-manager`
-* `sound`
-* `squid`
-* `ssh_import`
-* `sysconfig`
-* `tftp-server`
-* `upgrade`
+- `FCoE`
+- `add-on`
+- `audit-laf`
+- `auth-client`
+- `configuration_management`
+- `deploy_image`
+- `dhcp-server`
+- `dns-server`
+- `files`
+- `firstboot`
+- `ftp-server`
+- `groups`
+- `host`
+- `http-server`
+- `mail`
+- `nfs`
+- `nfs_server`
+- `nis`
+- `nis_server`
+- `ntp-client`
+- `printer`
+- `samba-client`
+- `services-manager`
+- `sound`
+- `squid`
+- `ssh_import`
+- `sysconfig`
+- `tftp-server`
+- `upgrade`

--- a/doc/autoyast.md
+++ b/doc/autoyast.md
@@ -390,9 +390,10 @@ About the `slp_discoverty` element, Agama does not support [SLP] at all?
 | install_updates                  | Never     |                           |                                      |
 | reg_code                         | Yes       | product.registrationCode  |                                      |
 | reg_server                       | Planned   |                           |                                      |
-| reg_server_cert                  | Undecided |                           | It is not clear how addons will work |
+| reg_server_cert                  | Planned   |                           |                                      |
 | reg_server_cert_fingerprint      | Planned   |                           |                                      |
 | reg_server_cert_fingerprint_type | Planned   |                           |                                      |
+| addons                           | Undecided |                           | It is not clear how addons will work |
 | slp_discovery                    | No        |                           |                                      |
 
 ### `timezone`

--- a/doc/autoyast.md
+++ b/doc/autoyast.md
@@ -126,10 +126,28 @@ For the first user, the following elements are supported:
 | user_password        | Yes       | password |                        |
 | username             | Yes       | userName |                        |
 
-### `keyboard`, `language` and `timezone`
+### `keyboard`
 
-These sections are rather simple, but we need to do some mapping between AutoYaST and Agama values.
-Additionally, the `hwclock` element is not present in Agama.
+Only the `keymap` element is translated. The rest of options are ignored in YaST and they are not
+even documented in the AutoYaST handbook.
+
+| AutoYaST | Supported  | Agama         | Comment                        |
+| -------- | ---------- | ------------- | ------------------------------ |
+| keymap   | Yes        | l10n.keyboard | Should we rename it to keymap? |
+| capslock | Deprecated |               |                                |
+| delay    | Deprecated |               |                                |
+| discaps  | Deprecated |               |                                |
+| numlock  | Deprecated |               |                                |
+| rate     | Deprecated |               |                                |
+| scrlock  | Deprecated |               |                                |
+| tty      | Deprecated |               |                                |
+
+### `language`
+
+| AutoYaST  | Supported | Agama          | Comment                   |
+| --------- | --------- | -------------- | ------------------------- |
+| language  | Yes       | l10n.languages | First element of the list |
+| languages | Yes       | l10n.languages |                           |
 
 ### `networking`
 
@@ -227,6 +245,13 @@ It is arguable whether we should offer a `install_updates` element instead of ju
 About the `slp_discoverty` element, Agama does not support [SLP] at all?
 
 [SLP]: https://documentation.suse.com/sles/15-SP5/single-html/SLES-administration/#cha-slp
+
+### `timezone`
+
+| AutoYaST | Supported | Agama         | Comment |
+| -------- | --------- | ------------- | ------- |
+| timezone | Yes       | l10n.timezone |         |
+| hwclock  | No        |               |         |
 
 ## Unsupported sections
 

--- a/doc/autoyast.md
+++ b/doc/autoyast.md
@@ -1,11 +1,10 @@
 # AutoYaST Support
 
 Agama offers a mechanism to perform [unattended installations](../autoinstallation/). However, we
-would like AutoYaST users to be able to use their AutoYaST profiles in Agama. This document
-describes how Agama could support, to some extent, such profiles.
+would like AutoYaST users to be able to use their profiles in Agama. This document describes how
+Agama could support, to some extent, such profiles.
 
-Bear in mind that this document is just a draft and our plans could change once we start working on
-the implementation.
+Bear in mind that it is a living document and our plans could change as we progress.
 
 ## What to support
 
@@ -74,6 +73,18 @@ About "ask lists", there might need more work. Fortunately, the code to [parse][
 
 ## Supported sections
 
+Let's describe which sections and elements from an AutoYaST profile are (or will be) supported in
+Agama. In some cases, you might find a table with the following columns:
+
+- AutoYaST: name of the AutoYaST element.
+- Supported: whether it is (or will be) supported. The meaning of each value is:
+  - Yes: fully supported.
+  - Planned: not supported yet, but there are plans to support it.
+  - Undecided: no decision about whether it should be supported.
+  - No: there are not plans for supporting that element.
+- Agama: name of the Agama element.
+- Comment: any comment or reason about the element.
+
 ### `dasd` and `iscsi-client`
 
 Support for iSCSI and DASD devices is missing in Agama profiles. Let's work on that when adding the
@@ -110,8 +121,8 @@ For the first user, the following elements are supported:
 
 | AutoYaST             | Supported | Agama    | Comment                |
 | -------------------- | --------- | -------- | ---------------------- |
-| authorized_keys      | No        |          | Only for the root user |
-| encrypted            | No        |          |                        |
+| authorized_keys      | Planned   |          | Only for the root user |
+| encrypted            | Planned   |          |                        |
 | forename             | No        |          |                        |
 | fullname             | Yes       | fullName |                        |
 | gid                  | No        |          |                        |
@@ -131,16 +142,16 @@ For the first user, the following elements are supported:
 Only the `keymap` element is translated. The rest of options are ignored in YaST and they are not
 even documented in the AutoYaST handbook.
 
-| AutoYaST | Supported  | Agama         | Comment                        |
-| -------- | ---------- | ------------- | ------------------------------ |
-| keymap   | Yes        | l10n.keyboard | Should we rename it to keymap? |
-| capslock | Deprecated |               |                                |
-| delay    | Deprecated |               |                                |
-| discaps  | Deprecated |               |                                |
-| numlock  | Deprecated |               |                                |
-| rate     | Deprecated |               |                                |
-| scrlock  | Deprecated |               |                                |
-| tty      | Deprecated |               |                                |
+| AutoYaST | Supported | Agama         | Comment                        |
+| -------- | --------- | ------------- | ------------------------------ |
+| keymap   | Yes       | l10n.keyboard | Should we rename it to keymap? |
+| capslock | No        |               | Deprecated                     |
+| delay    | No        |               | Deprecated                     |
+| discaps  | No        |               | Deprecated                     |
+| numlock  | No        |               | Deprecated                     |
+| rate     | No        |               | Deprecated                     |
+| scrlock  | No        |               | Deprecated                     |
+| tty      | No        |               | Deprecated                     |
 
 ### `language`
 
@@ -156,55 +167,55 @@ The `networking` section in AutoYaST is composed of several sections: `dns`, `in
 connections that could correspond with the AutoYaST interfaces list. We might need to extend Agama
 to support `dns`, `net-udev`, etc.
 
-| AutoYaST                | Supported | Agama       | Comment                           |
-| ----------------------- | --------- | ----------- | --------------------------------- |
-| backend                 | No        |             | No plan for additional backends   |
-| dhcp_options            | No        |             |                                   |
-| dns                     | Partial   |             | Included in connections           |
-| interfaces              | Partial   | connections | Check the connections table below |
-| ipv6                    | Never     |             |                                   |
-| keep_install_network    | Never     |             |                                   |
-| managed                 | Never     |             |                                   |
-| modules                 | No        |             |                                   |
-| net-udev                | No        |             |                                   |
-| routing                 | Partial   |             | Included in connections           |
-| s390-devices            | No        |             |                                   |
-| setup_before_proposal   | Never     |             |                                   |
-| strict_IP_check_timeout | Never     |             |                                   |
-| virt_brige_proposal     | No        |             |                                   |
+| AutoYaST                | Supported | Agama       | Comment                            |
+| ----------------------- | --------- | ----------- | ---------------------------------- |
+| backend                 | No        |             | No plan for additional backends    |
+| dhcp_options            | No        |             |                                    |
+| dns                     | Partial   |             | Included in connections            |
+| interfaces              | Partial   | connections | Check the connections table below  |
+| ipv6                    | Yes       |             | It affects `method4` and `method6` |
+| keep_install_network    | No        |             |                                    |
+| managed                 | No        |             |                                    |
+| modules                 | No        |             |                                    |
+| net-udev                | No        |             |                                    |
+| routing                 | Planned   |             |                                    |
+| s390-devices            | Planned   |             |                                    |
+| setup_before_proposal   | No        |             |                                    |
+| strict_IP_check_timeout | No        |             |                                    |
+| virt_brige_proposal     | No        |             |                                    |
 
 As seen in the table above, AutoYaST `interfaces` corresponds with Agama `connections`, but the
 format is not exactly the same.
 
-| AutoYaST                   | Supported  | Agama      | Comment                                 |
-| -------------------------- | ---------- | ---------- | --------------------------------------- |
-| device                     | Yes        | interface  |                                         |
-| name                       | Yes        | id         |                                         |
-| description                | Deprecated |            |                                         |
-| bootproto                  | Yes        | method4    |                                         |
-| startmode                  | Never      |            | Do not set up connections you won't use |
-| lladdr                     | Yes        | macAddress |                                         |
-| ifplugd_priority           | Never      |            | Not relevant (no ifplugd support)       |
-| usercontrol                | Never      |            |                                         |
-| dhclient_set_hostname      | No         |            |                                         |
-| ipaddr                     | Yes        | addresses  |                                         |
-| prefixlen                  | Yes        | addresses  | Part of `addresses`                     |
-| remote_ipaddr              | No         |            |                                         |
-| netmask                    | Yes        | addresses  | Part of `addresses`                     |
-| bonding_*                  | Yes        | bond       | Use a different format to define bonds  |
-| aliases                    | Yes        |            | Part of `addresses`                     |
-| broadcast                  | Deprecated |            | Part of `addresses`                     |
-| network                    | Deprecated |            | Part of `addresses`                     |
-| mtu                        | No         |            |                                         |
-| ethtool_options            | No         |            |                                         |
-| wireless                   | Yes        | wireless   | It uses a different format              |
-| wifi_settings              | Partial    | wireless   | It uses a different format              |
-| bridge_settings            | Planned    |            |                                         |
-| vlan_settings              | Planned    |            |                                         |
-| dhclient_set_down_link     | No         |            |                                         |
-| dhclient_set_default_route | No         |            |                                         |
-| zone                       | No         |            |                                         |
-| firewall                   | No         |            |                                         |
+| AutoYaST                   | Supported | Agama       | Comment                                 |
+| -------------------------- | --------- | ----------- | --------------------------------------- |
+| device                     | Yes       | interface   |                                         |
+| name                       | Yes       | id          |                                         |
+| description                | No        |             |                                         |
+| bootproto                  | Partial   | method{4,6} | Different set of values                 |
+| startmode                  | No        |             | Do not set up connections you won't use |
+| lladdr                     | Yes       | macAddress  |                                         |
+| ifplugd_priority           | No        |             | Not relevant (no ifplugd support)       |
+| usercontrol                | No        |             |                                         |
+| dhclient_set_hostname      | No        |             |                                         |
+| ipaddr                     | Yes       | addresses   |                                         |
+| prefixlen                  | Yes       | addresses   | Part of `addresses`                     |
+| remote_ipaddr              | Undecided |             |                                         |
+| netmask                    | Yes       | addresses   | Part of `addresses`                     |
+| bonding_*                  | Yes       | bond        | Use a different format to define bonds  |
+| aliases                    | Yes       |             | Part of `addresses`                     |
+| broadcast                  | No        |             | Part of `addresses`                     |
+| network                    | No        |             | Part of `addresses`                     |
+| mtu                        | Undecided |             |                                         |
+| ethtool_options            | Undecided |             |                                         |
+| wireless                   | Yes       | wireless    | It uses a different format              |
+| wifi_settings              | Partial   | wireless    | It uses a different format              |
+| bridge_settings            | Planned   |             |                                         |
+| vlan_settings              | Planned   |             |                                         |
+| dhclient_set_down_link     | No        |             |                                         |
+| dhclient_set_default_route | No        |             |                                         |
+| zone                       | No        |             |                                         |
+| firewall                   | No        |             |                                         |
 
 #### Wireless connections
 
@@ -214,24 +225,24 @@ Agama, the options are placed under a `wireless` key.
 | AutoYaST                     | Supported | Agama    | Comment                 |
 | ---------------------------- | --------- | -------- | ----------------------- |
 | wireless_auth_mode           | Partial   | security | Different set of values |
-| wireless_ap                  | No        |          |                         |
-| wireless_bitrate             | No        |          |                         |
-| wireless_ca_cert             | No        |          |                         |
-| wireless_channel             | No        |          |                         |
-| wireless_client_cert         | No        |          |                         |
-| wireless_client_key          | No        |          |                         |
-| wireless_client_key_password | No        |          |                         |
-| wireless_default_key         | No        |          |                         |
-| wireless_eap_auth            | No        |          |                         |
-| wireless_eap_mode            | No        |          |                         |
+| wireless_ap                  | Undecided |          |                         |
+| wireless_bitrate             | Undecided |          |                         |
+| wireless_ca_cert             | Undecided |          |                         |
+| wireless_channel             | Undecided |          |                         |
+| wireless_client_cert         | Undecided |          |                         |
+| wireless_client_key          | Undecided |          |                         |
+| wireless_client_key_password | Undecided |          |                         |
+| wireless_default_key         | Undecided |          |                         |
+| wireless_eap_auth            | Undecided |          |                         |
+| wireless_eap_mode            | Undecided |          |                         |
 | wireless_essid               | Yes       | ssid     |                         |
-| wireless_frequency           | No        |          |                         |
-| wireless_key                 | No        |          |                         |
-| wireless_key_0               | No        |          |                         |
-| wireless_key_1               | No        |          |                         |
-| wireless_key_2               | No        |          |                         |
-| wireless_key_3               | No        |          |                         |
-| wireless_key_length          | No        |          |                         |
+| wireless_frequency           | Undecided |          |                         |
+| wireless_key                 | Undecided |          |                         |
+| wireless_key_0               | Undecided |          |                         |
+| wireless_key_1               | Undecided |          |                         |
+| wireless_key_2               | Undecided |          |                         |
+| wireless_key_3               | Undecided |          |                         |
+| wireless_key_length          | Undecided |          |                         |
 | wireless_mode                | Partial   | mode     | Different set of values |
 | wireless_nick                | No        |          |                         |
 | wireless_nwid                | No        |          |                         |
@@ -347,18 +358,18 @@ web UI.
 
 | AutoYaST            | Supported | Agama             | Comment                           |
 | ------------------- | --------- | ----------------- | --------------------------------- |
-| do_online_update    | Never     |                   | No 2nd stage                      |
+| do_online_update    | No        |                   | No 2nd stage                      |
 | install_recommended | No        |                   |                                   |
 | instsource          | No        |                   |                                   |
 | kernel              | No        |                   |                                   |
 | packages            | No        |                   |                                   |
 | patterns            | Partial   | software.patterns | No support for regular expresions |
-| post-packages       | Never     |                   | No 2nd stage                      |
-| post-patterns       | Never     |                   | No 2nd stage                      |
+| post-packages       | No        |                   | No 2nd stage                      |
+| post-patterns       | No        |                   | No 2nd stage                      |
 | products            | Yes       | software.id       |                                   |
-| remove-packages     | Never     |                   | No upgrade                        |
-| remove-patterns     | Never     |                   | No upgrade                        |
-| remove-products     | Never     |                   | No upgrade                        |
+| remove-packages     | No        |                   | No upgrade                        |
+| remove-patterns     | No        |                   | No upgrade                        |
+| remove-products     | No        |                   | No upgrade                        |
 
 ### `suse_register`
 
@@ -372,17 +383,17 @@ About the `slp_discoverty` element, Agama does not support [SLP] at all?
 
 [SLP]: https://documentation.suse.com/sles/15-SP5/single-html/SLES-administration/#cha-slp
 
-| AutoYaST                         | Supported | Agama                     | Comment                                         |
-| -------------------------------- | --------- | ------------------------- | ----------------------------------------------- |
-| do_registration                  | Never     |                           | The system is registered if there is a reg code |
-| email                            | Yes       | product.registrationEmail |                                                 |
-| install_updates                  | Never     |                           |                                                 |
-| reg_code                         | Yes       | product.registrationCode  |                                                 |
-| reg_server                       | Planned   |                           |                                                 |
-| reg_server_cert                  | Undecided |                           | It is not clear how addons will work            |
-| reg_server_cert_fingerprint      | Planned   |                           |                                                 |
-| reg_server_cert_fingerprint_type | Planned   |                           |                                                 |
-| slp_discovery                    | Never     |                           |                                                 |
+| AutoYaST                         | Supported | Agama                     | Comment                              |
+| -------------------------------- | --------- | ------------------------- | ------------------------------------ |
+| do_registration                  | Yes       |                           | The section is ignored if `false`    |
+| email                            | Yes       | product.registrationEmail |                                      |
+| install_updates                  | Never     |                           |                                      |
+| reg_code                         | Yes       | product.registrationCode  |                                      |
+| reg_server                       | Planned   |                           |                                      |
+| reg_server_cert                  | Undecided |                           | It is not clear how addons will work |
+| reg_server_cert_fingerprint      | Planned   |                           |                                      |
+| reg_server_cert_fingerprint_type | Planned   |                           |                                      |
+| slp_discovery                    | No        |                           |                                      |
 
 ### `timezone`
 

--- a/doc/autoyast.md
+++ b/doc/autoyast.md
@@ -99,6 +99,33 @@ groups plus some authentication settings. We have at least two options here:
   This behavior is already implemented.
 - Import these sections as given because they are handled by the YaST code in Agama.
 
+| AutoYaST | Supported | Agama | Comment                                      |
+| -------- | --------- | ----- | -------------------------------------------- |
+| groups   | No        |       | It is not planned, but we should consider    |
+| users    | No        |       | It is not planned, but we should consider    |
+|          |           | root  | Root user (only password and SSH public key) |
+|          |           | user  | First non-system user from "users"           |
+
+For the first user, the following elements are supported:
+
+| AutoYaST             | Supported | Agama    | Comment                |
+| -------------------- | --------- | -------- | ---------------------- |
+| authorized_keys      | No        |          | Only for the root user |
+| encrypted            | No        |          |                        |
+| forename             | No        |          |                        |
+| fullname             | Yes       | fullName |                        |
+| gid                  | No        |          |                        |
+| group                | No        |          |                        |
+| groups               | No        |          |                        |
+| home                 | No        |          |                        |
+| home_btrfs_subvolume | No        |          |                        |
+| password_settings    | No        |          |                        |
+| shell                | No        |          |                        |
+| surname              | No        |          |                        |
+| uid                  | No        |          |                        |
+| user_password        | Yes       | password |                        |
+| username             | Yes       | userName |                        |
+
 ### `keyboard`, `language` and `timezone`
 
 These sections are rather simple, but we need to do some mapping between AutoYaST and Agama values.

--- a/doc/autoyast.md
+++ b/doc/autoyast.md
@@ -152,14 +152,140 @@ even documented in the AutoYaST handbook.
 ### `networking`
 
 The `networking` section in AutoYaST is composed of several sections: `dns`, `interfaces`,
-`net-udev`, `routing` and `s390-devices`. Additionally, other elements like `ipv6` or
-`keep_install_network` might need some level of support.
+`net-udev`, `routing` and `s390-devices`. At this point, Agama only supports defining a list of
+connections that could correspond with the AutoYaST interfaces list. We might need to extend Agama
+to support `dns`, `net-udev`, etc.
 
-At this point, Agama only supports defining a list of connections that could correspond with the
-AutoYaST interfaces list. We might need to extend Agama to support `dns`, `net-udev`, etc.
+| AutoYaST                | Supported | Agama       | Comment                           |
+| ----------------------- | --------- | ----------- | --------------------------------- |
+| backend                 | No        |             | No plan for additional backends   |
+| dhcp_options            | No        |             |                                   |
+| dns                     | Partial   |             | Included in connections           |
+| interfaces              | Partial   | connections | Check the connections table below |
+| ipv6                    | Never     |             |                                   |
+| keep_install_network    | Never     |             |                                   |
+| managed                 | Never     |             |                                   |
+| modules                 | No        |             |                                   |
+| net-udev                | No        |             |                                   |
+| routing                 | Partial   |             | Included in connections           |
+| s390-devices            | No        |             |                                   |
+| setup_before_proposal   | Never     |             |                                   |
+| strict_IP_check_timeout | Never     |             |                                   |
+| virt_brige_proposal     | No        |             |                                   |
 
-About `keep_install_network` and `setup_before_proposal`, we should not implement them to keep
-things simple.
+As seen in the table above, AutoYaST `interfaces` corresponds with Agama `connections`, but the
+format is not exactly the same.
+
+| AutoYaST                   | Supported  | Agama      | Comment                                 |
+| -------------------------- | ---------- | ---------- | --------------------------------------- |
+| device                     | Yes        | interface  |                                         |
+| name                       | Yes        | id         |                                         |
+| description                | Deprecated |            |                                         |
+| bootproto                  | Yes        | method4    |                                         |
+| startmode                  | Never      |            | Do not set up connections you won't use |
+| lladdr                     | Yes        | macAddress |                                         |
+| ifplugd_priority           | Never      |            | Not relevant (no ifplugd support)       |
+| usercontrol                | Never      |            |                                         |
+| dhclient_set_hostname      | No         |            |                                         |
+| ipaddr                     | Yes        | addresses  |                                         |
+| prefixlen                  | Yes        | addresses  | Part of `addresses`                     |
+| remote_ipaddr              | No         |            |                                         |
+| netmask                    | Yes        | addresses  | Part of `addresses`                     |
+| bonding_*                  | Yes        | bond       | Use a different format to define bonds  |
+| aliases                    | Yes        |            | Part of `addresses`                     |
+| broadcast                  | Deprecated |            | Part of `addresses`                     |
+| network                    | Deprecated |            | Part of `addresses`                     |
+| mtu                        | No         |            |                                         |
+| ethtool_options            | No         |            |                                         |
+| wireless                   | Yes        | wireless   | It uses a different format              |
+| wifi_settings              | Partial    | wireless   | It uses a different format              |
+| bridge_settings            | Planned    |            |                                         |
+| vlan_settings              | Planned    |            |                                         |
+| dhclient_set_down_link     | No         |            |                                         |
+| dhclient_set_default_route | No         |            |                                         |
+| zone                       | No         |            |                                         |
+| firewall                   | No         |            |                                         |
+
+#### Wireless connections
+
+Setting up a wireless connection in AutoYaST is not even documented, although it is possible. In
+Agama, the options are placed under a `wireless` key.
+
+| AutoYaST                     | Supported | Agama    | Comment                 |
+| ---------------------------- | --------- | -------- | ----------------------- |
+| wireless_auth_mode           | Partial   | security | Different set of values |
+| wireless_ap                  | No        |          |                         |
+| wireless_bitrate             | No        |          |                         |
+| wireless_ca_cert             | No        |          |                         |
+| wireless_channel             | No        |          |                         |
+| wireless_client_cert         | No        |          |                         |
+| wireless_client_key          | No        |          |                         |
+| wireless_client_key_password | No        |          |                         |
+| wireless_default_key         | No        |          |                         |
+| wireless_eap_auth            | No        |          |                         |
+| wireless_eap_mode            | No        |          |                         |
+| wireless_essid               | Yes       | ssid     |                         |
+| wireless_frequency           | No        |          |                         |
+| wireless_key                 | No        |          |                         |
+| wireless_key_0               | No        |          |                         |
+| wireless_key_1               | No        |          |                         |
+| wireless_key_2               | No        |          |                         |
+| wireless_key_3               | No        |          |                         |
+| wireless_key_length          | No        |          |                         |
+| wireless_mode                | Partial   | mode     | Different set of values |
+| wireless_nick                | No        |          |                         |
+| wireless_nwid                | No        |          |                         |
+| wireless_peap_version        | No        |          |                         |
+| wireless_power               | No        |          |                         |
+| wireless_wpa_anonid          | No        |          |                         |
+| wireless_wpa_identity        | No        |          |                         |
+| wireless_wpa_password        | Yes       | password |                         |
+| wireless_wpa_psk             | Yes       | password |                         |
+
+#### Bonding connections
+
+The AutoYaST `bonding*` elements allow setting up a bonding interface. In Agama, those settings are
+placed under a `bond` key in the `connection` structure.
+
+| AutoYaST            | Supported | Agama   | Comment                       |
+| ------------------- | --------- | ------- | ----------------------------- |
+| bonding_master      | Yes       |         | The master defines the `bond` |
+| bonding_slaveX      | Yes       | ports   |                               |
+| bonding_module_opts | Yes       | options |                               |
+| -                   |           | mode    | Specific key to set the mode  |
+
+Agama includes an specific `mode` options to set the mode, instead of abusing the
+`bonding_module_opts`.
+
+### Bridge connections
+
+> [!WARNING]
+> Bridge support is not implemented yet, although we have support at model level.
+
+The AutoYaST `bridge*` elements allow setting up a bridge. In Agama, those settings are placed under
+a `bridge` key in the `connection` structure.
+
+| AutoYaST             | Supported | Agama         | Comment                                 |
+| -------------------- | --------- | ------------- | --------------------------------------- |
+| bridge               | Planned   |               | An existing `bridge` key means the same |
+| bridge_ports         | Planned   | ports         |                                         |
+| bridge_stp           | Planned   | stp           |                                         |
+| bridge_forward_delay | Planned   | forward_delay |                                         |
+| bridge_forwarddelay  | Planned   | forward_delay | Compatibility bsc#1180944               |
+
+### VLAN
+
+> [!WARNING]
+> VLAN support is not implemented yet, although we have support at model level.
+
+The AutoYaST `vlan_settings` elements allow setting up a bridge. In Agama, those settings are placed
+under a `vlan` key in the `connection` structure.
+
+| AutoYaST    | Supported | Agama    | Comment |
+| ----------- | --------- | -------- | ------- |
+| vlan_id     | Planned   | id       |         |
+| etherdevice | Planned   | parent   |         |
+| -           | Planned   | protocol |         |
 
 ### `partitioning`
 

--- a/doc/autoyast.md
+++ b/doc/autoyast.md
@@ -174,6 +174,21 @@ Only the product and the list of products or patterns are available for Agama. W
 adding support for the packages list and the `install_recommended` setting, although none are in the
 web UI.
 
+| AutoYaST            | Supported | Agama             | Comment                           |
+| ------------------- | --------- | ----------------- | --------------------------------- |
+| do_online_update    | Never     |                   | No 2nd stage                      |
+| install_recommended | No        |                   |                                   |
+| instsource          | No        |                   |                                   |
+| kernel              | No        |                   |                                   |
+| packages            | No        |                   |                                   |
+| patterns            | Partial   | software.patterns | No support for regular expresions |
+| post-packages       | Never     |                   | No 2nd stage                      |
+| post-patterns       | Never     |                   | No 2nd stage                      |
+| products            | Yes       | software.id       |                                   |
+| remove-packages     | Never     |                   | No upgrade                        |
+| remove-patterns     | Never     |                   | No upgrade                        |
+| remove-products     | Never     |                   | No upgrade                        |
+
 ### `suse_register`
 
 Basic support for registering in the SUSE Customer Center is already in place, although there is no

--- a/service/lib/agama/autoyast/bond_reader.rb
+++ b/service/lib/agama/autoyast/bond_reader.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2network/wireless_auth_mode"
+require "y2network/wireless_mode"
+
+# :nodoc:
+module Agama
+  module AutoYaST
+    # Extracts the bonding information from an AutoYaST interface section.
+    class BondReader
+      # @param section [Y2Network::AutoinstProfile::InterfaceSection]
+      def initialize(section)
+        @section = section
+      end
+
+      # Return a hash that corresponds to Agama's bond section
+      #
+      # @return [Hash]
+      def read
+        bond = {}
+
+        ports = read_ports
+        bond["ports"] = ports unless ports.empty?
+
+        mode = read_mode
+        bond["mode"] = mode unless mode.nil?
+
+        options = read_options
+        bond["options"] = options unless options.to_s.empty?
+
+        return {} if bond.empty?
+
+        { "bond" => bond }
+      end
+
+    private
+
+      attr_reader :section
+
+      def read_ports
+        (0..9).map { |i| section.send("bonding_slave#{i}").to_s }.reject(&:empty?)
+      end
+
+      def read_mode
+        options = section.bonding_module_opts.to_s
+        return nil if options.empty?
+
+        options[/mode=\S+/].split("=").last
+      end
+
+      def read_options
+        options = section.bonding_module_opts.to_s
+        return nil if options.empty?
+
+        options.gsub(/mode=\S+\ ?/, "")
+      end
+    end
+  end
+end

--- a/service/lib/agama/autoyast/bond_reader.rb
+++ b/service/lib/agama/autoyast/bond_reader.rb
@@ -27,14 +27,18 @@ require "y2network/wireless_mode"
 # :nodoc:
 module Agama
   module AutoYaST
-    # Extracts the bonding information from an AutoYaST interface section.
+    # Builds an Agama "bond" section from an AutoYaST InterfaceSection.
     class BondReader
-      # @param section [Y2Network::AutoinstProfile::InterfaceSection]
+      # @param section [Y2Network::AutoinstProfile::InterfaceSection] Interface section
+      #   Section to extract the information from
       def initialize(section)
         @section = section
       end
 
-      # Return a hash that corresponds to Agama's bond section
+      # Returns a hash that corresponds to Agama "bond" section
+      #
+      # The result could include "ports", "mode" and "options" keys. If there is
+      # no bonding information, it returns an empty hash.
       #
       # @return [Hash]
       def read
@@ -58,10 +62,16 @@ module Agama
 
       attr_reader :section
 
+      # Reads the bonding ports.
+      #
+      # @return [Array<String>]
       def read_ports
         (0..9).map { |i| section.send("bonding_slave#{i}").to_s }.reject(&:empty?)
       end
 
+      # Extracts the `mode` from the kernel module options.
+      #
+      # @return [String, nil]
       def read_mode
         options = section.bonding_module_opts.to_s
         return nil if options.empty?
@@ -69,6 +79,9 @@ module Agama
         options[/mode=\S+/].split("=").last
       end
 
+      # Reads the kernel module options removing the `mode` option
+      #
+      # @return [String, nil]
       def read_options
         options = section.bonding_module_opts.to_s
         return nil if options.empty?

--- a/service/lib/agama/autoyast/connections_reader.rb
+++ b/service/lib/agama/autoyast/connections_reader.rb
@@ -1,0 +1,145 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2network/boot_protocol"
+require "y2network/ip_address"
+require "agama/autoyast/bond_reader"
+require "agama/autoyast/wireless_reader"
+require "ipaddr"
+
+# :nodoc:
+module Agama
+  module AutoYaST
+    # Extracts the network information from an AutoYaST profile.
+    class ConnectionsReader
+      # @param section [Y2Network::AutoinstProfile::Interfaces]
+      def initialize(section, ipv6: false)
+        @section = section
+        @ipv6 = ipv6
+      end
+
+      # Converts an AutoYaST interfaces into Agama network connections.
+      #
+      # @return [Hash] Agama "user" section
+      def read
+        interfaces = section.interfaces
+        return {} if interfaces.empty?
+
+        connections = interfaces.map { |i| read_connection(i) }
+        { "connections" => connections }
+      end
+
+    private
+
+      attr_reader :section
+
+      def ipv6?
+        @ipv6
+      end
+
+      # Reads an AutoYaST interface entry and builds its corresponding connection.
+      #
+      # @return [Y2Network::AutoinstProfile::InterfaceSection]
+      def read_connection(interface)
+        conn = {}
+        conn["device"] = interface.device if interface.device
+        conn["id"] = interface.name if interface.name
+
+        addresses = read_addresses(interface)
+        method4, method6 = read_methods(interface)
+        conn["method4"] = method4
+        conn["method6"] = method6
+        conn["addresses"] = addresses
+        wireless = Agama::AutoYaST::WirelessReader.new(interface).read
+        conn["wireless"] = wireless unless wireless.empty?
+        bond = Agama::AutoYaST::BondReader.new(interface).read
+        conn["bond"] = bond unless bond.empty?
+
+        conn
+      end
+
+      # @param networking [Y2Network::AutoinstProfile::NetworkingSection]
+      # @return [Array<Hash>]
+      def read_addresses(interface)
+        addresses = []
+        if !interface.ipaddr.to_s.empty?
+          primary = ipaddress_from(interface.ipaddr, interface.prefixlen, interface.netmask)
+          addresses.push(primary) if primary
+        end
+
+        secondary = interface.aliases.map { |a| ipaddress_from(a.ipaddr, a.prefixlen, a.netmask) }
+        addresses.concat(secondary)
+      end
+
+      # @return [IPAddress]
+      def ipaddress_from(address, prefix, netmask)
+        ipaddr = Y2Network::IPAddress.from_string(address)
+
+        # Assign first netmask, as prefix has precedence so it will overwrite it
+        ipaddr.prefix = prefix_for(netmask) if !netmask.to_s.empty?
+        ipaddr.prefix = prefix_for(prefix) if !prefix.to_s.empty?
+
+        ipaddr
+      rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
+        nil
+      end
+
+      # @param interface [Y2Network::AutoinstProfile::InterfaceSection]
+      # @return [String, String] method4 and method6 values
+      def read_methods(interface)
+        bootproto = Y2Network::BootProtocol.from_name(interface.bootproto)
+        case bootproto
+        when Y2Network::BootProtocol::DHCP4
+          ["auto", "disabled"]
+        when Y2Network::BootProtocol::DHCP6
+          ["disabled", "auto"]
+        when Y2Network::BootProtocol::STATIC
+          ["manual", ipv6? ? "manual" : "disabled"]
+        when Y2Network::BootProtocol::NONE
+          ["disabled", "disabled"]
+        else
+          ["auto", ipv6? ? "auto" : "disabled"]
+        end
+      end
+
+      # Converts a given IP Address netmask or prefix length in different
+      # formats to its prefix length value.
+      #
+      # @param value [String] IP Address prefix length or netmask in its different formats
+      # @return [Integer,nil] the given value in IP Address prefix length
+      #   format
+      # Taken from Y2Network::Autoinst::InterfacesReader
+      def prefix_for(value)
+        if value.empty?
+          nil
+        elsif value.start_with?("/")
+          value[1..-1].to_i
+        elsif value =~ /^\d{1,3}$/
+          value.to_i
+        else
+          IPAddr.new("#{value}/#{value}").prefix
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/autoyast/converter.rb
+++ b/service/lib/agama/autoyast/converter.rb
@@ -23,6 +23,7 @@
 require "yast"
 require "autoinstall/script_runner"
 require "autoinstall/script"
+require "agama/autoyast/l10n_reader"
 require "agama/autoyast/product_reader"
 require "agama/autoyast/root_reader"
 require "agama/autoyast/software_reader"
@@ -119,6 +120,7 @@ module Agama
         root = Agama::AutoYaST::RootReader.new(profile)
         software = Agama::AutoYaST::SoftwareReader.new(profile)
         product = Agama::AutoYaST::ProductReader.new(profile)
+        l10n = Agama::AutoYaST::L10nReader.new(profile)
         storage = Agama::AutoYaST::StorageReader.new(profile)
 
         user.read
@@ -126,6 +128,7 @@ module Agama
           .merge(software.read)
           .merge(product.read)
           .merge(storage.read)
+          .merge(l10n.read)
       end
 
       def import_yast

--- a/service/lib/agama/autoyast/converter.rb
+++ b/service/lib/agama/autoyast/converter.rb
@@ -114,21 +114,22 @@ module Agama
         )
       end
 
+      # Sections which have a corresponding reader. The reader is expected to be
+      # named in Pascal case and adding "Reader" as suffix (e.g., "L10nReader").
+      SECTIONS = ["l10n", "product", "root", "software", "storage", "user"].freeze
+
+      # Builds the Agama profile
+      #
+      # It goes through the list of READERS and merges the results of all of them.
+      #
       # @return [Hash] Agama profile
       def export_profile(profile)
-        user = Agama::AutoYaST::UserReader.new(profile)
-        root = Agama::AutoYaST::RootReader.new(profile)
-        software = Agama::AutoYaST::SoftwareReader.new(profile)
-        product = Agama::AutoYaST::ProductReader.new(profile)
-        l10n = Agama::AutoYaST::L10nReader.new(profile)
-        storage = Agama::AutoYaST::StorageReader.new(profile)
-
-        user.read
-          .merge(root.read)
-          .merge(software.read)
-          .merge(product.read)
-          .merge(storage.read)
-          .merge(l10n.read)
+        SECTIONS.reduce({}) do |result, section|
+          require "agama/autoyast/#{section}_reader"
+          klass = "#{section}_reader".split("_").map(&:capitalize).join
+          reader = Agama::AutoYaST.const_get(klass).new(profile)
+          result.merge(reader.read)
+        end
       end
 
       def import_yast

--- a/service/lib/agama/autoyast/l10n_reader.rb
+++ b/service/lib/agama/autoyast/l10n_reader.rb
@@ -26,13 +26,17 @@ require "yast"
 module Agama
   # :nodoc:
   module AutoYaST
-    # Extracts the localization information from an AutoYaST profile.
+    # Builds an Agama "l10n" section from an AutoYaST profile.
     class L10nReader
       # @param profile [ProfileHash] AutoYaST profile
       def initialize(profile)
         @profile = profile
       end
 
+      # Returns a hash to corresponds to Agama "l10n" section
+      #
+      # If there is no l10n information, it returns an empty hash.
+      #
       # @return [Hash] Agama "l10n" section
       def read
         l10n = keyboard

--- a/service/lib/agama/autoyast/l10n_reader.rb
+++ b/service/lib/agama/autoyast/l10n_reader.rb
@@ -1,0 +1,81 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+# :nodoc:
+module Agama
+  # :nodoc:
+  module AutoYaST
+    # Extracts the localization information from an AutoYaST profile.
+    class L10nReader
+      # @param profile [ProfileHash] AutoYaST profile
+      def initialize(profile)
+        @profile = profile
+      end
+
+      # @return [Hash] Agama "l10n" section
+      def read
+        l10n = keyboard
+          .merge(languages)
+          .merge(timezone)
+        l10n.empty? ? {} : { "l10n" => l10n }
+      end
+
+    private
+
+      attr_reader :profile
+
+      def keyboard
+        section = profile.fetch_as_hash("keyboard")
+        keymap = section["keymap"]
+        return {} if keymap.nil?
+
+        { "keyboard" => keymap.to_s }
+      end
+
+      def languages
+        section = profile.fetch_as_hash("language")
+        primary = section["language"]
+        secondary = section["languages"].to_s.split(",").map(&:strip)
+
+        languages = []
+        languages.push(primary.to_s) unless primary.nil?
+        languages.concat(secondary)
+
+        with_encoding = languages.map do |lang|
+          lang.include?(".") ? lang : "#{lang}.UTF-8"
+        end
+
+        with_encoding.empty? ? {} : { "languages" => with_encoding.uniq }
+      end
+
+      def timezone
+        section = profile.fetch_as_hash("timezone")
+        timezone = section["timezone"]
+        return {} if timezone.nil?
+
+        { "timezone" => timezone.to_s }
+      end
+    end
+  end
+end

--- a/service/lib/agama/autoyast/network_reader.rb
+++ b/service/lib/agama/autoyast/network_reader.rb
@@ -22,11 +22,7 @@
 
 require "yast"
 require "y2network/autoinst_profile/networking_section"
-require "y2network/boot_protocol"
-require "y2network/ip_address"
-require "agama/autoyast/bond_reader"
-require "agama/autoyast/wireless_reader"
-require "ipaddr"
+require "agama/autoyast/connections_reader"
 
 # :nodoc:
 module Agama
@@ -43,115 +39,22 @@ module Agama
         networking = profile.fetch_as_hash("networking")
         return {} if networking.empty?
 
-        network = {}
         section = Y2Network::AutoinstProfile::NetworkingSection.new_from_hashes(networking)
-        connections = read_connections(section)
-        network["connections"] = connections unless connections.empty?
-        { "network" => network }
+        connections_reader = Agama::AutoYaST::ConnectionsReader.new(
+          section.interfaces, ipv6: ipv6?
+        )
+        connections = connections_reader.read
+        return {} if connections.empty?
+
+        { "network" => connections }
       end
 
     private
 
       attr_reader :profile
 
-      # Converts a list of AutoYaST interfaces into Agama network connections.
-      #
-      # @param networking [Y2Network::AutoinstProfile::NetworkingSection]
-      # @return [Hash]
-      def read_connections(networking)
-        interfaces = networking.interfaces.interfaces
-        # TODO: add an empty? method to InterfacesSection
-        return {} if interfaces.empty?
-
-        interfaces.map { |i| read_connection(i) }
-      end
-
-      # Reads an AutoYaST interface entry and builds its corresponding connection.
-      #
-      # @return [Y2Network::AutoinstProfile::InterfaceSection]
-      def read_connection(interface)
-        conn = {}
-        conn["device"] = interface.device if interface.device
-        conn["id"] = interface.name if interface.name
-
-        addresses = read_addresses(interface)
-        method4, method6 = read_methods(interface)
-        conn["method4"] = method4
-        conn["method6"] = method6
-        conn["addresses"] = addresses
-        wireless = Agama::AutoYaST::WirelessReader.new(interface).read
-        conn["wireless"] = wireless unless wireless.empty?
-        bond = Agama::AutoYaST::BondReader.new(interface).read
-        conn["bond"] = bond unless bond.empty?
-
-        conn
-      end
-
-      # @param networking [Y2Network::AutoinstProfile::NetworkingSection]
-      # @return [Array<Hash>]
-      def read_addresses(interface)
-        addresses = []
-        if !interface.ipaddr.to_s.empty?
-          primary = ipaddress_from(interface.ipaddr, interface.prefixlen, interface.netmask)
-          addresses.push(primary) if primary
-        end
-
-        secondary = interface.aliases.map { |a| ipaddress_from(a.ipaddr, a.prefixlen, a.netmask) }
-        addresses.concat(secondary)
-      end
-
       def ipv6?
         profile.fetch_as_hash("networking").fetch("ipv6", false)
-      end
-
-      # @return [IPAddress]
-      def ipaddress_from(address, prefix, netmask)
-        ipaddr = Y2Network::IPAddress.from_string(address)
-
-        # Assign first netmask, as prefix has precedence so it will overwrite it
-        ipaddr.prefix = prefix_for(netmask) if !netmask.to_s.empty?
-        ipaddr.prefix = prefix_for(prefix) if !prefix.to_s.empty?
-
-        ipaddr
-      rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
-        nil
-      end
-
-      # @param interface [Y2Network::AutoinstProfile::InterfaceSection]
-      # @return [String, String] method4 and method6 values
-      def read_methods(interface)
-        bootproto = Y2Network::BootProtocol.from_name(interface.bootproto)
-        case bootproto
-        when Y2Network::BootProtocol::DHCP4
-          ["auto", "disabled"]
-        when Y2Network::BootProtocol::DHCP6
-          ["disabled", "auto"]
-        when Y2Network::BootProtocol::STATIC
-          ["manual", ipv6? ? "manual" : "disabled"]
-        when Y2Network::BootProtocol::NONE
-          ["disabled", "disabled"]
-        else
-          ["auto", ipv6? ? "auto" : "disabled"]
-        end
-      end
-
-      # Converts a given IP Address netmask or prefix length in different
-      # formats to its prefix length value.
-      #
-      # @param value [String] IP Address prefix length or netmask in its different formats
-      # @return [Integer,nil] the given value in IP Address prefix length
-      #   format
-      # Taken from Y2Network::Autoinst::InterfacesReader
-      def prefix_for(value)
-        if value.empty?
-          nil
-        elsif value.start_with?("/")
-          value[1..-1].to_i
-        elsif value =~ /^\d{1,3}$/
-          value.to_i
-        else
-          IPAddr.new("#{value}/#{value}").prefix
-        end
       end
     end
   end

--- a/service/lib/agama/autoyast/network_reader.rb
+++ b/service/lib/agama/autoyast/network_reader.rb
@@ -27,7 +27,7 @@ require "agama/autoyast/connections_reader"
 # :nodoc:
 module Agama
   module AutoYaST
-    # Extracts the network information from an AutoYaST profile.
+    # Builds the Agama "network" section from an AutoYaST profile.
     class NetworkReader
       # @param profile [ProfileHash] AutoYaST profile
       def initialize(profile)

--- a/service/lib/agama/autoyast/network_reader.rb
+++ b/service/lib/agama/autoyast/network_reader.rb
@@ -1,0 +1,158 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2network/autoinst_profile/networking_section"
+require "y2network/boot_protocol"
+require "y2network/ip_address"
+require "agama/autoyast/bond_reader"
+require "agama/autoyast/wireless_reader"
+require "ipaddr"
+
+# :nodoc:
+module Agama
+  module AutoYaST
+    # Extracts the network information from an AutoYaST profile.
+    class NetworkReader
+      # @param profile [ProfileHash] AutoYaST profile
+      def initialize(profile)
+        @profile = profile
+      end
+
+      # @return [Hash] Agama "user" section
+      def read
+        networking = profile.fetch_as_hash("networking")
+        return {} if networking.empty?
+
+        network = {}
+        section = Y2Network::AutoinstProfile::NetworkingSection.new_from_hashes(networking)
+        connections = read_connections(section)
+        network["connections"] = connections unless connections.empty?
+        { "network" => network }
+      end
+
+    private
+
+      attr_reader :profile
+
+      # Converts a list of AutoYaST interfaces into Agama network connections.
+      #
+      # @param networking [Y2Network::AutoinstProfile::NetworkingSection]
+      # @return [Hash]
+      def read_connections(networking)
+        interfaces = networking.interfaces.interfaces
+        # TODO: add an empty? method to InterfacesSection
+        return {} if interfaces.empty?
+
+        interfaces.map { |i| read_connection(i) }
+      end
+
+      # Reads an AutoYaST interface entry and builds its corresponding connection.
+      #
+      # @return [Y2Network::AutoinstProfile::InterfaceSection]
+      def read_connection(interface)
+        conn = {}
+        conn["device"] = interface.device if interface.device
+        conn["id"] = interface.name if interface.name
+
+        addresses = read_addresses(interface)
+        method4, method6 = read_methods(interface)
+        conn["method4"] = method4
+        conn["method6"] = method6
+        conn["addresses"] = addresses
+        wireless = Agama::AutoYaST::WirelessReader.new(interface).read
+        conn["wireless"] = wireless unless wireless.empty?
+        bond = Agama::AutoYaST::BondReader.new(interface).read
+        conn["bond"] = bond unless bond.empty?
+
+        conn
+      end
+
+      # @param networking [Y2Network::AutoinstProfile::NetworkingSection]
+      # @return [Array<Hash>]
+      def read_addresses(interface)
+        addresses = []
+        if !interface.ipaddr.to_s.empty?
+          primary = ipaddress_from(interface.ipaddr, interface.prefixlen, interface.netmask)
+          addresses.push(primary) if primary
+        end
+
+        secondary = interface.aliases.map { |a| ipaddress_from(a.ipaddr, a.prefixlen, a.netmask) }
+        addresses.concat(secondary)
+      end
+
+      def ipv6?
+        profile.fetch_as_hash("networking").fetch("ipv6", false)
+      end
+
+      # @return [IPAddress]
+      def ipaddress_from(address, prefix, netmask)
+        ipaddr = Y2Network::IPAddress.from_string(address)
+
+        # Assign first netmask, as prefix has precedence so it will overwrite it
+        ipaddr.prefix = prefix_for(netmask) if !netmask.to_s.empty?
+        ipaddr.prefix = prefix_for(prefix) if !prefix.to_s.empty?
+
+        ipaddr
+      rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
+        nil
+      end
+
+      # @param interface [Y2Network::AutoinstProfile::InterfaceSection]
+      # @return [String, String] method4 and method6 values
+      def read_methods(interface)
+        bootproto = Y2Network::BootProtocol.from_name(interface.bootproto)
+        case bootproto
+        when Y2Network::BootProtocol::DHCP4
+          ["auto", "disabled"]
+        when Y2Network::BootProtocol::DHCP6
+          ["disabled", "auto"]
+        when Y2Network::BootProtocol::STATIC
+          ["manual", ipv6? ? "manual" : "disabled"]
+        when Y2Network::BootProtocol::NONE
+          ["disabled", "disabled"]
+        else
+          ["auto", ipv6? ? "auto" : "disabled"]
+        end
+      end
+
+      # Converts a given IP Address netmask or prefix length in different
+      # formats to its prefix length value.
+      #
+      # @param value [String] IP Address prefix length or netmask in its different formats
+      # @return [Integer,nil] the given value in IP Address prefix length
+      #   format
+      # Taken from Y2Network::Autoinst::InterfacesReader
+      def prefix_for(value)
+        if value.empty?
+          nil
+        elsif value.start_with?("/")
+          value[1..-1].to_i
+        elsif value =~ /^\d{1,3}$/
+          value.to_i
+        else
+          IPAddr.new("#{value}/#{value}").prefix
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/autoyast/product_reader.rb
+++ b/service/lib/agama/autoyast/product_reader.rb
@@ -40,15 +40,42 @@ module Agama
       def read
         return {} if profile["software"].nil?
 
-        product = profile["software"].fetch_as_array("products").first
-        return {} unless product
+        software = profile.fetch_as_hash("software")
+        suse_register = profile.fetch_as_hash("suse_register")
 
-        { "product" => { "id" => product } }
+        product = from_software(software)
+          .merge(from_suse_register(suse_register))
+        return {} if product.empty?
+
+        { "product" => product }
       end
 
     private
 
       attr_reader :profile
+
+      # @param section [ProfileHash] AutoYaST profile
+      def from_software(section)
+        product = section.fetch_as_array("products").first
+        return {} if product.nil?
+
+        { "id" => product }
+      end
+
+      # @param section [ProfileHash] AutoYaST profile
+      def from_suse_register(section)
+        return {} unless section.fetch("do_registration", true)
+
+        result = {}
+
+        code = section["reg_code"].to_s
+        result["registrationCode"] = code unless code.empty?
+
+        email = section["email"].to_s
+        result["registrationEmail"] = email unless email.empty?
+
+        result
+      end
     end
   end
 end

--- a/service/lib/agama/autoyast/product_reader.rb
+++ b/service/lib/agama/autoyast/product_reader.rb
@@ -25,15 +25,17 @@ require "yast"
 # :nodoc:
 module Agama
   module AutoYaST
-    # Extracts the users information from an AutoYaST profile.
+    # Builds the Agama "product" section from an AutoYaST profile.
     class ProductReader
-      attr_reader :profile
-
       # @param profile [ProfileHash] AutoYaST profile
       def initialize(profile)
         @profile = profile
       end
 
+      # Returns a hash corresponding to Agama "product" section.
+      #
+      # If there is no product-related information, it returns an empty hash.
+      #
       # @return [Hash] Agama "product" section
       def read
         return {} if profile["software"].nil?
@@ -43,6 +45,10 @@ module Agama
 
         { "product" => { "id" => product } }
       end
+
+    private
+
+      attr_reader :profile
     end
   end
 end

--- a/service/lib/agama/autoyast/product_reader.rb
+++ b/service/lib/agama/autoyast/product_reader.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+# :nodoc:
+module Agama
+  module AutoYaST
+    # Extracts the users information from an AutoYaST profile.
+    class ProductReader
+      attr_reader :profile
+
+      # @param profile [ProfileHash] AutoYaST profile
+      def initialize(profile)
+        @profile = profile
+      end
+
+      # @return [Hash] Agama "product" section
+      def read
+        return {} if profile["software"].nil?
+
+        product = profile["software"].fetch_as_array("products").first
+        return {} unless product
+
+        { "product" => { "id" => product } }
+      end
+    end
+  end
+end

--- a/service/lib/agama/autoyast/root_reader.rb
+++ b/service/lib/agama/autoyast/root_reader.rb
@@ -27,13 +27,15 @@ require "y2users/autoinst/reader"
 # :nodoc:
 module Agama
   module AutoYaST
-    # Extracts the users information from an AutoYaST profile.
+    # Builds the Agama "root" section from an AutoYaST profile. 
     class RootReader
       # @param profile [ProfileHash] AutoYaST profile
       def initialize(profile)
         @profile = profile
       end
 
+      # Returns a hash that corresponds to Agama "root" section.
+      #
       # @return [Hash] Agama "root" section
       def read
         root_user = config.users.find { |u| u.name == "root" }

--- a/service/lib/agama/autoyast/root_reader.rb
+++ b/service/lib/agama/autoyast/root_reader.rb
@@ -28,33 +28,21 @@ require "y2users/autoinst/reader"
 module Agama
   module AutoYaST
     # Extracts the users information from an AutoYaST profile.
-    class UsersConverter
+    class RootReader
       # @param profile [ProfileHash] AutoYaST profile
       def initialize(profile)
         @profile = profile
       end
 
       # @return [Hash] Agama "root" section
-      def root
+      def read
         root_user = config.users.find { |u| u.name == "root" }
         return {} unless root_user
 
         hsh = { "password" => root_user.password.value.to_s }
         public_key = root_user.authorized_keys.first
         hsh["sshPublicKey"] = public_key if public_key
-        hsh
-      end
-
-      # @return [Hash] Agama "user" section
-      def user
-        user = config.users.find { |u| !u.system? && !u.root? }
-        return {} unless user
-
-        {
-          "userName" => user.name,
-          "fullName" => user.gecos.first.to_s,
-          "password" => user.password.value.to_s
-        }
+        { "root" => hsh }
       end
 
     private

--- a/service/lib/agama/autoyast/root_reader.rb
+++ b/service/lib/agama/autoyast/root_reader.rb
@@ -27,7 +27,7 @@ require "y2users/autoinst/reader"
 # :nodoc:
 module Agama
   module AutoYaST
-    # Builds the Agama "root" section from an AutoYaST profile. 
+    # Builds the Agama "root" section from an AutoYaST profile.
     class RootReader
       # @param profile [ProfileHash] AutoYaST profile
       def initialize(profile)

--- a/service/lib/agama/autoyast/software_reader.rb
+++ b/service/lib/agama/autoyast/software_reader.rb
@@ -25,15 +25,17 @@ require "yast"
 # :nodoc:
 module Agama
   module AutoYaST
-    # Extracts the users information from an AutoYaST profile.
+    # Builds the Agama "software" section from an AutoYaST profile.
     class SoftwareReader
-      attr_reader :profile
-
       # @param profile [ProfileHash] AutoYaST profile
       def initialize(profile)
         @profile = profile
       end
 
+      # Returns a hash corresponding to Agama "product" section.
+      #
+      # If there is no software-related information, it returns an empty hash.
+      #
       # @return [Hash] Agama "software" section
       def read
         return {} if profile["software"].nil?
@@ -43,6 +45,10 @@ module Agama
 
         { "software" => { "patterns" => patterns } }
       end
+
+    private
+
+      attr_reader :profile
     end
   end
 end

--- a/service/lib/agama/autoyast/software_reader.rb
+++ b/service/lib/agama/autoyast/software_reader.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+# :nodoc:
+module Agama
+  module AutoYaST
+    # Extracts the users information from an AutoYaST profile.
+    class SoftwareReader
+      attr_reader :profile
+
+      # @param profile [ProfileHash] AutoYaST profile
+      def initialize(profile)
+        @profile = profile
+      end
+
+      # @return [Hash] Agama "software" section
+      def read
+        return {} if profile["software"].nil?
+
+        patterns = profile["software"].fetch_as_array("patterns")
+        return {} if patterns.empty?
+
+        { "software" => { "patterns" => patterns } }
+      end
+    end
+  end
+end

--- a/service/lib/agama/autoyast/storage_reader.rb
+++ b/service/lib/agama/autoyast/storage_reader.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+# :nodoc:
+module Agama
+  module AutoYaST
+    # Extracts the users information from an AutoYaST profile.
+    class StorageReader
+      attr_reader :profile
+
+      # @param profile [ProfileHash] AutoYaST profile
+      def initialize(profile)
+        @profile = profile
+      end
+
+      # @return [Hash] Agama "storage" section
+      def read
+        drives = profile.fetch_as_array("partitioning")
+        return {} if drives.nil?
+
+        # TODO: rely on AutoinstProfile classes
+        devices = drives.each_with_object([]) do |d, all|
+          next unless d["device"]
+
+          all << d["device"]
+        end
+        return {} if devices.empty?
+
+        { "storage" => { "bootDevice" => devices.first } }
+      end
+    end
+  end
+end

--- a/service/lib/agama/autoyast/user_reader.rb
+++ b/service/lib/agama/autoyast/user_reader.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2users/config"
+require "y2users/autoinst/reader"
+
+# :nodoc:
+module Agama
+  module AutoYaST
+    # Extracts the first user information from an AutoYaST profile.
+    class UserReader
+      # @param profile [ProfileHash] AutoYaST profile
+      def initialize(profile)
+        @profile = profile
+      end
+
+      # @return [Hash] Agama "user" section
+      def read
+        user = config.users.find { |u| !u.system? && !u.root? }
+        return {} unless user
+
+        hsh = {
+          "userName" => user.name,
+          "fullName" => user.gecos.first.to_s,
+          "password" => user.password.value.to_s
+        }
+        { "user" => hsh }
+      end
+
+    private
+
+      attr_reader :profile
+
+      # @return [Y2Users::Config] Users configuration
+      def config
+        return @config if @config
+
+        reader = Y2Users::Autoinst::Reader.new(profile)
+        result = reader.read
+        @config = result.config
+      end
+    end
+  end
+end

--- a/service/lib/agama/autoyast/user_reader.rb
+++ b/service/lib/agama/autoyast/user_reader.rb
@@ -27,13 +27,15 @@ require "y2users/autoinst/reader"
 # :nodoc:
 module Agama
   module AutoYaST
-    # Extracts the first user information from an AutoYaST profile.
+    # Builds the Agama "user" section from an AutoYaST profile.
     class UserReader
       # @param profile [ProfileHash] AutoYaST profile
       def initialize(profile)
         @profile = profile
       end
 
+      # Returns a hash that corresponds to Agama "user" section.
+      #
       # @return [Hash] Agama "user" section
       def read
         user = config.users.find { |u| !u.system? && !u.root? }

--- a/service/lib/agama/autoyast/wireless_reader.rb
+++ b/service/lib/agama/autoyast/wireless_reader.rb
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2network/wireless_auth_mode"
+require "y2network/wireless_mode"
+
+# :nodoc:
+module Agama
+  module AutoYaST
+    # Extracts the wireless information from an AutoYaST interface section.
+    class WirelessReader
+      # @param section [Y2Network::AutoinstProfile::InterfaceSection]
+      def initialize(section)
+        @section = section
+      end
+
+      # Return a hash that corresponds to Agama's wireless section
+      #
+      # @return [Hash]
+      def read
+        wireless = {}
+        security = security_from(section.wireless_auth_mode)
+        wireless["security"] = security if security
+        mode = mode_from(section.wireless_mode)
+        wireless["mode"] = mode if mode
+        wireless["ssid"] = section.wireless_essid.to_s
+
+        case security
+        when "wpa-psk"
+          wireless["password"] = section.wireless_wpa_psk.to_s
+        when "wpa-eap"
+          wireless["password"] = section.wireless_wpa_password.to_s
+        end
+
+        return {} if wireless.empty?
+
+        { "wireless" => wireless }
+      end
+
+    private
+
+      attr_reader :section
+
+      # Returns the security protocol according to the given WirelessAuthMode
+      #
+      # @param [String] Name of the YaST's wireless authentication mode
+      # @return [String, nil] Name of Agama's security protocol
+      def security_from(auth_mode)
+        case auth_mode
+        when Y2Network::WirelessAuthMode::WPA_PSK
+          "wpa-psk"
+        when Y2Network::WirelessAuthMode::WPA_EAP
+          "wpa-eap"
+        else
+          "none"
+        end
+      end
+
+      # Returns the wireless mode according to the given WirelessMode.
+      #
+      # @param [Y2Network::WirelessMode] YaST's wireless mode
+      # @return [String, nil] Name of Agama's wireless mode.
+      def mode_from(mode)
+        case mode
+        when Y2Network::WirelessMode::AD_HOC
+          "adhoc"
+        when Y2Network::WirelessMode::MASTER
+          "ap"
+        when Y2Network::WirelessMode::MANAGED
+          "infrastructure"
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/autoyast/wireless_reader.rb
+++ b/service/lib/agama/autoyast/wireless_reader.rb
@@ -27,14 +27,16 @@ require "y2network/wireless_mode"
 # :nodoc:
 module Agama
   module AutoYaST
-    # Extracts the wireless information from an AutoYaST interface section.
+    # Builds an Agama "wireless" section from an AutoYaST InterfaceSection.
     class WirelessReader
-      # @param section [Y2Network::AutoinstProfile::InterfaceSection]
+      # @param section [Y2Network::AutoinstProfile::InterfaceSection] Interface section
       def initialize(section)
         @section = section
       end
 
-      # Return a hash that corresponds to Agama's wireless section
+      # Returns a hash that corresponds to Agama's "wireless" section
+      #
+      # If there is no wireless information, it returns an empty hash.
       #
       # @return [Hash]
       def read
@@ -63,7 +65,7 @@ module Agama
 
       # Returns the security protocol according to the given WirelessAuthMode
       #
-      # @param [String] Name of the YaST's wireless authentication mode
+      # @param auth_mode [String] Name of the YaST's wireless authentication mode
       # @return [String, nil] Name of Agama's security protocol
       def security_from(auth_mode)
         case auth_mode
@@ -76,10 +78,10 @@ module Agama
         end
       end
 
-      # Returns the wireless mode according to the given WirelessMode.
+      # Returns the wireless mode according to the given WirelessMode
       #
-      # @param [Y2Network::WirelessMode] YaST's wireless mode
-      # @return [String, nil] Name of Agama's wireless mode.
+      # @param mode [Y2Network::WirelessMode] YaST's wireless mode
+      # @return [String, nil] Name of Agama's wireless mode
       def mode_from(mode)
         case mode
         when Y2Network::WirelessMode::AD_HOC

--- a/service/test/agama/autoyast/bond_reader_test.rb
+++ b/service/test/agama/autoyast/bond_reader_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "y2network/autoinst_profile/interface_section"
+require "agama/autoyast/bond_reader"
+
+Yast.import "Profile"
+
+describe Agama::AutoYaST::BondReader do
+  let(:profile) do
+    {
+      "id"                  => "bond0",
+      "bonding_slave0"      => "eth0",
+      "bonding_slave1"      => "eth1",
+      "bonding_module_opts" => "some-option=true mode=active-backup miimon=100"
+    }
+  end
+
+  subject do
+    described_class.new(Y2Network::AutoinstProfile::InterfaceSection.new_from_hashes(profile))
+  end
+
+  describe "#read" do
+    it "sets the ports" do
+      bond = subject.read["bond"]
+      expect(bond["ports"]).to eq(["eth0", "eth1"])
+    end
+
+    it "sets the options" do
+      bond = subject.read["bond"]
+      expect(bond["options"]).to eq("some-option=true miimon=100")
+    end
+
+    it "sets the mode" do
+      bond = subject.read["bond"]
+      expect(bond["mode"]).to eq("active-backup")
+    end
+  end
+end

--- a/service/test/agama/autoyast/bond_reader_test.rb
+++ b/service/test/agama/autoyast/bond_reader_test.rb
@@ -24,8 +24,6 @@ require "yast"
 require "y2network/autoinst_profile/interface_section"
 require "agama/autoyast/bond_reader"
 
-Yast.import "Profile"
-
 describe Agama::AutoYaST::BondReader do
   let(:profile) do
     {

--- a/service/test/agama/autoyast/connections_reader_test.rb
+++ b/service/test/agama/autoyast/connections_reader_test.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "agama/autoyast/connections_reader"
+require "y2network/autoinst_profile/interfaces_section"
+
+describe Agama::AutoYaST::ConnectionsReader do
+  let(:interfaces) { [eth0] }
+  let(:eth0) do
+    { "bootproto" => eth0_bootproto, "name" => "eth0" }
+  end
+  let(:ipv6?) { true }
+  let(:eth0_bootproto) { "dhcp" }
+
+  subject do
+    section = Y2Network::AutoinstProfile::InterfacesSection.new_from_hashes(
+      interfaces
+    )
+    described_class.new(section, ipv6: ipv6?)
+  end
+
+  describe "#read" do
+    context "when there are no interfaces" do
+      let(:interfaces) { [] }
+
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
+    context "when bootproto is set to DHCP" do
+      it "sets method4 to 'auto'" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["method4"]).to eq("auto")
+      end
+
+      it "sets method6 to 'auto'" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["method6"]).to eq("auto")
+      end
+
+      context "when IPv6 is disabled" do
+        let(:ipv6?) { false }
+
+        it "sets method6 to 'disabled'" do
+          connections = subject.read["connections"]
+          conn = connections.find { |c| c["id"] == "eth0" }
+          expect(conn["method6"]).to eq("disabled")
+        end
+      end
+    end
+
+    context "when bootproto is set to DHCP6" do
+      let(:eth0_bootproto) { "dhcp6" }
+
+      it "sets method6 to 'auto'" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["method6"]).to eq("auto")
+      end
+
+      it "sets method4 to 'disabled'" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["method4"]).to eq("disabled")
+      end
+    end
+
+    context "when bootproto is set to STATIC" do
+      let(:eth0_bootproto) { "static" }
+
+      it "sets method4 to 'manual'" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["method4"]).to eq("manual")
+      end
+
+      it "sets method6 to 'manual'" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["method6"]).to eq("manual")
+      end
+
+      context "when IPv6 is disabled" do
+        let(:ipv6?) { false }
+
+        it "sets method6 to 'disabled'" do
+          connections = subject.read["connections"]
+          conn = connections.find { |c| c["id"] == "eth0" }
+          expect(conn["method6"]).to eq("disabled")
+        end
+      end
+    end
+
+    context "when bootproto is set to NONE" do
+      let(:eth0_bootproto) { "none" }
+
+      it "sets method4 to 'disabled'" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["method4"]).to eq("disabled")
+      end
+
+      it "sets method6 to 'disabled'" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["method6"]).to eq("disabled")
+      end
+    end
+
+    context "when an IP and a prefix are given" do
+      let(:eth0) do
+        { name: "eth0", ipaddr: "192.168.122.2", prefixlen: "24" }
+      end
+
+      it "includes the IP to the list of addresses" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["addresses"].map(&:to_s)).to eq(["192.168.122.2/24"])
+      end
+    end
+
+    context "when an IP and a netmask are given" do
+      let(:eth0) do
+        { name: "eth0", ipaddr: "192.168.122.2", netmask: "255.255.255.0" }
+      end
+
+      it "includes the IP to the list of addresses" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["addresses"].map(&:to_s)).to eq(["192.168.122.2/24"])
+      end
+    end
+
+    context "when IP aliases are defined" do
+      let(:eth0) do
+        {
+          name: "eth0", ipaddr: "192.168.122.2", prefixlen: "24",
+          "aliases" => {
+            alias0: { ipaddr: "10.0.0.2", prefixlen: "255.0.0.0", label: "0" },
+            alias1: { ipaddr: "192.168.0.2", prefixlen: "24", label: "1" }
+          }
+        }
+      end
+
+      it "includes them in the list of IP addresses" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["addresses"].map(&:to_s))
+          .to eq(["192.168.122.2/24", "10.0.0.2/8", "192.168.0.2/24"])
+      end
+    end
+
+    context "when there are wireless settings" do
+      let(:eth0) do
+        { "name" => "eth0", "wireless_mode" => "wpa-psk" }
+      end
+
+      it "includes a 'wireless' key containing those settings" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["wireless"]).to be_a(Hash)
+      end
+    end
+
+    context "when there are bonding settings" do
+      let(:eth0) do
+        { "name" => "eth0", "bonding_slave0" => "eth1" }
+      end
+
+      it "includes a 'bond' key containing those settings" do
+        connections = subject.read["connections"]
+        conn = connections.find { |c| c["id"] == "eth0" }
+        expect(conn["bond"]).to be_a(Hash)
+      end
+    end
+  end
+end

--- a/service/test/agama/autoyast/converter_test.rb
+++ b/service/test/agama/autoyast/converter_test.rb
@@ -118,6 +118,15 @@ describe Agama::AutoYaST::Converter do
           "password" => "12345678", "fullName" => "Jane Doe")
       end
     end
+
+    it "exports l10n settings" do
+      subject.to_agama(workdir)
+      expect(result["l10n"]).to include(
+        "languages" => ["en_US.UTF-8"],
+        "timezone"  => "Atlantic/Canary",
+        "keyboard"  => "us"
+      )
+    end
   end
 
   context "when an invalid profile is given" do

--- a/service/test/agama/autoyast/converter_test.rb
+++ b/service/test/agama/autoyast/converter_test.rb
@@ -85,14 +85,14 @@ describe Agama::AutoYaST::Converter do
 
       it "runs the script" do
         subject.to_agama(workdir)
-        expect(result["software"]).to include("product" => "Tumbleweed")
+        expect(result["product"]).to include("id" => "Tumbleweed")
       end
     end
 
     context "when a product is selected" do
       it "exports the selected product" do
         subject.to_agama(workdir)
-        expect(result["software"]).to include("product" => "Tumbleweed")
+        expect(result["product"]).to include("id" => "Tumbleweed")
       end
     end
 

--- a/service/test/agama/autoyast/converter_test.rb
+++ b/service/test/agama/autoyast/converter_test.rb
@@ -89,6 +89,17 @@ describe Agama::AutoYaST::Converter do
       end
     end
 
+    context "when the profile contains some ERB" do
+      let(:profile_name) { "simple.xml.erb" }
+
+      it "evaluates the ERB code" do
+        subject.to_agama(workdir)
+        expect(result["l10n"]).to include(
+          "languages" => ["en_US.UTF-8", "es_ES.UTF-8"]
+        )
+      end
+    end
+
     context "when a product is selected" do
       it "exports the selected product" do
         subject.to_agama(workdir)

--- a/service/test/agama/autoyast/l10n_reader_test.rb
+++ b/service/test/agama/autoyast/l10n_reader_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "agama/autoyast/l10n_reader"
+
+Yast.import "Profile"
+
+describe Agama::AutoYaST::L10nReader do
+  let(:profile) do
+    {}
+  end
+
+  subject do
+    described_class.new(Yast::ProfileHash.new(profile))
+  end
+
+  describe "#read" do
+    context "when there is no l10n-related sections" do
+      let(:profile) { {} }
+
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
+    context "when a keymap is defined" do
+      let(:profile) do
+        { "keyboard" => { "keymap" => "us" } }
+      end
+
+      it "includes a 'keyboard' key with its value" do
+        l10n = subject.read["l10n"]
+        expect(l10n["keyboard"]).to eq("us")
+      end
+    end
+
+    context "when there are primary and secondary languages" do
+      let(:profile) do
+        {
+          "language" => {
+            "language"  => "en_US.UTF-8",
+            "languages" => "es_ES.UTF-8, cs_CZ.UTF-8"
+          }
+        }
+      end
+
+      it "includes a 'languages' key with all the languages" do
+        l10n = subject.read["l10n"]
+        expect(l10n["languages"]).to eq(["en_US.UTF-8", "es_ES.UTF-8", "cs_CZ.UTF-8"])
+      end
+
+      context "when the encoding is not included" do
+        let(:profile) do
+          {
+            "language" => {
+              "language"  => "en_US",
+              "languages" => "es_ES"
+            }
+          }
+        end
+
+        it "uses the UTF-8 encoding" do
+          l10n = subject.read["l10n"]
+          expect(l10n["languages"]).to eq(["en_US.UTF-8", "es_ES.UTF-8"])
+        end
+      end
+    end
+
+    context "when a timezone is defined" do
+      let(:profile) do
+        { "timezone" => { "timezone" => "Europe/Berlin" } }
+      end
+
+      it "includes a 'keyboard' key with its value" do
+        l10n = subject.read["l10n"]
+        expect(l10n["timezone"]).to eq("Europe/Berlin")
+      end
+    end
+  end
+end

--- a/service/test/agama/autoyast/network_reader_test.rb
+++ b/service/test/agama/autoyast/network_reader_test.rb
@@ -29,17 +29,10 @@ describe Agama::AutoYaST::NetworkReader do
   let(:profile) do
     {
       "networking" => {
-        "interfaces" => [eth0],
-        "ipv6"       => ipv6
+        "interfaces" => [{ "name" => "eth0" }]
       }
     }
   end
-
-  let(:eth0) do
-    { "bootproto" => eth0_bootproto, "name" => "eth0" }
-  end
-  let(:ipv6) { true }
-  let(:eth0_bootproto) { "dhcp" }
 
   subject do
     described_class.new(Yast::ProfileHash.new(profile))
@@ -54,152 +47,10 @@ describe Agama::AutoYaST::NetworkReader do
       end
     end
 
-    context "when bootproto is set to DHCP" do
-      it "sets method4 to 'auto'" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["method4"]).to eq("auto")
-      end
-
-      it "sets method6 to 'auto'" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["method6"]).to eq("auto")
-      end
-
-      context "when IPv6 is disabled" do
-        let(:ipv6) { false }
-
-        it "sets method6 to 'disabled'" do
-          network = subject.read["network"]
-          conn = network["connections"].find { |c| c["id"] == "eth0" }
-          expect(conn["method6"]).to eq("disabled")
-        end
-      end
-    end
-
-    context "when bootproto is set to DHCP6" do
-      let(:eth0_bootproto) { "dhcp6" }
-
-      it "sets method6 to 'auto'" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["method6"]).to eq("auto")
-      end
-
-      it "sets method4 to 'disabled'" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["method4"]).to eq("disabled")
-      end
-    end
-
-    context "when bootproto is set to STATIC" do
-      let(:eth0_bootproto) { "static" }
-
-      it "sets method4 to 'manual'" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["method4"]).to eq("manual")
-      end
-
-      it "sets method6 to 'manual'" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["method6"]).to eq("manual")
-      end
-
-      context "when IPv6 is disabled" do
-        let(:ipv6) { false }
-
-        it "sets method6 to 'disabled'" do
-          network = subject.read["network"]
-          conn = network["connections"].find { |c| c["id"] == "eth0" }
-          expect(conn["method6"]).to eq("disabled")
-        end
-      end
-    end
-
-    context "when bootproto is set to NONE" do
-      let(:eth0_bootproto) { "none" }
-
-      it "sets method4 to 'disabled'" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["method4"]).to eq("disabled")
-      end
-
-      it "sets method6 to 'disabled'" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["method6"]).to eq("disabled")
-      end
-    end
-
-    context "when an IP and a prefix are given" do
-      let(:eth0) do
-        { name: "eth0", ipaddr: "192.168.122.2", prefixlen: "24" }
-      end
-
-      it "includes the IP to the list of addresses" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["addresses"].map(&:to_s)).to eq(["192.168.122.2/24"])
-      end
-    end
-
-    context "when an IP and a netmask are given" do
-      let(:eth0) do
-        { name: "eth0", ipaddr: "192.168.122.2", netmask: "255.255.255.0" }
-      end
-
-      it "includes the IP to the list of addresses" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["addresses"].map(&:to_s)).to eq(["192.168.122.2/24"])
-      end
-    end
-
-    context "when IP aliases are defined" do
-      let(:eth0) do
-        {
-          name: "eth0", ipaddr: "192.168.122.2", prefixlen: "24",
-          "aliases" => {
-            alias0: { ipaddr: "10.0.0.2", prefixlen: "255.0.0.0", label: "0" },
-            alias1: { ipaddr: "192.168.0.2", prefixlen: "24", label: "1" }
-          }
-        }
-      end
-
-      it "includes them in the list of IP addresses" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["addresses"].map(&:to_s))
-          .to eq(["192.168.122.2/24", "10.0.0.2/8", "192.168.0.2/24"])
-      end
-    end
-
-    context "when there are wireless settings" do
-      let(:eth0) do
-        { "name" => "eth0", "wireless_mode" => "wpa-psk" }
-      end
-
-      it "includes a 'wireless' key containing those settings" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["wireless"]).to be_a(Hash)
-      end
-    end
-
-    context "when there are bonding settings" do
-      let(:eth0) do
-        { "name" => "eth0", "bonding_slave0" => "eth1" }
-      end
-
-      it "includes a 'bond' key containing those settings" do
-        network = subject.read["network"]
-        conn = network["connections"].find { |c| c["id"] == "eth0" }
-        expect(conn["bond"]).to be_a(Hash)
+    context "when there is a 'connections' list" do
+      it "returns a section with the 'connections' list" do
+        network = subject.read
+        expect(network["network"].keys).to include("connections")
       end
     end
   end

--- a/service/test/agama/autoyast/network_reader_test.rb
+++ b/service/test/agama/autoyast/network_reader_test.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "agama/autoyast/network_reader"
+
+Yast.import "Profile"
+
+describe Agama::AutoYaST::NetworkReader do
+  let(:profile) do
+    {
+      "networking" => {
+        "interfaces" => [eth0],
+        "ipv6"       => ipv6
+      }
+    }
+  end
+
+  let(:eth0) do
+    { "bootproto" => eth0_bootproto, "name" => "eth0" }
+  end
+  let(:ipv6) { true }
+  let(:eth0_bootproto) { "dhcp" }
+
+  subject do
+    described_class.new(Yast::ProfileHash.new(profile))
+  end
+
+  describe "#read" do
+    context "when there is no 'networking' section" do
+      let(:profile) { {} }
+
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
+    context "when bootproto is set to DHCP" do
+      it "sets method4 to 'auto'" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["method4"]).to eq("auto")
+      end
+
+      it "sets method6 to 'auto'" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["method6"]).to eq("auto")
+      end
+
+      context "when IPv6 is disabled" do
+        let(:ipv6) { false }
+
+        it "sets method6 to 'disabled'" do
+          network = subject.read["network"]
+          conn = network["connections"].find { |c| c["id"] == "eth0" }
+          expect(conn["method6"]).to eq("disabled")
+        end
+      end
+    end
+
+    context "when bootproto is set to DHCP6" do
+      let(:eth0_bootproto) { "dhcp6" }
+
+      it "sets method6 to 'auto'" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["method6"]).to eq("auto")
+      end
+
+      it "sets method4 to 'disabled'" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["method4"]).to eq("disabled")
+      end
+    end
+
+    context "when bootproto is set to STATIC" do
+      let(:eth0_bootproto) { "static" }
+
+      it "sets method4 to 'manual'" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["method4"]).to eq("manual")
+      end
+
+      it "sets method6 to 'manual'" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["method6"]).to eq("manual")
+      end
+
+      context "when IPv6 is disabled" do
+        let(:ipv6) { false }
+
+        it "sets method6 to 'disabled'" do
+          network = subject.read["network"]
+          conn = network["connections"].find { |c| c["id"] == "eth0" }
+          expect(conn["method6"]).to eq("disabled")
+        end
+      end
+    end
+
+    context "when bootproto is set to NONE" do
+      let(:eth0_bootproto) { "none" }
+
+      it "sets method4 to 'disabled'" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["method4"]).to eq("disabled")
+      end
+
+      it "sets method6 to 'disabled'" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["method6"]).to eq("disabled")
+      end
+    end
+
+    context "when an IP and a prefix are given" do
+      let(:eth0) do
+        { name: "eth0", ipaddr: "192.168.122.2", prefixlen: "24" }
+      end
+
+      it "includes the IP to the list of addresses" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["addresses"].map(&:to_s)).to eq(["192.168.122.2/24"])
+      end
+    end
+
+    context "when an IP and a netmask are given" do
+      let(:eth0) do
+        { name: "eth0", ipaddr: "192.168.122.2", netmask: "255.255.255.0" }
+      end
+
+      it "includes the IP to the list of addresses" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["addresses"].map(&:to_s)).to eq(["192.168.122.2/24"])
+      end
+    end
+
+    context "when IP aliases are defined" do
+      let(:eth0) do
+        {
+          name: "eth0", ipaddr: "192.168.122.2", prefixlen: "24",
+          "aliases" => {
+            alias0: { ipaddr: "10.0.0.2", prefixlen: "255.0.0.0", label: "0" },
+            alias1: { ipaddr: "192.168.0.2", prefixlen: "24", label: "1" }
+          }
+        }
+      end
+
+      it "includes them in the list of IP addresses" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["addresses"].map(&:to_s))
+          .to eq(["192.168.122.2/24", "10.0.0.2/8", "192.168.0.2/24"])
+      end
+    end
+
+    context "when there are wireless settings" do
+      let(:eth0) do
+        { "name" => "eth0", "wireless_mode" => "wpa-psk" }
+      end
+
+      it "includes a 'wireless' key containing those settings" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["wireless"]).to be_a(Hash)
+      end
+    end
+
+    context "when there are bonding settings" do
+      let(:eth0) do
+        { "name" => "eth0", "bonding_slave0" => "eth1" }
+      end
+
+      it "includes a 'bond' key containing those settings" do
+        network = subject.read["network"]
+        conn = network["connections"].find { |c| c["id"] == "eth0" }
+        expect(conn["bond"]).to be_a(Hash)
+      end
+    end
+  end
+end

--- a/service/test/agama/autoyast/product_reader_test.rb
+++ b/service/test/agama/autoyast/product_reader_test.rb
@@ -28,11 +28,17 @@ Yast.import "Profile"
 describe Agama::AutoYaST::ProductReader do
   let(:profile) do
     {
-      "software" => {
-        "products" => ["SLE"],
-        "patterns" => ["base", "gnome"]
-      }
+      "software" => software_section,
+      "suse_register" => suse_register_section
     }
+  end
+
+  let(:software_section) do
+    { "products" => ["SLE"], "patterns" => ["base", "gnome"] }
+  end
+
+  let(:suse_register_section) do
+    { "reg_code" => "123456", "email" => "test@opensuse.org" }
   end
 
   subject do
@@ -52,6 +58,14 @@ describe Agama::AutoYaST::ProductReader do
       it "includes the product ID as 'product.id'" do
         product_id = subject.read.dig("product", "id")
         expect(product_id).to eq("SLE")
+      end
+    end
+
+    context "when there is registration information" do
+      it "includes the registration code" do
+        product = subject.read["product"]
+        expect(product["registrationCode"]).to eq("123456")
+        expect(product["registrationEmail"]).to eq("test@opensuse.org")
       end
     end
   end

--- a/service/test/agama/autoyast/product_reader_test.rb
+++ b/service/test/agama/autoyast/product_reader_test.rb
@@ -28,7 +28,7 @@ Yast.import "Profile"
 describe Agama::AutoYaST::ProductReader do
   let(:profile) do
     {
-      "software" => software_section,
+      "software"      => software_section,
       "suse_register" => suse_register_section
     }
   end

--- a/service/test/agama/autoyast/product_reader_test.rb
+++ b/service/test/agama/autoyast/product_reader_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "agama/autoyast/product_reader"
+
+Yast.import "Profile"
+
+describe Agama::AutoYaST::ProductReader do
+  let(:profile) do
+    {
+      "software" => {
+        "products" => ["SLE"],
+        "patterns" => ["base", "gnome"]
+      }
+    }
+  end
+
+  subject do
+    described_class.new(Yast::ProfileHash.new(profile))
+  end
+
+  describe "#read" do
+    context "when there is no 'software' section" do
+      let(:profile) { {} }
+
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
+    context "when a product ID is included" do
+      it "includes the product ID as 'product.id'" do
+        product_id = subject.read.dig("product", "id")
+        expect(product_id).to eq("SLE")
+      end
+    end
+  end
+end

--- a/service/test/agama/autoyast/root_reader_test.rb
+++ b/service/test/agama/autoyast/root_reader_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "agama/autoyast/root_reader"
+
+Yast.import "Profile"
+
+describe Agama::AutoYaST::RootReader do
+  let(:profile) do
+    { "users" => [root, user] }
+  end
+
+  let(:user) do
+    {
+      "username"      => "suse",
+      "fullname"      => "SUSE",
+      "user_password" => "nots3cr3t",
+      "encrypted"     => false
+    }
+  end
+
+  let(:root) do
+    { "username"        => "root",
+      "user_password"   => "123456",
+      "encrypted"       => false,
+      "authorized_keys" => ["ssh-key 1", "ssh-key 2"] }
+  end
+
+  subject do
+    described_class.new(Yast::ProfileHash.new(profile))
+  end
+
+  describe "#read" do
+    context "when there is no 'users' section" do
+      let(:profile) { {} }
+
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
+    context "when no root user is defined" do
+      let(:profile) { { "users" => [user] } }
+
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
+    context "when a root user is defined" do
+      it "includes a 'root' key with the root user data" do
+        root = subject.read["root"]
+        expect(root).to eq(
+          "password" => "123456", "sshPublicKey" => "ssh-key 1"
+        )
+      end
+    end
+  end
+end

--- a/service/test/agama/autoyast/software_reader_test.rb
+++ b/service/test/agama/autoyast/software_reader_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "agama/autoyast/software_reader"
+
+Yast.import "Profile"
+
+describe Agama::AutoYaST::SoftwareReader do
+  let(:profile) do
+    {
+      "software" => {
+        "products" => ["SLE"],
+        "patterns" => ["base", "gnome"]
+      }
+    }
+  end
+
+  subject do
+    described_class.new(Yast::ProfileHash.new(profile))
+  end
+
+  describe "#read" do
+    context "when there is no 'software' section" do
+      let(:profile) { {} }
+
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
+    context "when a list of patterns is included" do
+      it "includes the list of patterns under 'software.patterns'" do
+        patterns = subject.read.dig("software", "patterns")
+        expect(patterns).to eq(["base", "gnome"])
+      end
+    end
+  end
+end

--- a/service/test/agama/autoyast/storage_reader_test.rb
+++ b/service/test/agama/autoyast/storage_reader_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "agama/autoyast/storage_reader"
+
+Yast.import "Profile"
+
+describe Agama::AutoYaST::StorageReader do
+  let(:profile) do
+    {
+      "partitioning" => [
+        { "use" => "all" },
+        {
+          "device" => "/dev/vda",
+          "use"    => "all"
+        }
+      ]
+    }
+  end
+
+  subject do
+    described_class.new(Yast::ProfileHash.new(profile))
+  end
+
+  describe "#read" do
+    context "when there is no 'partitioning' section" do
+      let(:profile) { {} }
+
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
+    context "when there is a list of drives" do
+      it "uses the first 'device' key as 'bootDevice'" do
+        boot_device = subject.read.dig("storage", "bootDevice")
+        expect(boot_device).to eq("/dev/vda")
+      end
+    end
+  end
+end

--- a/service/test/agama/autoyast/user_reader_test.rb
+++ b/service/test/agama/autoyast/user_reader_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "agama/autoyast/user_reader"
+
+Yast.import "Profile"
+
+describe Agama::AutoYaST::UserReader do
+  let(:profile) do
+    { "users" => [root, user] }
+  end
+
+  let(:user) do
+    {
+      "username"      => "suse",
+      "fullname"      => "SUSE",
+      "user_password" => "nots3cr3t",
+      "encrypted"     => false
+    }
+  end
+
+  let(:root) do
+    { "username"        => "root",
+      "user_password"   => "123456",
+      "encrypted"       => false,
+      "authorized_keys" => ["ssh-key 1", "ssh-key 2"] }
+  end
+
+  subject do
+    described_class.new(Yast::ProfileHash.new(profile))
+  end
+
+  describe "#read" do
+    context "when there is no 'users' section" do
+      let(:profile) { {} }
+
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
+    context "when no regular user is defined" do
+      let(:profile) { { "users" => [root] } }
+
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
+    context "when a regular user is defined" do
+      it "includes a 'user' key with the root user data" do
+        user = subject.read["user"]
+        expect(user).to eq(
+          "userName" => "suse",
+          "fullName" => "SUSE",
+          "password" => "nots3cr3t"
+        )
+      end
+    end
+  end
+end

--- a/service/test/agama/autoyast/wireless_reader_test.rb
+++ b/service/test/agama/autoyast/wireless_reader_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "y2network/autoinst_profile/interface_section"
+require "y2network/wireless_auth_mode"
+require "y2network/wireless_mode"
+require "agama/autoyast/wireless_reader"
+
+Yast.import "Profile"
+
+describe Agama::AutoYaST::WirelessReader do
+  let(:profile) do
+    {
+      "wireless_auth_mode" => auth_mode,
+      "wireless_mode"      => mode,
+      "wireless_essid"     => "DUMMY_NETWORK"
+    }
+  end
+
+  let(:auth_mode) { Y2Network::WirelessAuthMode::NONE }
+  let(:mode) { Y2Network::WirelessMode::MANAGED }
+
+  subject do
+    described_class.new(Y2Network::AutoinstProfile::InterfaceSection.new_from_hashes(profile))
+  end
+
+  describe "#read" do
+    it "sets the ssid" do
+      result = subject.read["wireless"]
+      expect(result["ssid"]).to eq("DUMMY_NETWORK")
+    end
+
+    context "when wireless_auth_mode is WPA_PSK" do
+      let(:auth_mode) { Y2Network::WirelessAuthMode::WPA_PSK }
+
+      it "sets 'wpa-psk' as security protocol" do
+        result = subject.read["wireless"]
+        expect(result["security"]).to eq("wpa-psk")
+      end
+    end
+
+    context "when wireless_auth_mode is WPA_PSK" do
+      let(:auth_mode) { Y2Network::WirelessAuthMode::WPA_EAP }
+
+      it "sets 'wpa-eap' as security protocol" do
+        result = subject.read["wireless"]
+        expect(result["security"]).to eq("wpa-eap")
+      end
+    end
+
+    context "when wireless_auth_mode is WEP" do
+      let(:auth_mode) { Y2Network::WirelessAuthMode::WEP_OPEN }
+
+      it "sets 'none' as security protocol" do
+        result = subject.read["wireless"]
+        expect(result["security"]).to eq("none")
+      end
+    end
+
+    context "when wireless_mode is AD_HOC" do
+      let(:mode) { Y2Network::WirelessMode::AD_HOC }
+
+      it "sets 'adhoc' as mode" do
+        result = subject.read["wireless"]
+        expect(result["mode"]).to eq("adhoc")
+      end
+    end
+
+    context "when wireless_mode is MASTER" do
+      let(:mode) { Y2Network::WirelessMode::MASTER }
+
+      it "sets 'ap' as mode" do
+        result = subject.read["wireless"]
+        expect(result["mode"]).to eq("ap")
+      end
+    end
+
+    context "when wireless_mode is MANAGED" do
+      let(:mode) { Y2Network::WirelessMode::MANAGED }
+
+      it "sets 'infrastructure' as mode" do
+        result = subject.read["wireless"]
+        expect(result["mode"]).to eq("infrastructure")
+      end
+    end
+  end
+end

--- a/service/test/fixtures/profiles/profile/rules/rules.xml
+++ b/service/test/fixtures/profiles/profile/rules/rules.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE autoinstall>
+<autoinstall xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <rules config:type="list">
+    <rule>
+      <custom1>
+        <script>
+echo -n testing.xml
+        </script>
+        <match>*</match>
+        <match_type>exact</match_type>
+      </custom1>
+      <result>
+        <profile>@custom1@</profile>
+        <continue config:type="boolean">false</continue>
+      </result>
+    </rule>
+  </rules>
+</autoinstall>

--- a/service/test/fixtures/profiles/profile/testing.xml
+++ b/service/test/fixtures/profiles/profile/testing.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <software>
+    <products config:type="list">
+      <product>Tumbleweed</product>
+    </products>
+    <patterns config:type="list">
+      <pattern>enhanced_base</pattern>
+    </patterns>
+  </software>
+</profile>
+
+

--- a/service/test/fixtures/profiles/simple.xml
+++ b/service/test/fixtures/profiles/simple.xml
@@ -15,6 +15,14 @@
     <languages>en_US</languages>
   </language>
 
+  <timezone>
+    <timezone>Atlantic/Canary</timezone>
+  </timezone>
+
+  <keyboard>
+    <keymap>us</keymap>
+  </keyboard>
+
   <partitioning config:type="list">
    <drive>
      <device>/dev/vda</device>

--- a/service/test/fixtures/profiles/simple.xml.erb
+++ b/service/test/fixtures/profiles/simple.xml.erb
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <software>
+    <products config:type="list">
+      <product>Tumbleweed</product>
+    </products>
+  </software>
+
+  <language>
+    <language><%= "en_US" %></language>
+    <languages><%= ["en_US", "es_ES"].join(",") %></languages>
+  </language>
+
+  <timezone>
+    <timezone>Atlantic/Canary</timezone>
+  </timezone>
+
+  <keyboard>
+    <keymap>us</keymap>
+  </keyboard>
+
+  <partitioning config:type="list">
+   <drive>
+     <device>/dev/vda</device>
+     <use>all</use>
+   </drive>
+  </partitioning>
+
+  <users config:type="list">
+    <user>
+      <username>root</username>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <authorized_keys config:type="list">
+        <listentry>ssh-rsa ...</listentry>
+      </authorized_keys>
+    </user>
+    <user>
+      <username>jane</username>
+      <uid>1000</uid>
+      <fullname>Jane Doe</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>12345678</user_password>
+    </user>
+  </users>
+</profile>


### PR DESCRIPTION
* Extend the converter to read some missing sections: `networking`, `language`, `keyboard`, `timezone`, and `suse_register`.
* Document how supported sections are handled, including what is missing.
* Improve test coverage.

## Tasks

- [x] Read and document the `networking` section
- [x] Read and document the `language` section
- [x] Read and document the `keyboard` section
- [x] Read and document the `timezone` section
- [x] Read and document the `suse_register` section