### PR TITLE
fix(dbus): refresh AvailableProducts property

### DIFF
--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -182,3 +182,13 @@ trait Issues {
     #[dbus_proxy(property)]
     fn all(&self) -> zbus::Result<Vec<(String, String, u32, u32)>>;
 }
+
+#[dbus_proxy(
+    interface = "org.opensuse.Agama1.Locale",
+    default_service = "org.opensuse.Agama.Manager1",
+    default_path = "/org/opensuse/Agama/Manager1"
+)]
+trait Locale {
+    /// SetLocale method
+    fn set_locale(&self, locale: &str) -> zbus::Result<()>;
+}

--- a/rust/agama-lib/src/software/proxies.rs
+++ b/rust/agama-lib/src/software/proxies.rs
@@ -80,8 +80,7 @@ trait SoftwareProduct {
     /// SelectProduct method
     fn select_product(&self, id: &str) -> zbus::Result<(u32, String)>;
 
-    /// AvailableProducts property
-    #[dbus_proxy(property)]
+    /// AvailableProducts method
     fn available_products(&self) -> zbus::Result<Vec<Product>>;
 
     /// SelectedProduct property

--- a/service/lib/agama/dbus/clients/software.rb
+++ b/service/lib/agama/dbus/clients/software.rb
@@ -21,6 +21,7 @@
 
 require "agama/dbus/clients/base"
 require "agama/dbus/clients/with_issues"
+require "agama/dbus/clients/with_locale"
 require "agama/dbus/clients/with_progress"
 require "agama/dbus/clients/with_service_status"
 
@@ -29,6 +30,7 @@ module Agama
     module Clients
       # D-Bus client for software configuration
       class Software < Base
+        include WithLocale
         include WithIssues
         include WithProgress
         include WithServiceStatus

--- a/service/lib/agama/dbus/clients/storage.rb
+++ b/service/lib/agama/dbus/clients/storage.rb
@@ -21,6 +21,7 @@
 
 require "agama/dbus/clients/base"
 require "agama/dbus/clients/with_service_status"
+require "agama/dbus/clients/with_locale"
 require "agama/dbus/clients/with_progress"
 require "agama/dbus/clients/with_issues"
 
@@ -29,6 +30,7 @@ module Agama
     module Clients
       # D-Bus client for storage configuration
       class Storage < Base
+        include WithLocale
         include WithServiceStatus
         include WithProgress
         include WithIssues

--- a/service/lib/agama/dbus/clients/with_locale.rb
+++ b/service/lib/agama/dbus/clients/with_locale.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Agama
+  module DBus
+    module Clients
+      # Mixin for clients of services that define the Locale D-Bus interface
+      #
+      # Provides a method to interact with the API of the Locale interface.
+      #
+      # @note This mixin is expected to be included in a class inherited from {Clients::Base} and
+      #   it requires a #dbus_object method that returns a {::DBus::Object} implementing the
+      #   Locale interface.
+      module WithLocale
+        # Changes the service locale
+        #
+        # @param locale [String] new locale
+        def locale=(locale)
+          dbus_object.SetLocale(locale)
+        end
+      end
+    end
+  end
+
+end

--- a/service/lib/agama/dbus/interfaces/locale.rb
+++ b/service/lib/agama/dbus/interfaces/locale.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "dbus"
+
+Yast.import "WFM"
+
+module Agama
+  module DBus
+    module Interfaces
+      # Mixin to define the Locale interface.
+      #
+      # @note This mixin is expected to be included in a class that inherits from {DBus::BaseObject}
+      # and it requires a #locale= method that sets the service's locale.
+      module Locale
+        include Yast::I18n
+        include Yast::Logger
+
+        LOCALE_INTERFACE = "org.opensuse.Agama1.Locale"
+
+        def self.included(base)
+          base.class_eval do
+            dbus_interface LOCALE_INTERFACE do
+              dbus_method :SetLocale, "in locale:s" do |locale|
+                self.locale = locale
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/dbus/manager.rb
+++ b/service/lib/agama/dbus/manager.rb
@@ -24,6 +24,7 @@ require "agama/manager"
 require "agama/dbus/base_object"
 require "agama/dbus/with_service_status"
 require "agama/dbus/interfaces/progress"
+require "agama/dbus/interfaces/locale"
 require "agama/dbus/interfaces/service_status"
 require "agama/autoyast/converter"
 
@@ -34,6 +35,7 @@ module Agama
       include WithServiceStatus
       include Interfaces::Progress
       include Interfaces::ServiceStatus
+      include Interfaces::Locale
 
       PATH = "/org/opensuse/Agama/Manager1"
       private_constant :PATH
@@ -139,6 +141,12 @@ module Agama
       # @return [DBus::ServiceStatus]
       def service_status
         backend.service_status
+      end
+
+      def locale=(locale)
+        safe_run do
+          busy_while { backend.locale = locale  }
+        end
       end
 
     private

--- a/service/lib/agama/dbus/manager_service.rb
+++ b/service/lib/agama/dbus/manager_service.rb
@@ -28,7 +28,6 @@ require "agama/dbus/clients/locale"
 require "agama/dbus/manager"
 require "agama/dbus/users"
 require "agama/dbus/storage/proposal"
-require "agama/ui_locale"
 
 module Agama
   module DBus
@@ -74,8 +73,6 @@ module Agama
         export
         # We need locale for data from users
         locale_client = Clients::Locale.instance
-        # TODO: test if we need to pass block with additional actions
-        @ui_locale = UILocale.new(locale_client)
         manager.on_progress_change { dispatch } # make single thread more responsive
         manager.startup_phase
       end

--- a/service/lib/agama/dbus/software/manager.rb
+++ b/service/lib/agama/dbus/software/manager.rb
@@ -24,6 +24,7 @@ require "agama/dbus/base_object"
 require "agama/dbus/clients/locale"
 require "agama/dbus/clients/network"
 require "agama/dbus/interfaces/issues"
+require "agama/dbus/interfaces/locale"
 require "agama/dbus/interfaces/progress"
 require "agama/dbus/interfaces/service_status"
 require "agama/dbus/with_service_status"
@@ -37,6 +38,7 @@ module Agama
         include Interfaces::Progress
         include Interfaces::ServiceStatus
         include Interfaces::Issues
+        include Interfaces::Locale
 
         PATH = "/org/opensuse/Agama/Software1"
         private_constant :PATH
@@ -132,6 +134,12 @@ module Agama
 
         def finish
           busy_while { backend.finish }
+        end
+
+        def locale=(locale)
+          busy_while do
+            backend.locale = locale
+          end
         end
 
       private

--- a/service/lib/agama/dbus/software/product.rb
+++ b/service/lib/agama/dbus/software/product.rb
@@ -91,7 +91,9 @@ module Agama
         private_constant :PRODUCT_INTERFACE
 
         dbus_interface PRODUCT_INTERFACE do
-          dbus_reader :available_products, "a(ssa{sv})"
+          dbus_method :AvailableProducts, "out result:a(ssa{sv})" do
+            [available_products]
+          end
 
           dbus_reader :selected_product, "s"
 

--- a/service/lib/agama/dbus/software/product.rb
+++ b/service/lib/agama/dbus/software/product.rb
@@ -23,7 +23,9 @@ require "dbus"
 require "suse/connect"
 require "agama/dbus/base_object"
 require "agama/dbus/interfaces/issues"
+require "agama/dbus/clients/locale"
 require "agama/registration"
+require "agama/ui_locale"
 
 module Agama
   module DBus
@@ -241,11 +243,17 @@ module Agama
           #   software related issues.
           backend.registration.on_change { issues_properties_changed }
           backend.registration.on_change { registration_properties_changed }
+          UILocale.new(Clients::Locale.instance) { product_properties_changed }
         end
 
         def registration_properties_changed
           dbus_properties_changed(REGISTRATION_INTERFACE,
             interfaces_and_properties[REGISTRATION_INTERFACE], [])
+        end
+
+        def product_properties_changed
+          dbus_properties_changed(PRODUCT_INTERFACE,
+            interfaces_and_properties[PRODUCT_INTERFACE], [])
         end
 
         # Result from calling to SUSE connect.

--- a/service/lib/agama/dbus/software/product.rb
+++ b/service/lib/agama/dbus/software/product.rb
@@ -25,7 +25,6 @@ require "agama/dbus/base_object"
 require "agama/dbus/interfaces/issues"
 require "agama/dbus/clients/locale"
 require "agama/registration"
-require "agama/ui_locale"
 
 module Agama
   module DBus
@@ -243,7 +242,6 @@ module Agama
           #   software related issues.
           backend.registration.on_change { issues_properties_changed }
           backend.registration.on_change { registration_properties_changed }
-          UILocale.new(Clients::Locale.instance) { product_properties_changed }
         end
 
         def registration_properties_changed

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -25,6 +25,7 @@ require "yast"
 require "y2storage/storage_manager"
 require "agama/dbus/base_object"
 require "agama/dbus/interfaces/issues"
+require "agama/dbus/interfaces/locale"
 require "agama/dbus/interfaces/progress"
 require "agama/dbus/interfaces/service_status"
 require "agama/dbus/storage/devices_tree"
@@ -48,6 +49,7 @@ module Agama
         include WithServiceStatus
         include ::DBus::ObjectManager
         include DBus::Interfaces::Issues
+        include DBus::Interfaces::Locale
         include DBus::Interfaces::Progress
         include DBus::Interfaces::ServiceStatus
 
@@ -352,6 +354,10 @@ module Agama
           end
 
           dbus_method(:Delete, "in node:o, out result:u") { |n| iscsi_delete(n) }
+        end
+
+        def locale=(locale)
+          backend.locale = locale
         end
 
       private

--- a/service/lib/agama/dbus/storage_service.rb
+++ b/service/lib/agama/dbus/storage_service.rb
@@ -24,7 +24,6 @@ require "agama/dbus/bus"
 require "agama/dbus/clients/locale"
 require "agama/dbus/storage"
 require "agama/storage"
-require "agama/ui_locale"
 
 module Agama
   module DBus
@@ -53,8 +52,6 @@ module Agama
       # Starts storage service. It does more then just #export method.
       def start
         export
-        # TODO: test if we need to pass block with additional actions
-        @ui_locale = UILocale.new(Clients::Locale.instance)
       end
 
       # Exports the storage proposal object through the D-Bus service

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -23,6 +23,7 @@ require "yast"
 require "agama/config"
 require "agama/network"
 require "agama/proxy_setup"
+require "agama/with_locale"
 require "agama/with_progress"
 require "agama/installation_phase"
 require "agama/service_status_recorder"
@@ -43,6 +44,7 @@ module Agama
   # other services via D-Bus (e.g., `org.opensuse.Agama.Software1`).
   class Manager
     include WithProgress
+    include WithLocale
     include Helpers
     include Yast::I18n
 
@@ -77,6 +79,20 @@ module Agama
 
       logger.info("Startup phase done")
       service_status.idle
+    end
+
+    def locale=(locale)
+      service_status.busy
+      change_process_locale(locale)
+      start_progress_with_descriptions(
+        _("Load software translations"),
+        _("Load storage translations")
+      )
+      progress.step { software.locale = locale }
+      progress.step { storage.locale = locale }
+    ensure
+      service_status.idle
+      finish_progress
     end
 
     # Runs the config phase

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -31,6 +31,7 @@ require "agama/storage/iscsi/manager"
 require "agama/storage/finisher"
 require "agama/storage/proposal_settings_reader"
 require "agama/issue"
+require "agama/with_locale"
 require "agama/with_issues"
 require "agama/with_progress"
 require "agama/security"
@@ -43,6 +44,7 @@ module Agama
   module Storage
     # Manager to handle storage configuration
     class Manager
+      include WithLocale
       include WithIssues
       include WithProgress
       include Yast::I18n
@@ -169,6 +171,13 @@ module Agama
 
         staging = Y2Storage::StorageManager.instance.staging
         Actions.new(logger, staging.actiongraph).all
+      end
+
+      # Changes the service's locale
+      #
+      # @param locale [String] new locale
+      def locale=(locale)
+        change_process_locale(locale)
       end
 
     private

--- a/service/lib/agama/with_locale.rb
+++ b/service/lib/agama/with_locale.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022] SUSE LLC
+# Copyright (c) [2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -24,27 +24,12 @@ require "yast"
 Yast.import "WFM"
 
 module Agama
-  # Object responsible for managing changes of localization produced by D-Bus backend.
-  class UILocale
+  # Mixin that implements methods for handling with the localization
+  module WithLocale
     include Yast::I18n
     include Yast::Logger
-    # creates new UILocale object that will handle change of UI locale.
-    #
-    # @param [Agama::DBus::Clients::Locale] locale_client to communicate with dbus service
-    # @yield block is callback that is called when ui locale is changed
-    #   to allow user to call methods that needs retranslation
-    def initialize(locale_client, &block)
-      @client = locale_client
-      change_locale(@client.ui_locale)
-      @client.on_ui_locale_change do |locale|
-        change_locale(locale)
-        block.call(locale) if block_given?
-      end
-    end
 
-  private
-
-    def change_locale(locale)
+    def change_process_locale(locale)
       language, encoding = locale.split(".")
       Yast::WFM.SetLanguage(language, encoding)
       # explicitly set ENV to get localization also from libraries like libstorage

--- a/service/test/agama/dbus/software/product_test.rb
+++ b/service/test/agama/dbus/software/product_test.rb
@@ -24,6 +24,8 @@ require "agama/dbus/software/product"
 require "agama/config"
 require "agama/registration"
 require "agama/software/manager"
+require "agama/ui_locale"
+require "agama/dbus/clients/locale"
 require "suse/connect"
 
 describe Agama::DBus::Software::Product do
@@ -37,8 +39,16 @@ describe Agama::DBus::Software::Product do
 
   let(:target_dir) { Dir.mktmpdir }
 
+  let(:locale_client) do
+     instance_double(
+       Agama::DBus::Clients::Locale,
+       ui_locale: "en_US.UTF-8", on_ui_locale_change: nil
+     )
+  end
+
   before do
     stub_const("Agama::Software::Manager::TARGET_DIR", target_dir)
+    allow(Agama::DBus::Clients::Locale).to receive(:instance).and_return(locale_client)
     allow(config).to receive(:products).and_return(products)
     allow(subject).to receive(:dbus_properties_changed)
     allow(Agama::ProductReader).to receive(:new).and_call_original
@@ -49,7 +59,7 @@ describe Agama::DBus::Software::Product do
   end
 
   let(:products) do
-    { "Tumbleweed" => {}, "ALP-Dolomite" => {} }
+    { "Tumbleweed" => {}, "MicroOS" => {} }
   end
 
   it "defines Product D-Bus interface" do
@@ -83,7 +93,7 @@ describe Agama::DBus::Software::Product do
 
     context "if the current product is registered" do
       before do
-        subject.select_product("Leap16")
+        subject.select_product("MicroOS")
         allow(backend.registration).to receive(:reg_code).and_return("123XX432")
       end
 

--- a/service/test/agama/dbus/software/product_test.rb
+++ b/service/test/agama/dbus/software/product_test.rb
@@ -24,7 +24,6 @@ require "agama/dbus/software/product"
 require "agama/config"
 require "agama/registration"
 require "agama/software/manager"
-require "agama/ui_locale"
 require "agama/dbus/clients/locale"
 require "suse/connect"
 


### PR DESCRIPTION
The HTTP/JSON API uses a proxy to access the products interface. When the language changes, the `AvailableProducts` property is silently updated (not really updated because it gets calculated each time we try to access it).

The proxy does not know that this property changed and returns the old value. We can:

* Stop caching those values (in the HTTP/JSON API).
* Fix the D-Bus service to report that the `AvailableProducts` changed (this one).
* Decide that `AvailableProperties` is a method instead of a property.

This PR is a tentative fix I have not tried in a real ISO.

## To do

- [ ] After logging in, the wrong translations still appear.
- [ ] Fix unit tests