### PR TITLE
fix: add the agama.libsonnet file to the spec

### DIFF
--- a/rust/etc/agama.d/server.yaml
+++ b/rust/etc/agama.d/server.yaml
@@ -1,0 +1,2 @@
+---
+jwt_secret: "replace-me"

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon May 27 05:49:46 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add agama.libssonnet to the spec file (gh#openSUSE/agama#1261).
+
+-------------------------------------------------------------------
 Thu May 23 15:47:28 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Avoid deadlock when "setxkbmap" call gets stucked, use a timeout

--- a/rust/package/agama.spec
+++ b/rust/package/agama.spec
@@ -125,6 +125,7 @@ echo $PATH
 %files -n agama-cli
 %{_bindir}/agama
 %dir %{_datadir}/agama-cli
+%{_datadir}/agama-cli/agama.libsonnet
 %{_datadir}/agama-cli/profile.schema.json
 
 %changelog


### PR DESCRIPTION
## Problem

The `agama.libsonnet` file is missing from the spec file, which causes a problem when building the package in OBS.

## Solution

Just add the file and update the changelog.