### PR TITLE
web: improvements for Installer Options dialog

### DIFF
--- a/web/src/components/core/InstallerOptions.jsx
+++ b/web/src/components/core/InstallerOptions.jsx
@@ -23,7 +23,7 @@
 
 import React, { useState } from "react";
 import { useLocation } from "react-router-dom";
-import { Button, Stack } from "@patternfly/react-core";
+import { Button, Card, CardBody, Flex } from "@patternfly/react-core";
 import { Icon } from "~/components/layout";
 import { LogsButton, Popup } from "~/components/core";
 import { InstallerLocaleSwitcher, InstallerKeymapSwitcher } from "~/components/l10n";
@@ -61,11 +61,11 @@ export default function InstallerOptions() {
         isOpen={isOpen}
         title={_("Installer options")}
       >
-        <Stack hasGutter>
+        <Flex direction={{ default: "column" }} gap={{ default: "gapLg" }}>
           <InstallerLocaleSwitcher />
           <InstallerKeymapSwitcher />
           <LogsButton />
-        </Stack>
+        </Flex>
         <Popup.Actions>
           <Popup.Confirm onClick={close} autoFocus>{_("Close")}</Popup.Confirm>
         </Popup.Actions>

--- a/web/src/components/core/LogsButton.jsx
+++ b/web/src/components/core/LogsButton.jsx
@@ -91,7 +91,8 @@ const LogsButton = ({ ...props }) => {
   return (
     <>
       <Button
-        variant="tertiary"
+        variant="link"
+        isInline
         onClick={collectAndDownload}
         isLoading={isCollecting}
         isDisabled={isCollecting}

--- a/web/src/components/l10n/InstallerLocaleSwitcher.jsx
+++ b/web/src/components/l10n/InstallerLocaleSwitcher.jsx
@@ -19,10 +19,12 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useCallback, useState } from "react";
-import { Link } from "react-router-dom";
-import { FormSelect, FormSelectOption, Popover } from "@patternfly/react-core";
-
+import React, { useState } from "react";
+import {
+  Flex,
+  Select, SelectList, SelectOption,
+  MenuToggle
+} from "@patternfly/react-core";
 import { Icon } from "../layout";
 import { _ } from "~/i18n";
 import { useInstallerL10n } from "~/context/installerL10n";
@@ -30,52 +32,44 @@ import supportedLanguages from "~/languages.json";
 
 export default function InstallerLocaleSwitcher() {
   const { language, changeLanguage } = useInstallerL10n();
-  const [selected, setSelected] = useState(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState(language);
 
-  const onChange = useCallback((_event, value) => {
+  const onSelect = (_event, value) => {
+    setIsOpen(false);
     setSelected(value);
     changeLanguage(value);
-  }, [setSelected, changeLanguage]);
+  };
+
+  const toggle = toggleRef => (
+    <MenuToggle ref={toggleRef} onClick={() => setIsOpen(!isOpen)} isExpanded={isOpen}>
+      {supportedLanguages[selected]}
+    </MenuToggle>
+  );
 
   // sort by the language code to maintain consistent order
   const options = Object.keys(supportedLanguages).sort()
-    .map(id => <FormSelectOption key={id} value={id} label={supportedLanguages[id]} />);
-
-  // TRANSLATORS: help text for the language selector in the sidebar,
-  // %s will be replaced by the "Localization" page link
-  const [msg1, msg2] = _("The language used by the installer. The language \
-for the installed system can be set in the %s page.").split("%s");
-
-  // "hide" is a function which closes the popover
-  const description = (hide) => (
-    <>
-      {msg1}
-      {/* close the popover after clicking the link */}
-      <Link to="/l10n" onClick={hide}>
-        {_("Localization")}
-      </Link>
-      {msg2}
-    </>
-  );
+    .map(id => <SelectOption key={id} value={id}>{supportedLanguages[id]}</SelectOption>);
 
   return (
-    <>
-      <h3>
-        <Icon name="translate" size="s" />
-        {_("Language")}&nbsp;
-        {/* smaller width of the popover so it does not overflow outside the sidebar */}
-        <Popover showClose={false} bodyContent={description} maxWidth="15em">
-          <Icon name="info" size="xxs" />
-        </Popover>
-      </h3>
-      <FormSelect
+    <Flex gap={{ default: "gapMd" }} alignItems={{ default: "alignItemsCenter" }}>
+      <div>
+        <Icon name="translate" size="s" /> <b>{_("Language")}</b>
+      </div>
+      <Select
         id="language"
-        aria-label={_("language")}
-        value={selected || language}
-        onChange={onChange}
+        isScrollable
+        isOpen={isOpen}
+        aria-label={_("Choose a language")}
+        selected={selected}
+        onSelect={onSelect}
+        onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        toggle={toggle}
       >
-        {options}
-      </FormSelect>
-    </>
+        <SelectList>
+          {options}
+        </SelectList>
+      </Select>
+    </Flex>
   );
 }


### PR DESCRIPTION
This PRs slightly improves the look&feel of the recently added `Installer Options` dialog.

| Before | After |
|-|-|
| ![Screenshot from 2024-06-11 09-55-52](https://github.com/openSUSE/agama/assets/1691872/7113c24a-ff5d-43f9-a40e-79d77b48e80f) | ![Screenshot from 2024-06-11 09-55-15](https://github.com/openSUSE/agama/assets/1691872/562f669a-3ef9-4cb0-8fc0-e93756aef568) |
