### PR TITLE
Reconnect the HTTP client websocket automatically

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -27,12 +27,9 @@ import { useProduct } from "./context/product";
 import { INSTALL, STARTUP } from "~/client/phase";
 import { BUSY } from "~/client/status";
 
-import { DBusError, If, Installation } from "~/components/core";
+import { WebSocketError, If, Installation } from "~/components/core";
 import { Loading } from "./components/layout";
 import { useInstallerL10n } from "./context/installerL10n";
-
-// D-Bus connection attempts before displaying an error.
-const ATTEMPTS = 3;
 
 /**
  * Main application component.
@@ -43,7 +40,6 @@ const ATTEMPTS = 3;
  */
 function App() {
   const client = useInstallerClient();
-  const { attempt } = useInstallerClientStatus();
   const { products } = useProduct();
   const { language } = useInstallerL10n();
   const [status, setStatus] = useState(undefined);
@@ -75,9 +71,8 @@ function App() {
   }, [client, setPhase, setStatus]);
 
   const Content = () => {
-    if (!client || !products) {
-      return (attempt > ATTEMPTS) ? <DBusError /> : <Loading />;
-    }
+    if (!client || !client.isRecoverable()) return <WebSocketError />;
+    if (!products) return <Loading />;
 
     if ((phase === STARTUP && status === BUSY) || phase === undefined || status === undefined) {
       return <Loading />;

--- a/web/src/components/core/WebSocketError.jsx
+++ b/web/src/components/core/WebSocketError.jsx
@@ -28,19 +28,19 @@ import { locationReload } from "~/utils";
 
 const ErrorIcon = () => <Icon name="error" className="icon-xxxl" />;
 
-function DBusError() {
+function WebSocketError() {
   return (
     // TRANSLATORS: page title
-    <Page icon="problem" title={_("D-Bus Error")}>
+    <Page icon="problem" title={_("Websocket Error")}>
       <Center>
         <EmptyState variant="xl">
           <EmptyStateHeader
-            titleText={_("Cannot connect to D-Bus")}
+            titleText={_("Cannot connect to HTTP server")}
             headingLevel="h2"
             icon={<EmptyStateIcon icon={ErrorIcon} />}
           />
           <EmptyStateBody>
-            {_("Could not connect to the D-Bus service. Please, check whether it is running.")}
+            {_("Could not connect to the HTTP server. Please, check whether it is running.")}
           </EmptyStateBody>
         </EmptyState>
       </Center>
@@ -55,4 +55,4 @@ function DBusError() {
   );
 }
 
-export default DBusError;
+export default WebSocketError;

--- a/web/src/components/core/WebSocketError.test.jsx
+++ b/web/src/components/core/WebSocketError.test.jsx
@@ -24,19 +24,19 @@ import { screen } from "@testing-library/react";
 import { plainRender } from "~/test-utils";
 
 import * as utils from "~/utils";
-import { DBusError } from "~/components/core";
+import { WebSocketError } from "~/components/core";
 
 jest.mock("~/components/core/Sidebar", () => () => <div>Agama sidebar</div>);
 
-describe("DBusError", () => {
-  it("includes a generic D-Bus connection problem message", () => {
-    plainRender(<DBusError />);
-    screen.getByText(/Could not connect to the D-Bus service/i);
+describe("WebSocketError", () => {
+  it("includes a generic websocket connection problem message", () => {
+    plainRender(<WebSocketError />);
+    screen.getByText(/Could not connect to the HTTP server/i);
   });
 
   it("calls location.reload when user clicks on 'Reload'", async () => {
     jest.spyOn(utils, "locationReload").mockImplementation(utils.noop);
-    const { user } = plainRender(<DBusError />);
+    const { user } = plainRender(<WebSocketError />);
     const reloadButton = await screen.findByRole("button", { name: /Reload/i });
     await user.click(reloadButton);
     expect(utils.locationReload).toHaveBeenCalled();

--- a/web/src/components/core/index.js
+++ b/web/src/components/core/index.js
@@ -21,7 +21,7 @@
 
 export { default as About } from "./About";
 export { default as PageMenu } from "./PageMenu";
-export { default as DBusError } from "./DBusError";
+export { default as WebSocketError } from "./WebSocketError";
 export { default as Description } from "./Description";
 export { default as Disclosure } from "./Disclosure";
 export { default as Sidebar } from "./Sidebar";

--- a/web/src/context/installer.jsx
+++ b/web/src/context/installer.jsx
@@ -27,7 +27,7 @@ import { createDefaultClient } from "~/client";
 const InstallerClientContext = React.createContext(null);
 // TODO: we use a separate context to avoid changing all the codes to
 // `useInstallerClient`. We should merge them in the future.
-const InstallerClientStatusContext = React.createContext({ connected: false, attempt: 0 });
+const InstallerClientStatusContext = React.createContext({ connected: false });
 
 /**
  * Returns the D-Bus installer client
@@ -48,7 +48,6 @@ function useInstallerClient() {
  *
  * @typedef {object} ClientStatus
  * @property {boolean} connected - whether the client is connected
- * @property {number} attempt - number of attempt to connect
  *
  * @return {ClientStatus} installer client status
  */
@@ -61,8 +60,6 @@ function useInstallerClientStatus() {
   return context;
 }
 
-const INTERVAL = 2000;
-
 /**
   * @param {object} props
   * @param {import("~/client").InstallerClient|undefined} [props.client] client to connect to
@@ -73,23 +70,14 @@ const INTERVAL = 2000;
   * @param {React.ReactNode} [props.children] - content to display within the provider
   */
 function InstallerClientProvider({
-  children, client = null, interval = INTERVAL
+  children, client = null
 }) {
   const [value, setValue] = useState(client);
-  const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
     const connectClient = async () => {
       const client = await createDefaultClient();
-      if (await client.isConnected()) {
-        setValue(client);
-        setAttempt(0);
-        return;
-      }
-
-      console.warn(`Failed to connect to Agama API (attempt ${attempt + 1})`);
-      await new Promise(resolve => setTimeout(resolve, interval));
-      setAttempt(attempt + 1);
+      setValue(client);
     };
 
     // allow hot replacement for the clients code
@@ -99,28 +87,23 @@ function InstallerClientProvider({
         console.log("[Agama HMR] A client module has been updated");
 
         const updated_client = await createDefaultClient();
-        if (await updated_client.isConnected()) {
-          console.log("[Agama HMR] Using new clients");
-          setValue(updated_client);
-        } else {
-          console.warn("[Agama HMR] Updating clients failed, using full page reload");
-          window.location.reload();
-        }
+        console.log("[Agama HMR] Using new clients");
+        setValue(updated_client);
       });
     }
 
     if (!value) connectClient();
-  }, [setValue, value, setAttempt, attempt, interval]);
+  }, [setValue, value]);
 
-  useEffect(() => {
-    if (!value) return;
+  const connected = () => {
+    if (!value) return false;
 
-    return value.onDisconnect(() => setValue(null));
-  }, [value]);
+    return value.isConnected();
+  };
 
   return (
     <InstallerClientContext.Provider value={value}>
-      <InstallerClientStatusContext.Provider value={{ attempt, connected: !!value }}>
+      <InstallerClientStatusContext.Provider value={{ connected: connected() }}>
         {children}
       </InstallerClientStatusContext.Provider>
     </InstallerClientContext.Provider>


### PR DESCRIPTION
## Problem

When the current WebSocket is closed or there is an error the frontend is not aware of it and does not react properly just stop receiving notifications. It would be nice to reconnect silently reporting in case that it is impossible to reconnect after a while.

- Trello Card: https://trello.com/c/Kqaez0RH/3632-2-agama-adapt-connection-error-handling

## Solution

When the WebSocket is closed we will try to reconnect during a while. From that point in advance the state of the socket will be unrecoverable needing a user manual reconnection.


