### PR TITLE
fix(zypp): Reuse the repositories, use libzypp in "chroot"

### DIFF
--- a/service/test/agama/software/manager_test.rb
+++ b/service/test/agama/software/manager_test.rb
@@ -50,6 +50,7 @@ describe Agama::Software::Manager do
       disabled:   disabled_repos
     )
   end
+  let(:products) { [] }
 
   let(:proposal) do
     instance_double(
@@ -126,6 +127,20 @@ describe Agama::Software::Manager do
         expect(manager.product.id).to eq("test1")
       end
     end
+
+    context "when GPG keys are available at /" do
+      let(:gpg_keys) { ["/usr/lib/gnupg/keys/gpg-key.asc"] }
+
+      it "imports the GPG keys" do
+        expect(Yast::Pkg).to receive(:ImportGPGKey).with(gpg_keys.first, true)
+        described_class.new(config, logger)
+      end
+    end
+
+    it "initializes the package system" do
+      expect(Yast::Pkg).to receive(:TargetInitialize)
+      described_class.new(config, logger)
+    end
   end
 
   shared_examples "software issues" do |tested_method|
@@ -184,33 +199,8 @@ describe Agama::Software::Manager do
   end
 
   describe "#probe" do
-    let(:rootdir) { Dir.mktmpdir }
-    let(:repos_dir) { File.join(rootdir, "etc", "zypp", "repos.d") }
-    let(:backup_repos_dir) { File.join(rootdir, "etc", "zypp", "repos.d.backup") }
-
     before do
-      stub_const("Agama::Software::Manager::REPOS_DIR", repos_dir)
-      stub_const("Agama::Software::Manager::REPOS_BACKUP", backup_repos_dir)
-      FileUtils.mkdir_p(repos_dir)
       subject.select_product("Tumbleweed")
-    end
-
-    after do
-      FileUtils.remove_entry(rootdir)
-    end
-
-    it "initializes the package system" do
-      expect(Yast::Pkg).to receive(:TargetInitialize).with("/")
-      subject.probe
-    end
-
-    context "when GPG keys are available at /" do
-      let(:gpg_keys) { ["/usr/lib/gnupg/keys/gpg-key.asc"] }
-
-      it "imports the GPG keys" do
-        expect(Yast::Pkg).to receive(:ImportGPGKey).with(gpg_keys.first, true)
-        subject.probe
-      end
     end
 
     it "creates a packages proposal" do
@@ -351,31 +341,13 @@ describe Agama::Software::Manager do
   end
 
   describe "#finish" do
-    let(:rootdir) { Dir.mktmpdir }
-    let(:repos_dir) { File.join(rootdir, "etc", "zypp", "repos.d") }
-    let(:backup_repos_dir) { File.join(rootdir, "etc", "zypp", "repos.d.backup") }
-
-    before do
-      stub_const("Agama::Software::Manager::REPOS_DIR", repos_dir)
-      stub_const("Agama::Software::Manager::REPOS_BACKUP", backup_repos_dir)
-      FileUtils.mkdir_p(repos_dir)
-      FileUtils.mkdir_p(backup_repos_dir)
-      FileUtils.touch(File.join(backup_repos_dir, "example.repo"))
-      puts Dir[File.join(repos_dir, "**", "*")]
-    end
-
-    after do
-      FileUtils.remove_entry(rootdir)
-    end
-
-    it "releases the packaging system and restores the backup" do
+    it "releases the packaging system" do
       expect(Yast::Pkg).to receive(:SourceSaveAll)
       expect(Yast::Pkg).to receive(:TargetFinish)
       expect(Yast::Pkg).to receive(:SourceCacheCopyTo)
         .with(Yast::Installation.destdir)
 
       subject.finish
-      expect(File).to exist(File.join(repos_dir, "example.repo"))
     end
   end
 


### PR DESCRIPTION
## Problem

- When changing the product from openSUSE Tumleweed to openSUSE MicroOS the Tumbleweed repository is refreshed again
- The code initializes the libzypp in the Live ISO system, there are some workarounds to avoid reusing the Live ISO repositories

Related cards:
- https://trello.com/c/liPX29Cu/3695-5-research-improve-software-management-performance
 

## Solution

- When the changed product uses the same repositories then just reuse them, do not create the repositories again
- Run libzypp in `/run/agama/zypp` repository to not mess with the package management from the Live ISO, removed the related workarounds

## Notes

- The reusing is simple all-or-nothing, i.e. the products must use the very same repositories. In the future we could improve it to allow reusing just a subset of the repositories.
- Maybe it will need some adoption when the system is registered, but as there is no real product to register I'm leaving this for the future.
- I put the zypp lock to `/run/agama/zypp` as well, that means now you can run `zypper` in the Live system while Agama is running, yay! :star_struck: 
- That workaround with switching `Yast::Stage` is not needed anymore, it was needed when we run the proposal using the YaST code, it is not needed with the new refactored code.

## Testing

- Tested manually (mvidner: in container, switched products 3 times, without hitting Install)
