### PR TITLE
fix(CI): Fetch all history

### DIFF
--- a/.github/workflows/obs-staging-shared.yml
+++ b/.github/workflows/obs-staging-shared.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
         with:
+          # fetch all history with tags, we need to find the latest version tag
+          fetch-depth: 0
           fetch-tags: true
 
       - name: Configure osc


### PR DESCRIPTION
## Problem

- The packages in the [Staging](https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Staging/openSUSE_Tumbleweed/x86_64/) project have RPM versions like `1717740471.88237f7b`, e.g. Unix time stamp + short commit SHA
- It should be something like `8+192`, i.e. the latest version tag + number of commits since then
- The problem is that the cloned Git repository in CI does not contain any tags

## Solution

- We need to find the latest version tag in the history. By default the action/checkout uses "--depth 1" parameter which fetches only a single commit without history. I guess this problem was introduces by upgrading `actions/checkout` to version 4.
- The fix is to checkout the complete history

## Notes

- I found a [solution](https://stackoverflow.com/a/74389910) which allows to fetch history only up to a specified tag, this decreases the amount of data to download as it does not fetch the complete history.
- However, finding the latest tag on the server and the downloading the content using several commands has a big overhead. Currently downloading the whole history is faster than this optimized process. It would make sense only on a really slow internet connection. With any decent connection the full clone is faster.
- But I guess that at some point in the future, when the Git history grows a lot, this approach will be faster and more efficient