### PR TITLE
feat(live): Set the root password from ISO metadata

### DIFF
--- a/live/root/etc/systemd/system/agama-password-cmdline.service
+++ b/live/root/etc/systemd/system/agama-password-cmdline.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Set the Agama/root password from kernel command line
+
 # before starting the SSH and Agama server so they use the new password
 Before=sshd.service
 Before=agama-web-server.service

--- a/live/root/etc/systemd/system/agama-password-iso.service
+++ b/live/root/etc/systemd/system/agama-password-iso.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Set the Agama/root password from ISO application area
+
+# before starting the SSH and Agama server so they use the new password
+Before=sshd.service
+Before=agama-web-server.service
+
+# before the other password setting methods so they can override it
+Before=agama-password-cmdline.service
+Before=agama-password-dialog.service
+Before=agama-password-systemd.service
+
+[Service]
+ExecStart=agama-password --iso
+Type=oneshot
+
+[Install]
+WantedBy=default.target

--- a/live/root/usr/bin/agama-password
+++ b/live/root/usr/bin/agama-password
@@ -85,6 +85,9 @@ password_from_iso() {
   # if there is no parent device use the device itself (e.g. /dev/sr0)
   if [ -z "$DEVICE" ]; then
     DEVICE="$PARTITION"
+  else
+    # add the /dev/ prefix
+    DEVICE="/dev/$DEVICE"
   fi
 
   echo "Reading password from $DEVICE..."

--- a/live/root/usr/bin/agama-password
+++ b/live/root/usr/bin/agama-password
@@ -68,6 +68,43 @@ ask_password_systemd() {
   fi
 }
 
+# check if the root password is present in the ISO file metadata
+password_from_iso() {
+  # get the partition where the live ISO is mounted
+  PARTITION=$(blkid -L agama-live)
+
+  if [ -z "$PARTITION" ]; then
+    echo "Live ISO partition not found, skipping password configuration"
+    exit 0
+  fi
+
+  # get the parent device name for the partition (/dev/sda2 -> /dev/sda),
+  # for some devices just removing the trailing number does not work
+  DEVICE=$(lsblk --noheadings --output PKNAME "$PARTITION")
+
+  # if there is no parent device use the device itself (e.g. /dev/sr0)
+  if [ -z "$DEVICE" ]; then
+    DEVICE="$PARTITION"
+  fi
+
+  echo "Reading password from $DEVICE..."
+
+  # run tagmedia and extract the password value
+  TAG=$(tagmedia "$DEVICE" | grep "^agama_password = " | sed -e "s/^agama_password = //")
+
+  if [ -z "$TAG" ]; then
+    echo "Password not found at $DEVICE"
+    exit 0
+  fi
+
+  if PWD=$(echo "$TAG" | base64 -d); then
+    usermod -p "$PWD" root
+  else
+    echo "Base64 decoding of the password failed!"
+    exit 1
+  fi
+}
+
 if [ "$1" = "--kernel" ]; then
   # get the password from the kernel command line
   PWD=$(awk -F 'agama.password=' '{sub(/ .*$/, "", $2); print $2}' < /proc/cmdline)
@@ -83,4 +120,6 @@ elif [ "$1" = "--dialog" ]; then
   ask_password
 elif [ "$1" = "--systemd" ]; then
   ask_password_systemd
+elif [ "$1" = "--iso" ]; then
+  password_from_iso
 fi

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -20,6 +20,7 @@ systemctl enable agama.service
 systemctl enable agama-web-server.service
 systemctl enable agama-password-cmdline.service
 systemctl enable agama-password-dialog.service
+systemctl enable agama-password-iso.service
 systemctl enable agama-password-systemd.service
 systemctl enable agama-auto.service
 systemctl enable agama-hostname.service


### PR DESCRIPTION
## Problem

Avoid using the well known default root password in the Live medium.

## Solution

Allow modifying the default root password in the ISO medium by users.  A new default root password can be embedded into the ISO file metadata using this command:
```
tagmedia --add-tag "agama_password=$((openssl passwd -6) | base64 -w 0)" <agama.iso>
```
This will embed a SHA512 hashed password into the ISO application area. This area is already used for storing the medium checksum, if you run the `checkmedia` command to verify the medium integrity then the expected checksum is read from this metadata. You can check its content by running `tagmedia <agama.iso>`.

The ISO application area is pretty small (512 bytes), but there is still enough space to embed a hashed root password.  Unfortunately it needs to be Base64 encoded otherwise `tagmedia` then reports an error about unsupported format.

If the root password is set by other options on the boot command line (see #1288) then they will override this ISO file default.

The advantage of this solution is that it does not need any special tweaks and you do not root permissions to modify the ISO image. This solution is suitable for mass deployment using the same physical medium. You can  modify the ISO, dump it on an USB stick and then install several machines using your specific root password.

## Testing

- Tested manually, the embedded password is correctly used by Agama and SSH.
- If the password is set by the other boot options from #1288 then they will take precedence.

## TODO

Later:

- [ ] Create documentation
- [ ] Update changes