### PR TITLE
Allow writing to loopback connection in agama-server

### DIFF
--- a/rust/agama-server/src/network/nm/adapter.rs
+++ b/rust/agama-server/src/network/nm/adapter.rs
@@ -23,13 +23,6 @@ impl<'a> NetworkManagerAdapter<'a> {
         let client = NetworkManagerClient::new(connection.clone()).await?;
         Ok(Self { client, connection })
     }
-
-    /// Determines whether the write operation is supported for a connection
-    ///
-    /// * `conn`: connection
-    fn is_writable(conn: &Connection) -> bool {
-        !conn.is_loopback()
-    }
 }
 
 #[async_trait]
@@ -118,10 +111,6 @@ impl<'a> Adapter for NetworkManagerAdapter<'a> {
         }
 
         for conn in ordered_connections(network) {
-            if !Self::is_writable(conn) {
-                continue;
-            }
-
             if let Some(old_conn) = old_state.get_connection_by_uuid(conn.uuid) {
                 if old_conn == conn {
                     continue;

--- a/rust/agama-server/src/network/nm/dbus.rs
+++ b/rust/agama-server/src/network/nm/dbus.rs
@@ -119,6 +119,9 @@ pub fn connection_to_dbus<'a>(
             connection_dbus.insert("type", INFINIBAND_KEY.into());
             result.insert(INFINIBAND_KEY, infiniband_config_to_dbus(infiniband));
         }
+        ConnectionConfig::Loopback => {
+            connection_dbus.insert("type", LOOPBACK_KEY.into());
+        }
         _ => {}
     }
 

--- a/rust/agama-server/src/network/nm/model.rs
+++ b/rust/agama-server/src/network/nm/model.rs
@@ -83,7 +83,7 @@ impl TryFrom<NmDeviceType> for DeviceType {
             NmDeviceType(0) => Ok(DeviceType::Loopback),
             NmDeviceType(1) => Ok(DeviceType::Ethernet),
             NmDeviceType(2) => Ok(DeviceType::Wireless),
-            NmDeviceType(3) => Ok(DeviceType::Dummy),
+            NmDeviceType(22) => Ok(DeviceType::Dummy),
             NmDeviceType(10) => Ok(DeviceType::Bond),
             NmDeviceType(_) => Err(NmError::UnsupportedDeviceType(value.into())),
         }

--- a/rust/agama-server/src/network/nm/model.rs
+++ b/rust/agama-server/src/network/nm/model.rs
@@ -80,7 +80,7 @@ impl TryFrom<NmDeviceType> for DeviceType {
 
     fn try_from(value: NmDeviceType) -> Result<Self, Self::Error> {
         match value {
-            NmDeviceType(0) => Ok(DeviceType::Loopback),
+            NmDeviceType(32) => Ok(DeviceType::Loopback),
             NmDeviceType(1) => Ok(DeviceType::Ethernet),
             NmDeviceType(2) => Ok(DeviceType::Wireless),
             NmDeviceType(22) => Ok(DeviceType::Dummy),

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 12 10:15:33 UTC 2024 - Jorik Cronenberg <jorik.cronenberg@suse.com>
+
+- Allow writing to loopback connection in agama-server
+  (gh#openSUSE/agama#1318).
+
+-------------------------------------------------------------------
 Tue Jun 11 21:35:00 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - CLI: use the master token /run/agama/token if available and


### PR DESCRIPTION
## Problem

For the wicked to NM migration we need to write to the loopback connection.

## Solution

Allow writing to the loopback connection.
(I've also quickly updated a previous error of mine, that the Dummy device type was mapped to a wrong value)

## Testing

- *Tested manually*
- *Tested via the migration*