### PR TITLE
Fix s390x iso cd.ikr content

### DIFF
--- a/live/config-cdroot/fix_bootconfig.s390x
+++ b/live/config-cdroot/fix_bootconfig.s390x
@@ -159,6 +159,8 @@ dd status=none if=$boot_dir/linux of=$boot_dir/cd.ikr
 dd status=none conv=notrunc obs=1 seek=$((initrd_ofs_ofs)) if=$boot_dir/initrd.off of=$boot_dir/cd.ikr
 dd status=none conv=notrunc obs=1 seek=$((initrd_siz_ofs)) if=$boot_dir/initrd.siz of=$boot_dir/cd.ikr
 dd status=none conv=notrunc obs=4096 seek=$((initrd_ofs/4096)) if=$boot_dir/initrd of=$boot_dir/cd.ikr
+# clear kernel cmdline area; it's actually 4 kiB, but 1 block should be more than enough
+dd status=none conv=notrunc bs=1 count=512 seek=$((parmfile_ofs)) if=/dev/zero of=$boot_dir/cd.ikr
 echo -n "$parmfile_content" | dd status=none conv=notrunc obs=1 seek=$((parmfile_ofs)) of=$boot_dir/cd.ikr
 
 # S390 Magic?

--- a/live/src/agama-live.changes
+++ b/live/src/agama-live.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun  5 15:40:43 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix the cd.ikr content for booting the s390x iso 
+  (gh#openSUSE/agama#1289).
+
+-------------------------------------------------------------------
 Tue May 21 10:38:39 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add the procps4 package to the image (gh#openSUSE/agama#1245).


### PR DESCRIPTION
## Problem

Dracut is not able to switch the rootfs when booting the s390x iso using virt-manager and qemu s390x emulation.

## Solution

Fix the cd.ikr content cleaning the default kernel cmdline area. (requested by @wfeldt at https://build.opensuse.org/request/show/1178758).