### PR TITLE
doc(rust): remove references to "config add/set" subcommands

### DIFF
--- a/rust/agama-cli/src/commands.rs
+++ b/rust/agama-cli/src/commands.rs
@@ -7,13 +7,14 @@ use clap::Subcommand;
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    /// Change or show the installation settings.
+    /// Inspect or change the installation settings.
     ///
-    /// You can set any Agama configuration value from the command-line. You can change individual
-    /// values the "add" or "set" commands. Or modify many of them at a time by loading a so-called
-    /// profile through the "load" command.
+    /// You can inspect and change installation settings from the command-line. The "show"
+    /// subcommand generates a "profile" which is a JSON document describing the current
+    /// configuration.
     ///
-    /// Use "show" to display the current configuration in JSON format.
+    /// If you want to change any configuration value, you can load a profile (complete or partial)
+    /// using the "load" subcommand.
     #[command(subcommand)]
     Config(ConfigCommands),
 

--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -11,15 +11,15 @@ use clap::Subcommand;
 
 #[derive(Subcommand, Debug)]
 pub enum ConfigCommands {
-    /// Shows the value of the configuration settings.
+    /// Generates an installation profile with the current settings.
     ///
     /// It is possible that many configuration settings do not have a value. Those settings
     /// are not included in the output.
     ///
-    /// The output of command can be used as file content for `agama config load`.
+    /// The output of command can be used as input for the "agama config load".
     Show,
 
-    /// Loads the configuration from a JSON file.
+    /// Reads and loads a profile from the standard input.
     Load,
 }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 14 06:17:52 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Remove references to the old "config add/set" subcommands
+  (gh#openSUSE/agama/#1338).
+
+-------------------------------------------------------------------
 Thu Jun 13 10:50:44 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
 - Apply network changes when connecting or disconnecting


### PR DESCRIPTION
The old "config add/set" subcommands are still mentioned in the CLI help.

## Open question (out of scope)

* Should we merge `config` and `profile` commands?