### PR TITLE
feat(schema): guided and AutoYaST storage proposals

### DIFF
--- a/rust/agama-lib/share/examples/profile_tw.json
+++ b/rust/agama-lib/share/examples/profile_tw.json
@@ -12,7 +12,12 @@
     "id": "Tumbleweed"
   },
   "storage": {
-    "bootDevice": "/dev/dm-1"
+    "guided": {
+      "boot": {
+        "configure": true,
+        "device": "/dev/dm-1"
+      }
+    }
   },
   "user": {
     "fullName": "Jane Doe",

--- a/rust/agama-lib/share/examples/storage.json
+++ b/rust/agama-lib/share/examples/storage.json
@@ -1,0 +1,63 @@
+{
+  "storage": {
+    "guided": {
+      "target": {
+        "disk": "/dev/vdc"
+      },
+      "boot": {
+        "configure": true,
+        "device": "/dev/vda"
+      },
+      "encryption": {
+        "password": "notsecret",
+        "method": "luks2",
+        "pbkdFunction": "argon2i"
+      },
+      "space": {
+        "policy": "custom",
+        "actions": [
+          { "resize": "/dev/vda" },
+          { "forceDelete": "/dev/vdb1" }
+        ]
+      },
+      "volumes": [
+        {
+          "mount": {
+            "path": "/",
+            "options": ["ro"]
+          },
+          "filesystem": {
+            "btrfs": {
+              "snapshots": true
+            }
+          },
+          "size": [1024, "5 Gib"],
+          "target": "default"
+        },
+        {
+          "mount": {
+            "path": "/home"
+          },
+          "filesystem": "xfs",
+          "size": {
+            "min": "5 GiB",
+            "max": "20 GiB"
+          },
+          "target": {
+            "newVg": "/dev/vda"
+          }
+        },
+        {
+          "mount": {
+            "path": "swap"
+          },
+          "filesystem": "swap",
+          "size": "8 GiB",
+          "target": {
+            "newPartition": "/dev/vda"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -271,7 +271,6 @@
               "title": "Target device",
               "oneOf": [
                 {
-                  "type": "string",
                   "enum": ["disk", "newLvmVg"]
                 },
                 {
@@ -320,19 +319,16 @@
                 },
                 "method": {
                   "title": "Method used to create the encryption devices",
-                  "type": "string",
                   "enum": ["luks2", "tpm_fde"]
                 },
                 "pbkdFunction": {
                   "title": "Password-based key derivation function to use for LUKS2",
-                  "type": "string",
                   "enum": ["pbkdf2", "argon2i", "argon2id"]
                 }
               }
             },
             "space": {
               "title": "Policy to find space for the new partitions",
-              "type": "string",
               "enum": [ "delete", "resize", "keep" ]
             },
             "volumes": {

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://github.com/openSUSE/agama/blob/master/rust/agama-lib/share/profile.schema.json",
   "title": "Profile",
   "description": "Profile definition for automated installation",
@@ -96,8 +96,7 @@
                 "type": "array",
                 "items": {
                   "title": "Connection addresses",
-                  "type": "string",
-                  "additionalProperties": false
+                  "type": "string"
                 }
               },
               "nameservers": {
@@ -105,8 +104,7 @@
                 "items": {
                   "title": "Nameservers",
                   "description": "IPv4 and/or IPv6 are allowed.",
-                  "type": "string",
-                  "additionalProperties": false
+                  "type": "string"
                 }
               },
               "wireless": {
@@ -149,8 +147,7 @@
                     "type": "array",
                     "items": {
                       "title": "A list of the interfaces or connections to be bonded",
-                      "type": "string",
-                      "additionalProperties": false
+                      "type": "string"
                     }
                   }
                 }
@@ -164,32 +161,28 @@
                     "type": "array",
                     "items": {
                       "title": "A list of kernel command line arguments to match",
-                      "type": "string",
-                      "additionalProperties": false
+                      "type": "string"
                     }
                   },
                   "interface": {
                     "type": "array",
                     "items": {
                       "title": "A list of interface names to match",
-                      "type": "string",
-                      "additionalProperties": false
+                      "type": "string"
                     }
                   },
                   "driver": {
                     "type": "array",
                     "items": {
                       "title": "A list of driver names to match",
-                      "type": "string",
-                      "additionalProperties": false
+                      "type": "string"
                     }
                   },
                   "path": {
                     "type": "array",
                     "items": {
                       "title": "A list of paths to match against the ID_PATH udev property of devices",
-                      "type": "string",
-                      "additionalProperties": false
+                      "type": "string"
                     }
                   }
                 }
@@ -288,7 +281,7 @@
                       "items": { "type": "string" }
                     }
                   },
-                  "required": ["newLvmVg"] 
+                  "required": ["newLvmVg"]
                 }
               ]
             },
@@ -329,7 +322,64 @@
             },
             "space": {
               "title": "Policy to find space for the new partitions",
-              "enum": [ "delete", "resize", "keep" ]
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "policy": {
+                  "enum": ["delete", "resize", "keep", "custom"]
+                },
+                "actions": {
+                  "type": "array"
+                }
+              },
+              "if": {
+                "properties": {
+                  "policy": { "const": "custom" }
+                }
+              },
+              "then": {
+                "required": ["policy", "actions"],
+                "properties": {
+                  "actions": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "required": ["forceDelete"],
+                          "additionalProperties": false,
+                          "properties": {
+                            "forceDelete": {
+                              "title": "Device to delete",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "required": ["resize"],
+                          "additionalProperties": false,
+                          "properties": {
+                            "resize": {
+                              "title": "Device to allow resizing",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "else": {
+                "required": ["policy"],
+                "properties": {
+                  "actions": {
+                    "type": "array",
+                    "maxItems": 0
+                  }
+                }
+              }
             },
             "volumes": {
               "title": "Set of volumes (file systems) to create",
@@ -345,8 +395,8 @@
                     "required": ["path"],
                     "properties": {
                       "path": {
-                      "title": "Mount path",
-                      "type": "string"
+                        "title": "Mount path",
+                        "type": "string"
                       },
                       "options": {
                         "title": "Options to add to the fourth field of fstab",
@@ -392,19 +442,13 @@
                       { "$ref": "#/$defs/sizeString" },
                       { "$ref": "#/$defs/sizeInteger" },
                       {
+                        "description": "Lower size limit and optionally upper size limit",
                         "type": "array",
+                        "items": {
+                          "$ref": "#/$defs/sizeValue"
+                        },
                         "minItems": 1,
-                        "maxItems": 2,
-                        "prefixItems": [
-                          {
-                            "title": "Mandatory lower size limit",
-                            "$ref": "#/$defs/sizeValue"
-                          },
-                          {
-                            "title": "Optional upper size limit",
-                            "$ref": "#/$defs/sizeValue"
-                          }
-                        ]
+                        "maxItems": 2
                       },
                       {
                         "type": "object",
@@ -421,23 +465,7 @@
                         },
                         "required": ["min"]
                       }
-                    ],
-                    "$defs": {
-                      "sizeString": {
-                        "type": "string",
-                        "pattern": "^[0-9]+(\\.[0-9]+)?(\\s*([KkMmGgTtPpEeZzYy][iI]?)?[Bb])?"
-                      },
-                      "sizeInteger": {
-                        "type": "integer",
-                        "minimum": 0
-                      },
-                      "sizeValue": {
-                        "oneOf": [
-                          { "$ref": "#/$defs/sizeString" },
-                          { "$ref": "#/$defs/sizeInteger" }
-                        ]
-                      }
-                    }
+                    ]
                   },
                   "target": {
                     "title": "Location of the resulting file system",
@@ -481,6 +509,24 @@
     "legacyAutoyastStorage": {
       "title": "Legacy AutoYaST storage settings",
       "type": "object"
+    }
+  },
+  "$defs": {
+    "sizeString": {
+      "title": "Human readable size (e.g., '2 GiB')",
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+)?(\\s*([KkMmGgTtPpEeZzYy][iI]?)?[Bb])?$"
+    },
+    "sizeInteger": {
+      "title": "Size in bytes",
+      "type": "integer",
+      "minimum": 0
+    },
+    "sizeValue": {
+      "oneOf": [
+        { "$ref": "#/$defs/sizeString" },
+        { "$ref": "#/$defs/sizeInteger" }
+      ]
     }
   }
 }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -256,22 +256,194 @@
       }
     },
     "storage": {
-      "description": "Storage settings",
+      "title": "Storage settings",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
-        "bootDevice": {
-          "description": "Device used for booting (e.g., '/dev/sda'). By default, all file systems are created in the boot device.",
-          "type": "string"
-        },
-        "lvm": {
-          "description": "Whether LVM is used.",
-          "type": "boolean"
-        },
-        "encryptionPassword": {
-          "description": "If set, the devices are encrypted using the given password.",
-          "type": "string"
+        "guided": {
+          "title": "Settings to execute a Guided Proposal",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "target": {
+              "title": "Target device",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": ["disk", "newLvmVg"]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": { "disk": { "type": "string" } },
+                  "required": ["disk"]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "newLvmVg": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  },
+                  "required": ["newLvmVg"] 
+                }
+              ]
+            },
+            "boot": {
+              "title": "Configuration of the boot settings",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "configure": {
+                  "title": "Whether to configure partitions for booting",
+                  "type": "boolean"
+                },
+                "device": {
+                  "title": "Device to use for booting",
+                  "type": "string"
+                }
+              }
+            },
+            "encryption": {
+              "title": "Encryption settings",
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["password"],
+              "properties": {
+                "password": {
+                  "title": "Passphrase to use when creating new encryption devices",
+                  "type": "string"
+                },
+                "method": {
+                  "title": "Method used to create the encryption devices",
+                  "type": "string",
+                  "enum": ["luks2", "tpm_fde"]
+                },
+                "pbkdFunction": {
+                  "title": "Password-based key derivation function to use for LUKS2",
+                  "type": "string",
+                  "enum": ["pbkdf2", "argon2i", "argon2id"]
+                }
+              }
+            },
+            "space": {
+              "title": "Policy to find space for the new partitions",
+              "type": "string",
+              "enum": [ "delete", "resize", "keep" ]
+            },
+            "volumes": {
+              "title": "Set of volumes (file systems) to create",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["mount"],
+                "properties": {
+                  "mount": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["path"],
+                    "properties": {
+                      "path": {
+                      "title": "Mount path",
+                      "type": "string"
+                      },
+                      "options": {
+                        "title": "Options to add to the fourth field of fstab",
+                        "type": "array",
+                        "items": { "type": "string" }
+                      }
+                    }
+                  },
+                  "filesystem": {
+                    "title": "File system of the volume",
+                    "type": ["string", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "btrfs": {
+                        "title": "Specification of a Btrfs file system",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "snapshots": {
+                            "title": "Whether Btrfs snapshots should be configured",
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "size": {
+                    "title": "Size limits",
+                    "description": "It can be 'auto', a fixed size (as string or integer) or a set of size limits",
+                    "type": ["string", "integer", "array", "object"],
+                    "prefixItems": [
+                      {
+                        "title": "Mandatory lower size limit",
+                        "type": ["integer", "string"]
+                      },
+                      { 
+                        "title": "Optional upper size limit",
+                        "type": ["integer", "string"]
+                      }
+                    ],
+                    "additionalProperties": false,
+                    "required": ["min"],
+                    "properties": {
+                      "min": {
+                        "title": "Mandatory lower size limit",
+                        "type": ["integer", "string"]
+                      },
+                      "max": {
+                        "title": "Optional upper size limit",
+                        "type": ["integer", "string"]
+                      }
+                    }
+                  },
+                  "target": {
+                    "title": "Location of the resulting file system",
+                    "oneOf": [
+                      {
+                        "const": "default"
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": { "newPartition": { "type": "string" } },
+                        "required": ["newPartition"]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": { "newVg": { "type": "string" } },
+                        "required": ["newVg"]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": { "device": { "type": "string" } },
+                        "required": ["device"]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": { "filesystem": { "type": "string" } },
+                        "required": ["filesystem"]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
         }
       }
+    },
+    "legacyAutoyastStorage": {
+      "title": "Legacy AutoYaST storage settings",
+      "type": "object"
     }
   }
 }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -262,26 +262,37 @@
           "properties": {
             "target": {
               "title": "Target device",
-              "oneOf": [
+              "anyOf": [
                 {
                   "enum": ["disk", "newLvmVg"]
                 },
                 {
+                  "title": "Disk device for installing",
                   "type": "object",
                   "additionalProperties": false,
-                  "properties": { "disk": { "type": "string" } },
-                  "required": ["disk"]
+                  "required": ["disk"],
+                  "properties": {
+                    "disk": {
+                      "title": "Disk device name (e.g., '/dev/vda')",
+                      "type": "string"
+                    }
+                  }
                 },
                 {
+                  "title": "New LVM for installing",
                   "type": "object",
                   "additionalProperties": false,
+                  "required": ["newLvmVg"],
                   "properties": {
                     "newLvmVg": {
+                      "title": "Devices in which to create the physical volumes",
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "title": "Disk device name (e.g., '/dev/vda')",
+                        "type": "string"
+                      }
                     }
-                  },
-                  "required": ["newLvmVg"]
+                  }
                 }
               ]
             },
@@ -289,13 +300,15 @@
               "title": "Configuration of the boot settings",
               "type": "object",
               "additionalProperties": false,
+              "required": ["configure"],
               "properties": {
                 "configure": {
                   "title": "Whether to configure partitions for booting",
                   "type": "boolean"
                 },
                 "device": {
-                  "title": "Device to use for booting",
+                  "title": "Device to use for booting (e.g., '/dev/vda')",
+                  "description": "The installation device is used by default for booting",
                   "type": "string"
                 }
               }
@@ -341,27 +354,32 @@
                 "required": ["policy", "actions"],
                 "properties": {
                   "actions": {
+                    "title": "Actions to find space if policy is 'custom'",
                     "type": "array",
                     "items": {
                       "anyOf": [
                         {
+                          "title": "Delete device",
+                          "description": "Force device deletion",
                           "type": "object",
                           "required": ["forceDelete"],
                           "additionalProperties": false,
                           "properties": {
                             "forceDelete": {
-                              "title": "Device to delete",
+                              "title": "Device to delete (e.g., '/dev/vda')",
                               "type": "string"
                             }
                           }
                         },
                         {
+                          "title": "Allow shinking",
+                          "description": "Indicate the device can be shrunk in needed",
                           "type": "object",
                           "required": ["resize"],
                           "additionalProperties": false,
                           "properties": {
                             "resize": {
-                              "title": "Device to allow resizing",
+                              "title": "Device to allow resizing (e.g., '/dev/vda')",
                               "type": "string"
                             }
                           }
@@ -390,6 +408,7 @@
                 "required": ["mount"],
                 "properties": {
                   "mount": {
+                    "title": "Mount point",
                     "type": "object",
                     "additionalProperties": false,
                     "required": ["path"],
@@ -407,17 +426,20 @@
                   },
                   "filesystem": {
                     "title": "File system of the volume",
-                    "oneOf": [
+                    "anyOf": [
                       {
-                        "description": "File system type",
+                        "title": "File system type",
                         "enum": [
                           "bcachefs", "btrfs", "exfat", "ext2", "ext3", "ext4", "f2fs", "jfs",
                           "nfs", "nilfs2", "ntfs", "reiserfs", "swap", "tmpfs", "vfat", "xfs"
                         ]
                       },
                       {
+                        "title": "Btrfs file system",
+                        "description": "Indicates properties of the Btrfs file system",
                         "type": "object",
                         "additionalProperties": false,
+                        "required": ["btrfs"],
                         "properties": {
                           "btrfs": {
                             "title": "Specification of a Btrfs file system",
@@ -430,18 +452,25 @@
                               }
                             }
                           }
-                        },
-                        "required": ["btrfs"]
+                        }
                       }
                     ]
                   },
                   "size": {
                     "title": "Size limits",
-                    "oneOf": [
-                      { "const": "auto" },
-                      { "$ref": "#/$defs/sizeString" },
-                      { "$ref": "#/$defs/sizeInteger" },
+                    "description": "Options to indicate the size of a device",
+                    "anyOf": [
                       {
+                        "title": "Automatic size",
+                        "description": "The size is auto calculated according to the product",
+                        "const": "auto"
+                      },
+                      {
+                        "title": "Size unit",
+                        "$ref": "#/$defs/sizeValue"
+                      },
+                      {
+                        "title": "Size range (e.g., [1024, '2 GiB'])",
                         "description": "Lower size limit and optionally upper size limit",
                         "type": "array",
                         "items": {
@@ -451,6 +480,7 @@
                         "maxItems": 2
                       },
                       {
+                        "title": "Size range",
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
@@ -468,34 +498,63 @@
                     ]
                   },
                   "target": {
-                    "title": "Location of the resulting file system",
-                    "oneOf": [
+                    "title": "Location of the file system",
+                    "description": "Options to indicate the location of a file system",
+                    "anyOf": [
                       {
                         "const": "default"
                       },
                       {
+                        "title": "New partition",
+                        "description": "The file system is created over a new partition",
                         "type": "object",
+                        "required": ["newPartition"],
                         "additionalProperties": false,
-                        "properties": { "newPartition": { "type": "string" } },
-                        "required": ["newPartition"]
+                        "properties": {
+                          "newPartition": {
+                            "title": "Name of a disk device (e.g., '/dev/vda')",
+                            "type": "string"
+                            }
+                        }
                       },
                       {
+                        "title": "Dedicated LVM volume group",
+                        "description": "The file system is created over a dedicated LVM",
                         "type": "object",
                         "additionalProperties": false,
-                        "properties": { "newVg": { "type": "string" } },
-                        "required": ["newVg"]
+                        "required": ["newVg"],
+                        "properties": {
+                          "newVg": {
+                            "title": "Name of a disk device (e.g., '/dev/vda')",
+                            "type": "string"
+                          }
+                        }
                       },
                       {
+                        "title": "Re-used existing device",
+                        "description": "The file system is created over an existing device",
                         "type": "object",
                         "additionalProperties": false,
-                        "properties": { "device": { "type": "string" } },
-                        "required": ["device"]
+                        "required": ["device"],
+                        "properties": {
+                          "device": {
+                            "title": "Name of a device (e.g., '/dev/vda1')",
+                            "type": "string"
+                          }
+                        }
                       },
                       {
+                        "title": "Re-used existing file system",
+                        "description": "An existing file system is reused (without formatting)",
                         "type": "object",
                         "additionalProperties": false,
-                        "properties": { "filesystem": { "type": "string" } },
-                        "required": ["filesystem"]
+                        "required": ["filesystem"],
+                        "properties": {
+                          "filesystem": {
+                            "title": "Name of a device containing the file system (e.g., '/dev/vda1')",
+                            "type": "string"
+                          }
+                        }
                       }
                     ]
                   }
@@ -508,6 +567,7 @@
     },
     "legacyAutoyastStorage": {
       "title": "Legacy AutoYaST storage settings",
+      "description": "Accepts all options of the AutoYaST profile (XML to JSON)",
       "type": "object"
     }
   },
@@ -523,7 +583,7 @@
       "minimum": 0
     },
     "sizeValue": {
-      "oneOf": [
+      "anyOf": [
         { "$ref": "#/$defs/sizeString" },
         { "$ref": "#/$defs/sizeInteger" }
       ]

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -1,4 +1,5 @@
 {
+  "$comment": "based on doc/auto_storage.md",
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://github.com/openSUSE/agama/blob/master/rust/agama-lib/share/profile.schema.json",
   "title": "Profile",

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -7,55 +7,56 @@
   "additionalProperties": false,
   "properties": {
     "software": {
-      "description": "Software settings (e.g., product to install)",
+      "title": "Software settings",
       "type": "object",
       "properties": {
         "patterns": {
-          "description": "List of patterns to install",
+          "title": "List of patterns to install",
           "type": "array"
         }
       }
     },
     "product": {
-      "description": "Software settings (e.g., product to install)",
+      "title": "Product to install",
       "type": "object",
       "properties": {
         "id": {
-          "description": "Product identifier",
+          "title": "Product identifier",
           "type": "string"
         },
         "registrationCode": {
-          "description": "Product registration code",
+          "title": "Product registration code",
           "type": "string"
         },
         "registrationEmail": {
-          "description": "Product registration email",
+          "title": "Product registration email",
           "type": "string"
         }
       }
     },
     "network": {
-      "description": "Network settings",
+      "title": "Network settings",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "connections": {
-          "description": "Network connections to be defined",
+          "title": "Network connections to be defined",
           "type": "array",
           "items": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
               "id": {
-                "description": "Connection ID",
+                "title": "Connection ID",
                 "type": "string"
               },
               "interface": {
-                "description": "The name of the network interface bound to this connection",
+                "title": "The name of the network interface bound to this connection",
                 "type": "string"
               },
               "mac-address": {
-                "description": "Custom mac-address (can also be 'preserve', 'permanent', 'random' or 'stable')",
+                "title": "Custom mac-address",
+                "description": "Can also be 'preserve', 'permanent', 'random' or 'stable'.",
                 "type": "string"
               },
               "mtu": {
@@ -64,7 +65,7 @@
                 "minimum": 0
               },
               "method4": {
-                "description": "IPv4 configuration method (e.g., 'auto')",
+                "title": "IPv4 configuration method (e.g., 'auto')",
                 "type": "string",
                 "enum": [
                   "auto",
@@ -74,7 +75,7 @@
                 ]
               },
               "method6": {
-                "description": "IPv6 configuration method (e.g., 'auto')",
+                "title": "IPv6 configuration method (e.g., 'auto')",
                 "type": "string",
                 "enum": [
                   "auto",
@@ -84,17 +85,17 @@
                 ]
               },
               "gateway4": {
-                "description": "Connection gateway address (e.g., '192.168.122.1')",
+                "title": "Connection gateway address (e.g., '192.168.122.1')",
                 "type": "string"
               },
               "gateway6": {
-                "description": "Connection gateway address (e.g., '::ffff:c0a8:7a01')",
+                "title": "Connection gateway address (e.g., '::ffff:c0a8:7a01')",
                 "type": "string"
               },
               "addresses": {
                 "type": "array",
                 "items": {
-                  "description": "Connection addresses",
+                  "title": "Connection addresses",
                   "type": "string",
                   "additionalProperties": false
                 }
@@ -102,14 +103,15 @@
               "nameservers": {
                 "type": "array",
                 "items": {
-                  "description": "Nameservers (IPv4 and/or IPv6 are allowed)",
+                  "title": "Nameservers",
+                  "description": "IPv4 and/or IPv6 are allowed.",
                   "type": "string",
                   "additionalProperties": false
                 }
               },
               "wireless": {
                 "type": "object",
-                "description": "Wireless configuration",
+                "title": "Wireless configuration",
                 "additionalProperties": false,
                 "properties": {
                   "password": {
@@ -134,7 +136,7 @@
               },
               "bond": {
                 "type": "object",
-                "description": "Bonding configuration",
+                "title": "Bonding configuration",
                 "additionalProperties": false,
                 "properties": {
                   "mode": {
@@ -146,7 +148,7 @@
                   "ports": {
                     "type": "array",
                     "items": {
-                      "description": "A list of the interfaces or connections to be bonded",
+                      "title": "A list of the interfaces or connections to be bonded",
                       "type": "string",
                       "additionalProperties": false
                     }
@@ -155,13 +157,13 @@
               },
               "match": {
                 "type": "object",
-                "description": "Match settings",
+                "title": "Match settings",
                 "additionalProperties": false,
                 "properties": {
                   "kernel": {
                     "type": "array",
                     "items": {
-                      "description": "A list of kernel command line arguments to match",
+                      "title": "A list of kernel command line arguments to match",
                       "type": "string",
                       "additionalProperties": false
                     }
@@ -169,7 +171,7 @@
                   "interface": {
                     "type": "array",
                     "items": {
-                      "description": "A list of interface names to match",
+                      "title": "A list of interface names to match",
                       "type": "string",
                       "additionalProperties": false
                     }
@@ -177,7 +179,7 @@
                   "driver": {
                     "type": "array",
                     "items": {
-                      "description": "A list of driver names to match",
+                      "title": "A list of driver names to match",
                       "type": "string",
                       "additionalProperties": false
                     }
@@ -185,7 +187,7 @@
                   "path": {
                     "type": "array",
                     "items": {
-                      "description": "A list of paths to match against the ID_PATH udev property of devices",
+                      "title": "A list of paths to match against the ID_PATH udev property of devices",
                       "type": "string",
                       "additionalProperties": false
                     }
@@ -201,19 +203,19 @@
       }
     },
     "user": {
-      "description": "First user settings",
+      "title": "First user settings",
       "type": "object",
       "properties": {
         "fullName": {
-          "description": "Full name (e.g., 'Jane Doe')",
+          "title": "Full name (e.g., 'Jane Doe')",
           "type": "string"
         },
         "userName": {
-          "description": "User login name (e.g., 'jane.doe')",
+          "title": "User login name (e.g., 'jane.doe')",
           "type": "string"
         },
         "password": {
-          "description": "User password (e.g., 'nots3cr3t')",
+          "title": "User password (e.g., 'nots3cr3t')",
           "type": "string"
         }
       },
@@ -224,33 +226,33 @@
       ]
     },
     "root": {
-      "description": "Root authentication settings",
+      "title": "Root authentication settings",
       "type": "object",
       "properties": {
         "password": {
-          "description": "Root password",
+          "title": "Root password",
           "type": "string"
         },
         "sshPublicKey": {
-          "description": "SSH public key",
+          "title": "SSH public key",
           "type": "string"
         }
       }
     },
     "localization": {
-      "description": "Localization settings",
+      "title": "Localization settings",
       "type": "object",
       "properties": {
         "language": {
-          "description": "System language ID (e.g., 'en_US')",
+          "title": "System language ID (e.g., 'en_US')",
           "type": "string"
         },
         "keyboard": {
-          "description": "Keyboard layout ID",
+          "title": "Keyboard layout ID",
           "type": "string"
         },
         "timezone": {
-          "description": "Time zone identifier such as 'Europe/Berlin'",
+          "title": "Time zone identifier such as 'Europe/Berlin'",
           "type": "string"
         }
       }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -357,46 +357,85 @@
                   },
                   "filesystem": {
                     "title": "File system of the volume",
-                    "type": ["string", "object"],
-                    "additionalProperties": false,
-                    "properties": {
-                      "btrfs": {
-                        "title": "Specification of a Btrfs file system",
+                    "oneOf": [
+                      {
+                        "description": "File system type",
+                        "enum": [
+                          "bcachefs", "btrfs", "exfat", "ext2", "ext3", "ext4", "f2fs", "jfs",
+                          "nfs", "nilfs2", "ntfs", "reiserfs", "swap", "tmpfs", "vfat", "xfs"
+                        ]
+                      },
+                      {
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
-                          "snapshots": {
-                            "title": "Whether Btrfs snapshots should be configured",
-                            "type": "boolean"
+                          "btrfs": {
+                            "title": "Specification of a Btrfs file system",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "snapshots": {
+                                "title": "Whether Btrfs snapshots should be configured",
+                                "type": "boolean"
+                              }
+                            }
                           }
-                        }
+                        },
+                        "required": ["btrfs"]
                       }
-                    }
+                    ]
                   },
                   "size": {
                     "title": "Size limits",
-                    "description": "It can be 'auto', a fixed size (as string or integer) or a set of size limits",
-                    "type": ["string", "integer", "array", "object"],
-                    "prefixItems": [
+                    "oneOf": [
+                      { "const": "auto" },
+                      { "$ref": "#/$defs/sizeString" },
+                      { "$ref": "#/$defs/sizeInteger" },
                       {
-                        "title": "Mandatory lower size limit",
-                        "type": ["integer", "string"]
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 2,
+                        "prefixItems": [
+                          {
+                            "title": "Mandatory lower size limit",
+                            "$ref": "#/$defs/sizeValue"
+                          },
+                          {
+                            "title": "Optional upper size limit",
+                            "$ref": "#/$defs/sizeValue"
+                          }
+                        ]
                       },
-                      { 
-                        "title": "Optional upper size limit",
-                        "type": ["integer", "string"]
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "min": {
+                            "title": "Mandatory lower size limit",
+                            "$ref": "#/$defs/sizeValue"
+                          },
+                          "max": {
+                            "title": "Optional upper size limit",
+                            "$ref": "#/$defs/sizeValue"
+                          }
+                        },
+                        "required": ["min"]
                       }
                     ],
-                    "additionalProperties": false,
-                    "required": ["min"],
-                    "properties": {
-                      "min": {
-                        "title": "Mandatory lower size limit",
-                        "type": ["integer", "string"]
+                    "$defs": {
+                      "sizeString": {
+                        "type": "string",
+                        "pattern": "^[0-9]+(\\.[0-9]+)?(\\s*([KkMmGgTtPpEeZzYy][iI]?)?[Bb])?"
                       },
-                      "max": {
-                        "title": "Optional upper size limit",
-                        "type": ["integer", "string"]
+                      "sizeInteger": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "sizeValue": {
+                        "oneOf": [
+                          { "$ref": "#/$defs/sizeString" },
+                          { "$ref": "#/$defs/sizeInteger" }
+                        ]
                       }
                     }
                   },

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  1 15:50:40 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Schema definition for guided and AutoYaST storage proposals
+  (gh#openSUSE/agama#1263).
+
+-------------------------------------------------------------------
 Fri Jun 28 06:56:02 UTC 2024 - Martin Vidner <mvidner@suse.com>
 
 - Use gzip (.gz) instead of bzip2 (.bz2) to compress logs


### PR DESCRIPTION
Schema definition for the guided and AutoYaST storage proposals:

~~~json
{
  "storage": {
    "guided": { }
  },
  "legacyAutoyastStorage": [ ]
}
~~~

Based on [auto_storage.md](https://github.com/openSUSE/agama/blob/master/doc/auto_storage.md) which is expected to change over time.

Bonus: This includes a commit revisiting how `title` and `description` are used, to be more compliant with https://json-schema.org/understanding-json-schema/reference/annotations

Note for reviewers: you can easily check your JSON config files by using `agama profile validate config.json` 
