### PR TITLE
Live ISO: set the root password from boot command line or interactively

### DIFF
--- a/live/root/etc/systemd/system/agama-password-cmdline.service
+++ b/live/root/etc/systemd/system/agama-password-cmdline.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Set the Agama/root password from kernel command line
+# before starting the SSH and Agama server so they use the new password
+Before=sshd.service agama-web-server.service
+# plain text password or encrypted password passed via kernel command line
+ConditionKernelCommandLine=|agama.password
+ConditionKernelCommandLine=|agama.password_hash
+
+[Service]
+ExecStart=agama-password --kernel
+Type=oneshot
+
+[Install]
+WantedBy=default.target

--- a/live/root/etc/systemd/system/agama-password-cmdline.service
+++ b/live/root/etc/systemd/system/agama-password-cmdline.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=Set the Agama/root password from kernel command line
 # before starting the SSH and Agama server so they use the new password
-Before=sshd.service agama-web-server.service
+Before=sshd.service
+Before=agama-web-server.service
+
 # plain text password or encrypted password passed via kernel command line
 ConditionKernelCommandLine=|agama.password
 ConditionKernelCommandLine=|agama.password_hash

--- a/live/root/etc/systemd/system/agama-password-dialog.service
+++ b/live/root/etc/systemd/system/agama-password-dialog.service
@@ -1,0 +1,45 @@
+[Unit]
+Description=Interactively set the Agama/root password in a dialog
+
+# before starting the SSH and Agama server so they use the new password
+Before=sshd.service
+Before=agama-web-server.service
+# before X11 because it switches the terminal to VT7
+Before=x11-autologin.service
+
+# copied from YaST2-Second-Stage.service
+Before=getty@tty1.service
+Before=getty@tty2.service
+Before=getty@tty3.service
+Before=getty@tty4.service
+Before=getty@tty5.service
+Before=getty@tty6.service
+Before=serial-getty@hvc0.service
+Before=serial-getty@sclp_line0.service
+Before=serial-getty@ttyAMA0.service
+Before=serial-getty@ttyS0.service
+Before=serial-getty@ttyS1.service
+Before=serial-getty@ttyS2.service
+Before=serial-getty@ttysclp0.service
+
+# start at the end to avoid overwriting the screen with systemd messages
+After=agama.service
+After=modprobe@drm.service
+
+# kernel command line option
+ConditionKernelCommandLine=agama.password_dialog
+
+[Service]
+Type=oneshot
+Environment=TERM=linux
+ExecStartPre=dmesg --console-off
+ExecStart=agama-password --dialog
+ExecStartPost=dmesg --console-on
+TTYReset=yes
+TTYVHangup=yes
+StandardInput=tty
+RemainAfterExit=true
+TimeoutSec=0
+
+[Install]
+WantedBy=default.target

--- a/live/root/etc/systemd/system/agama-password-systemd.service
+++ b/live/root/etc/systemd/system/agama-password-systemd.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=Interactively set the Agama/root password
+
+# before starting the SSH and Agama server so they use the new password
+Before=sshd.service
+Before=agama-web-server.service
+# before X11 because it switches the terminal to VT7
+Before=x11-autologin.service
+
+# copied from YaST2-Second-Stage.service
+Before=getty@tty1.service
+Before=getty@tty2.service
+Before=getty@tty3.service
+Before=getty@tty4.service
+Before=getty@tty5.service
+Before=getty@tty6.service
+Before=serial-getty@hvc0.service
+Before=serial-getty@sclp_line0.service
+Before=serial-getty@ttyAMA0.service
+Before=serial-getty@ttyS0.service
+Before=serial-getty@ttyS1.service
+Before=serial-getty@ttyS2.service
+Before=serial-getty@ttysclp0.service
+
+# start at the end to avoid overwriting the screen with systemd messages
+After=agama.service
+After=modprobe@drm.service
+
+# kernel command line option
+ConditionKernelCommandLine=agama.password_systemd
+
+[Service]
+Type=oneshot
+ExecStartPre=dmesg --console-off
+ExecStart=agama-password --systemd
+ExecStartPost=dmesg --console-on
+StandardOutput=tty
+RemainAfterExit=true
+TimeoutSec=0
+
+[Install]
+WantedBy=default.target

--- a/live/root/usr/bin/agama-password
+++ b/live/root/usr/bin/agama-password
@@ -1,0 +1,86 @@
+#!/usr/bin/sh
+
+# Helper script wich sets the root (Agama) pasword from several sources
+# - Kernel boot command line (use --kernel option)
+# - Systemd ask password tool (use --systemd option)
+# - Interactively using a dialog (use --dialog option)
+
+MYDIR=$(realpath "$(dirname "$0")")
+export DIALOGRC="$MYDIR/../share/agama/misc/dialog.conf"
+
+# dialog titles
+BTITLE="Agama Configuration (Press Ctrl+L to refresh the screen)"
+TITLE="Set Login Password"
+
+# functions for entering the password in an interactive dialog
+confirm_exit() {
+  if dialog --backtitle "$BTITLE" --defaultno --yesno "Are you sure you want to cancel?" 5 40; then
+    exit 1
+  fi
+}
+
+msg_box() {
+  dialog --backtitle "$BTITLE" --msgbox "$1" 6 30
+}
+
+ask_password() {
+  if ! PWD1=$(dialog --title "$TITLE" --backtitle "$BTITLE" --stdout --insecure --passwordbox "Password:" 8 40); then
+    confirm_exit
+    ask_password
+  fi
+
+  if ! PWD2=$(dialog --title "$TITLE" --backtitle "$BTITLE" --stdout --insecure --passwordbox "Verify Password:" 8 40); then
+    confirm_exit
+    ask_password
+  fi
+  
+  if [ "$PWD1" != "$PWD2" ]; then
+    msg_box "Passwords do not match.\nPlease try again."
+    ask_password
+  elif [ -z "$PWD1" ]; then
+    msg_box "Password cannot be empty.\nPlease try again."
+    ask_password
+  else
+    echo "$PWD1" | passwd --stdin
+    exit 0
+  fi
+}
+
+# functions for entering the password using the "systemd-ask-password" tool
+ask_password_systemd() {
+  if ! PWD1=$(systemd-ask-password --timeout=0 "Set login password: "); then
+    exit 1
+  fi
+
+  if ! PWD2=$(systemd-ask-password --timeout=0 "Verify password: "); then
+    exit 1
+  fi
+
+  if [ "$PWD1" != "$PWD2" ]; then
+    echo "Passwords do not match, please try again."
+    ask_password_systemd
+  elif [ -z "$PWD1" ]; then
+    echo "Password cannot be empty, please try again. To skip the password configuration press Ctrl+C."
+    ask_password_systemd
+  else
+    echo "$PWD1" | passwd --stdin
+    exit 0
+  fi
+}
+
+if [ "$1" = "--kernel" ]; then
+  # get the password from the kernel command line
+  PWD=$(awk -F 'agama.password=' '{sub(/ .*$/, "", $2); print $2}' < /proc/cmdline)
+  if [ -n "$PWD" ]; then
+    echo "$PWD" | passwd --stdin
+  fi
+
+  PWD=$(awk -F 'agama.password_hash=' '{sub(/ .*$/, "", $2); print $2}' < /proc/cmdline)
+  if [ -n "$PWD" ]; then
+    usermod -p "$PWD" root
+  fi
+elif [ "$1" = "--dialog" ]; then
+  ask_password
+elif [ "$1" = "--systemd" ]; then
+  ask_password_systemd
+fi

--- a/live/root/usr/share/agama/misc/dialog.conf
+++ b/live/root/usr/share/agama/misc/dialog.conf
@@ -1,0 +1,10 @@
+#
+# Configuration file for the "dialog" tool
+#
+# To generate a full template with all options run:
+#
+#    dialog --create-rc dialog.conf
+#
+
+# Background screen color
+screen_color = (WHITE,CYAN,ON)

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -x
+set -ex
 
 # KIWI functions
 test -f /.kconfig && . /.kconfig
@@ -18,23 +18,29 @@ systemctl enable NetworkManager.service
 systemctl enable avahi-daemon.service
 systemctl enable agama.service
 systemctl enable agama-web-server.service
+systemctl enable agama-password-cmdline.service
+systemctl enable agama-password-dialog.service
+systemctl enable agama-password-systemd.service
 systemctl enable agama-auto.service
 systemctl enable agama-hostname.service
 systemctl enable agama-proxy-setup.service
 systemctl enable setup-systemd-proxy-env.path
 systemctl enable x11-autologin.service
-systemctl enable spice-vdagent.service
+systemctl enable spice-vdagentd.service
 systemctl enable zramswap
 
 # default target
 systemctl set-default graphical.target
 
-# adjust owner of extracted files
-chown -R root:root /root
-find /etc -user 1000 | xargs chown root:root
+# disable snapshot cleanup
+systemctl disable snapper-cleanup.timer
+systemctl disable snapper-timeline.timer
+
+# disable unused services
+systemctl disable YaST2-Firstboot.service
+systemctl disable YaST2-Second-Stage.service
 
 ### setup dracut for live system
-
 label=${kiwi_install_volid:-$kiwi_iname}
 arch=$(uname -m)
 


### PR DESCRIPTION
## Problem

- The Live ISO uses a static well known root password, that is insecure

## Solution

This adds several boot command line options for setting the root password:

- `agama.password=<password>` - set a plain text password, not really secure as every process can read it from `/proc/cmdline` but it is still far better than a predefined known password
- `agama.password_hash=<password_hash>` - set a hashed password (generated by `mkpasswd` or `openssl passwd`), this is more secure but difficult to type manually as the hashed password is usually quite long, suitable for environments where you can prepare the boot command line before booting (like in PXE boot)
- `agama.password_systemd` - interactively ask for the password during boot using the `systemd-ask-password` tool (simple prompt but should work also over a serial console)
- `agama.password_dialog` - interactively ask for the password during boot using an interactive dialog (more fancy, but might not work well over a serial console)

## Testing

- Tested manually in VirtualBox and KVM virtual machines
- The requested password is set properly and can be used in both Agama and SSH

## Additional Fixes

- Use `set -e` in `config.sh`, there was a hidden problem with activating the `spicevdagend` service, it was failing unnoticed for quite some time... :scream: 
- Disable the snapper snapshot cleanup services, if you left the password dialog running for long time enough then starting the timer services would mess the screen. Moreover these are not need and it is potentially dangerous to run such services from a Live ISO.
- Removed the `chown` workarounds, not needed anymore as we build the tarball using the `--owner=0 --group=0` options so the owner is properly set already in the archive.
- Disabled the YaST units, not needed at all, that might make the boot process a tiny bit faster :smiley: 

(But that gave me an idea about using the YaST Firstboot package for the Agama setup. We have almost full YaST in the Live ISO already. Using `dialog` is fine for simple things but if we ever need to do some more complicated setup then using YaST Firstboot might be a possible solution...)

## Notes

- In the interactive cases the SSH and Agama web server are blocked until you enter the password, that avoids (mis)using the default predefined password before a new one is set.
- Starting an interactive session via systemd is quite tricky, the boot process normally continues and the systemd progress messages scroll over the console possibly destroying the displayed content. The workaround is to run the interactive service as late as possible, ideally after all unblocked services are finished. That is achieved by using the `After=` option. If the screen later gets broken by another service the solution should be to add it into the `After=` list.
- Additionally printing the kernel messages to the console is disabled when the dialog is running
- The dialog contains the "Press Ctrl+L to refresh the screen" hint at the top in case the output is messed up by some background process
- The `systemd-ask-password` tool has the same problem so the same workaround is applied there as well. (I hoped it is better integrated into the systemd boot process, but there is nothing special about it regarding the terminal handling.)

## TODO

- [ ] Add documentation (will be added later in a separate PR)
- [ ] Update changes (the same here)

## Screenshots

### Entering a password using dialog
![agama_password_dialog](https://github.com/openSUSE/agama/assets/907998/a5631173-905d-4810-9bbe-f018bc0c1d4b)

### Entering a password using systemd
![agama_password_systemd](https://github.com/openSUSE/agama/assets/907998/a656d1c1-a95f-4a94-be78-281446028941)

