### PR TITLE
service: Avoid reading product mount points too early

### DIFF
--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon May 27 12:43:49 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Update product mount points as part of the probing (bsc#1225348).
+
+-------------------------------------------------------------------
 Tue May 21 05:32:46 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Emit a PropertiesChanged signal for ProductMountPoints and

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -69,9 +69,7 @@ describe Agama::DBus::Storage::Manager do
   end
 
   let(:software) do
-    instance_double(Agama::DBus::Clients::Software,
-      on_product_selected: nil,
-      on_probe_finished:   nil)
+    instance_double(Agama::DBus::Clients::Software, on_probe_finished: nil)
   end
 
   before do


### PR DESCRIPTION
## Problem

Changes in https://github.com/openSUSE/agama/pull/1236 introduced a bug reading the product mount points.

The list of mount points was read just after selecting a new product. At that time, the *storage* service has not updated its config yet, so it still uses the previous product.

Note that the *manager* service calls to storage `#probe` when a new product is selected, and the *storage* service updates its config as part of the call to `#probe`. For that reason, the product mount points cannot be updated until probe is done.

https://bugzilla.suse.com/show_bug.cgi?id=1225348

## Solution

Do not update the product mount points when the product changes. The list of product mount points is automatically refreshed once the probing is done.   
