### PR TITLE
service: Convert autoyast partitioning section

### DIFF
--- a/service/lib/agama/autoyast/storage_reader.rb
+++ b/service/lib/agama/autoyast/storage_reader.rb
@@ -34,20 +34,12 @@ module Agama
         @profile = profile
       end
 
-      # @return [Hash] Agama "storage" section
+      # @return [Hash] Agama "legacyAutoyastStorage" section
       def read
         drives = profile.fetch_as_array("partitioning")
-        return {} if drives.nil?
+        return {} if drives.empty?
 
-        # TODO: rely on AutoinstProfile classes
-        devices = drives.each_with_object([]) do |d, all|
-          next unless d["device"]
-
-          all << d["device"]
-        end
-        return {} if devices.empty?
-
-        { "storage" => { "bootDevice" => devices.first } }
+        { "legacyAutoyastStorage" => drives }
       end
     end
   end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  4 14:16:02 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Convert AutoYaST partitioning section to JSON
+  (gh#openSUSE/agama#1285).
+
+-------------------------------------------------------------------
 Mon May 27 12:43:49 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Update product mount points as part of the probing (bsc#1225348).

--- a/service/test/agama/autoyast/converter_test.rb
+++ b/service/test/agama/autoyast/converter_test.rb
@@ -131,10 +131,13 @@ describe Agama::AutoYaST::Converter do
       end
     end
 
-    context "when a storage device is selected" do
-      it "exports the device" do
+    context "when partitioning is defined" do
+      it "exports the drives information" do
         subject.to_agama(workdir)
-        expect(result["storage"]).to include("bootDevice" => "/dev/vda")
+        expect(result["legacyAutoyastStorage"]).to include({
+          "device" => "/dev/vda",
+          "use"    => "all"
+        })
       end
     end
 

--- a/service/test/agama/autoyast/storage_reader_test.rb
+++ b/service/test/agama/autoyast/storage_reader_test.rb
@@ -51,10 +51,17 @@ describe Agama::AutoYaST::StorageReader do
       end
     end
 
+    context "when there are no drives" do
+      let(:profile) { { "partitioning" => [] } }
+
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
     context "when there is a list of drives" do
-      it "uses the first 'device' key as 'bootDevice'" do
-        boot_device = subject.read.dig("storage", "bootDevice")
-        expect(boot_device).to eq("/dev/vda")
+      it "returns the list as 'legacyAutoyastStorage'" do
+        expect(subject.read["legacyAutoyastStorage"]).to eq(profile["partitioning"])
       end
     end
   end


### PR DESCRIPTION
The list of drives in the "partitioning" section of an AutoYaST profile is directly converted to json as "legacyAutoyastStorage" key. 

See:

* https://github.com/openSUSE/agama/pull/1279
* https://github.com/openSUSE/agama/pull/1284

~~~
$ ./service/bin/agama-autoyast file:///path/to/profile.xml /tmp
$ cat /tmp/autoinst.json | jq

{
  "legacyAutoyastStorage": [
    {
      "device": "/dev/sda",
      "disklabel": "gpt",
      "enable_snapshots": true,
      "initialize": true,
      "partitions": [
        {
          "create": true,
          "partition_id": 263,
          "partition_nr": 1,
          "resize": false,
          "size": "8225280"
        }
      ],
      "type": "CT_DISK",
      "use": "all"
  ]
}
~~~

Note: Agama CLI complains when using `file://`:

~~~
$ agama profile autoyast file:///path/to/profile.xml
No such file or directory (os error 2)
~~~ 