### PR TITLE
feat(web): add issues to the corresponding pages

### DIFF
--- a/web/src/client/index.js
+++ b/web/src/client/index.js
@@ -67,7 +67,7 @@ import { HTTPClient } from "./http";
  * @typedef {(issues: Issues) => void} IssuesHandler
  */
 
-const createIssuesList = (product, software, storage, users) => {
+const createIssuesList = (product = [], software = [], storage = [], users = []) => {
   const list = { product, storage, software, users };
   list.isEmpty = !Object.values(list).some(v => v.length > 0);
   return list;
@@ -155,4 +155,4 @@ const createDefaultClient = async () => {
   return createClient(httpUrl);
 };
 
-export { createClient, createDefaultClient, phase };
+export { createClient, createDefaultClient, phase, createIssuesList };

--- a/web/src/components/core/IssuesHint.jsx
+++ b/web/src/components/core/IssuesHint.jsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Hint, HintBody, List, ListItem, Stack } from "@patternfly/react-core";
+import { _ } from "~/i18n";
+
+export default function IssuesHint({ issues }) {
+  if (issues === undefined || issues.length === 0) return;
+
+  return (
+    <Hint>
+      <HintBody>
+        <Stack hasGutter>
+          <p>
+            {_("Please, pay attention to the following tasks:")}
+          </p>
+          <List>
+            {issues.map((i, idx) => <ListItem key={idx}>{i.description}</ListItem>)}
+          </List>
+        </Stack>
+      </HintBody>
+    </Hint>
+  );
+}

--- a/web/src/components/core/IssuesHint.test.jsx
+++ b/web/src/components/core/IssuesHint.test.jsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) [2022-2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import { plainRender } from "~/test-utils";
+import { IssuesHint } from "~/components/core";
+
+it("renders a list of issues", () => {
+  const issue = {
+    description: "You need to create a user",
+    source: "config",
+    severity: "error"
+  };
+  plainRender(<IssuesHint issues={[issue]} />);
+  expect(screen.getByText(issue.description)).toBeInTheDocument();
+});

--- a/web/src/components/core/index.js
+++ b/web/src/components/core/index.js
@@ -34,6 +34,7 @@ export { default as InstallationFinished } from "./InstallationFinished";
 export { default as InstallationProgress } from "./InstallationProgress";
 export { default as InstallButton } from "./InstallButton";
 export { default as IssuesDialog } from "./IssuesDialog";
+export { default as IssuesHint } from "./IssuesHint";
 export { default as SectionSkeleton } from "./SectionSkeleton";
 export { default as ListSearch } from "./ListSearch";
 export { default as LoginPage } from "./LoginPage";

--- a/web/src/components/overview/OverviewPage.jsx
+++ b/web/src/components/overview/OverviewPage.jsx
@@ -114,7 +114,7 @@ export default function OverviewPage() {
             </CardField>
           </GridItem>
           <GridItem sm={12} xl={6}>
-            <CardField label="Installation">
+            <CardField>
               <CardBody>
                 <Stack hasGutter>
                   {issues.isEmpty ? <ReadyForInstallation /> : <IssuesList issues={issues} />}

--- a/web/src/components/overview/OverviewPage.jsx
+++ b/web/src/components/overview/OverviewPage.jsx
@@ -53,7 +53,7 @@ const IssuesList = ({ issues }) => {
     issues.forEach((issue, idx) => {
       const link = (
         <ListItem key={idx}>
-          <Link to={scope}>{issue.description}</Link>
+          <Link to={`/${scope}`}>{issue.description}</Link>
         </ListItem>
       );
       list.push(link);

--- a/web/src/components/software/SoftwarePage.jsx
+++ b/web/src/components/software/SoftwarePage.jsx
@@ -22,17 +22,16 @@
 // @ts-check
 
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 
-import { ButtonLink, CardField, Page, Section, SectionSkeleton } from "~/components/core";
-import UsedSize from "./UsedSize";
 import { useInstallerClient } from "~/context/installer";
 import { useCancellablePromise } from "~/utils";
+import { useIssues } from "~/context/issues";
 import { BUSY } from "~/client/status";
 import { _ } from "~/i18n";
+import { ButtonLink, CardField, IssuesHint, Page, SectionSkeleton } from "~/components/core";
+import UsedSize from "./UsedSize";
 import { SelectedBy } from "~/client/software";
 import {
-  Card,
   CardBody,
   DescriptionList,
   DescriptionListDescription,
@@ -109,6 +108,7 @@ const SelectedPatternsList = ({ patterns }) => {
  * @returns {JSX.Element}
  */
 function SoftwarePage() {
+  const { software: issues } = useIssues();
   const [status, setStatus] = useState(BUSY);
   const [patterns, setPatterns] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -157,6 +157,9 @@ function SoftwarePage() {
 
       <Page.MainContent>
         <Grid hasGutter>
+          <GridItem sm={12}>
+            <IssuesHint issues={issues} />
+          </GridItem>
           <GridItem sm={12} xl={6}>
             <CardField
                label={_("Selected patterns")}

--- a/web/src/components/users/UsersPage.jsx
+++ b/web/src/components/users/UsersPage.jsx
@@ -22,11 +22,14 @@
 import React from "react";
 
 import { _ } from "~/i18n";
-import { CardField, Page } from "~/components/core";
+import { CardField, IssuesHint, Page } from "~/components/core";
 import { FirstUser, RootAuthMethods } from "~/components/users";
-import { Card, CardBody, Grid, GridItem, Stack } from "@patternfly/react-core";
+import { CardBody, Grid, GridItem, Stack } from "@patternfly/react-core";
+import { useIssues } from "~/context/issues";
 
 export default function UsersPage() {
+  const { users: issues } = useIssues();
+
   return (
     <>
       <Page.Header>
@@ -35,6 +38,9 @@ export default function UsersPage() {
 
       <Page.MainContent>
         <Grid hasGutter>
+          <GridItem sm={12}>
+            <IssuesHint issues={issues} />
+          </GridItem>
           <GridItem sm={12} xl={6}>
             <CardField label={_("First user")}>
               <CardBody>

--- a/web/src/context/app.jsx
+++ b/web/src/context/app.jsx
@@ -26,6 +26,7 @@ import { InstallerClientProvider } from "./installer";
 import { InstallerL10nProvider } from "./installerL10n";
 import { L10nProvider } from "./l10n";
 import { ProductProvider } from "./product";
+import { IssuesProvider } from "./issues";
 
 /**
  * Combines all application providers.
@@ -39,7 +40,9 @@ function AppProviders({ children }) {
       <InstallerL10nProvider>
         <L10nProvider>
           <ProductProvider>
-            {children}
+            <IssuesProvider>
+              {children}
+            </IssuesProvider>
           </ProductProvider>
         </L10nProvider>
       </InstallerL10nProvider>

--- a/web/src/context/issues.jsx
+++ b/web/src/context/issues.jsx
@@ -57,6 +57,9 @@ function IssuesProvider({ children }) {
   return <IssuesContext.Provider value={issues}>{children}</IssuesContext.Provider>;
 }
 
+/**
+ * @return {Issues}
+ */
 function useIssues() {
   const context = useContext(IssuesContext);
 

--- a/web/src/context/issues.jsx
+++ b/web/src/context/issues.jsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useContext, useEffect, useState } from "react";
+import { useCancellablePromise } from "~/utils";
+import { useInstallerClient } from "./installer";
+import { createIssuesList } from "~/client";
+
+/**
+ * @typedef {import ("~/client").Issues} Issues list
+ */
+
+const IssuesContext = React.createContext({});
+
+function IssuesProvider({ children }) {
+  const [issues, setIssues] = useState(createIssuesList());
+  const { cancellablePromise } = useCancellablePromise();
+  const client = useInstallerClient();
+
+  useEffect(() => {
+    const loadIssues = async () => {
+      const issues = await cancellablePromise(client.issues());
+      setIssues(issues);
+    };
+
+    if (client) {
+      loadIssues();
+    }
+  }, [client, cancellablePromise, setIssues]);
+
+  useEffect(() => {
+    if (!client) return;
+
+    return client.onIssuesChange((updated) => {
+      setIssues({ ...issues, ...updated });
+    });
+  }, [client, issues, setIssues]);
+
+  return <IssuesContext.Provider value={issues}>{children}</IssuesContext.Provider>;
+}
+
+function useIssues() {
+  const context = useContext(IssuesContext);
+
+  if (!context) {
+    throw new Error("useIssues must be used within an IssuesProvider");
+  }
+
+  return context;
+}
+
+export { IssuesProvider, useIssues };


### PR DESCRIPTION
* Add issues to the corresponding page. At this point, only software and users pages are adapted. The network service does not implement the issues interface and the storage page is different from the rest (and issues are reported in a different way).
* Fix the link to the issues in the overview page.

<details>
<summary>Showing the issues in the users page.</summary>

![Captura desde 2024-06-11 19-56-12](https://github.com/openSUSE/agama/assets/15836/afaf3444-3854-408d-90d3-9026d83634ec)
</details>