### PR TITLE
Fix patterns

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 22 14:26:18 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix disappeared search box when no pattern match search expression
+  (gh#openSUSE/agama#1241)
+
+-------------------------------------------------------------------
 Fri May 17 09:52:26 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 8

--- a/web/src/components/software/PatternSelector.jsx
+++ b/web/src/components/software/PatternSelector.jsx
@@ -130,7 +130,7 @@ function PatternSelector({ patterns, onSelectionChanged = noop }) {
   }, [patterns, onSelectionChanged]);
 
   // initial empty screen, the patterns are loaded very quickly, no need for any progress
-  if (visiblePatterns.length === 0) return null;
+  if (visiblePatterns.length === 0 && searchValue === "") return null;
 
   const groups = groupPatterns(visiblePatterns);
 


### PR DESCRIPTION
## Problem

Search input box disappear when text does not match any pattern. Issue #1241

## Solution

Fix condition to prevent displaying search box during initial load when patterns are not yet loaded.


## Testing

- *Tested manually*

