### PR TITLE
feat(rust): read the password from stdin

### DIFF
--- a/rust/agama-cli/src/auth.rs
+++ b/rust/agama-cli/src/auth.rs
@@ -18,6 +18,9 @@ const DEFAULT_FILE_MODE: u32 = 0o600;
 #[derive(Subcommand, Debug)]
 pub enum AuthCommands {
     /// Authenticate with Agama's server and store the credentials
+    ///
+    /// It reads the password from the standard input. If it is not available,
+    /// it asks the user.
     Login,
     /// Deauthenticate by removing the credentials
     Logout,

--- a/rust/agama-cli/src/auth.rs
+++ b/rust/agama-cli/src/auth.rs
@@ -1,4 +1,4 @@
-use clap::{arg, Args, Subcommand};
+use clap::Subcommand;
 
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use std::fs;
@@ -18,7 +18,7 @@ const DEFAULT_FILE_MODE: u32 = 0o600;
 #[derive(Subcommand, Debug)]
 pub enum AuthCommands {
     /// Authenticate with Agama's server and store the credentials
-    Login(LoginArgs),
+    Login,
     /// Deauthenticate by removing the credentials
     Logout,
     /// Prints currently stored credentials to the standard output
@@ -28,7 +28,7 @@ pub enum AuthCommands {
 /// Main entry point called from agama CLI main loop
 pub async fn run(subcommand: AuthCommands) -> anyhow::Result<()> {
     match subcommand {
-        AuthCommands::Login(_options) => login(read_password()?).await,
+        AuthCommands::Login => login(read_password()?).await,
         AuthCommands::Logout => logout(),
         AuthCommands::Show => show(),
     }
@@ -70,15 +70,6 @@ fn read_password() -> Result<String, CliError> {
         buffer
     };
     Ok(password)
-}
-
-/// Stores user provided configuration for login command
-#[derive(Args, Debug)]
-pub struct LoginArgs {
-    #[arg(long, short = 'p')]
-    password: Option<String>,
-    #[arg(long, short = 'f')]
-    file: Option<PathBuf>,
 }
 
 /// Path to file where JWT is stored

--- a/rust/agama-cli/src/error.rs
+++ b/rust/agama-cli/src/error.rs
@@ -10,4 +10,6 @@ pub enum CliError {
     InstallationError,
     #[error("Missing the '=' separator in '{0}'")]
     MissingSeparator(String),
+    #[error("Could not read the password: {0}")]
+    MissingPassword(#[from] std::io::Error),
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 27 14:11:55 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- The "agama auth" command reads the password from the standard
+  input (gh#openSUSE/agama#1265).
+
+-------------------------------------------------------------------
 Mon May 27 05:49:46 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add agama.libssonnet to the spec file (gh#openSUSE/agama#1261).


### PR DESCRIPTION
The `agama auth` command is more complex than it should be. Instead of having a "switch" to read from a file or from the CLI itself, it now reads the password from the stdin and, if that's not possible, asks the user.
