### PR TITLE
fix(rust): avoid a long-lived probing request

### DIFF
--- a/rust/agama-server/src/manager/web.rs
+++ b/rust/agama-server/src/manager/web.rs
@@ -111,7 +111,7 @@ pub async fn manager_service(dbus: zbus::Connection) -> Result<Router, ServiceEr
     responses(
       (
           status = 200,
-          description = "The probing was requested but there is no way to know whether it succeed."
+          description = "The probing was requested but there is no way to know whether it succeeded."
        )
     )
 )]

--- a/rust/agama-server/src/manager/web.rs
+++ b/rust/agama-server/src/manager/web.rs
@@ -33,6 +33,7 @@ use crate::{
 
 #[derive(Clone)]
 pub struct ManagerState<'a> {
+    dbus: zbus::Connection,
     manager: ManagerClient<'a>,
 }
 
@@ -86,8 +87,8 @@ pub async fn manager_service(dbus: zbus::Connection) -> Result<Router, ServiceEr
 
     let status_router = service_status_router(&dbus, DBUS_SERVICE, DBUS_PATH).await?;
     let progress_router = progress_router(&dbus, DBUS_SERVICE, DBUS_PATH).await?;
-    let manager = ManagerClient::new(dbus).await?;
-    let state = ManagerState { manager };
+    let manager = ManagerClient::new(dbus.clone()).await?;
+    let state = ManagerState { manager, dbus };
     Ok(Router::new()
         .route("/probe", post(probe_action))
         .route("/install", post(install_action))
@@ -100,16 +101,36 @@ pub async fn manager_service(dbus: zbus::Connection) -> Result<Router, ServiceEr
 }
 
 /// Starts the probing process.
+// The Probe D-Bus method is blocking and will not return until the probing is finished. To avoid a
+// long-lived HTTP connection, this method returns immediately (with a 200) and runs the request on
+// a separate task.
 #[utoipa::path(
     get,
     path = "/probe",
     context_path = "/api/manager",
     responses(
-      (status = 200, description = "The probing process was started.")
+      (
+          status = 200,
+          description = "The probing was requested but there is no way to know whether it succeed."
+       )
     )
 )]
-async fn probe_action(State(state): State<ManagerState<'_>>) -> Result<(), Error> {
-    state.manager.probe().await?;
+async fn probe_action<'a>(State(state): State<ManagerState<'a>>) -> Result<(), Error> {
+    let dbus = state.dbus.clone();
+    tokio::spawn(async move {
+        let result = dbus
+            .call_method(
+                Some("org.opensuse.Agama.Manager1"),
+                "/org/opensuse/Agama/Manager1",
+                Some("org.opensuse.Agama.Manager1"),
+                "Probe",
+                &(),
+            )
+            .await;
+        if let Err(error) = result {
+            tracing::error!("Could not start probing: {:?}", error);
+        }
+    });
     Ok(())
 }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 29 10:40:21 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- The HTTP request to perform a probing is not blocking anymore
+  (gh#openSUSE/agama#1272).
+
+-------------------------------------------------------------------
 Mon May 27 14:11:55 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - The "agama auth" command reads the password from the standard


### PR DESCRIPTION
The `Probe` D-Bus function is a blocking one. It causes the call `POST /api/manager/probe` to be a long-lived request which is causing some problems (see #1254).

The proposed fix is to return immediately and run the request as a separate Tokio task. After all, we will get an update on the status through a WebSocket. If needed, we could also emit an error through the WebSocket.