### PR TITLE
fix(web): do not redirect to login until really needed

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 14 07:37:58 UTC 2024 - David Diaz <dgonzalez@suse.com>
+
+- Do not redirect to login page until really needed
+  (gh#openSUSE/agama#1340).
+
+-------------------------------------------------------------------
 Fri Jun 14 05:34:52 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not redirect to the products selection page again after

--- a/web/src/Protected.jsx
+++ b/web/src/Protected.jsx
@@ -27,7 +27,7 @@ import { AppProviders } from "./context/app";
 export default function Protected() {
   const { isLoggedIn } = useAuth();
 
-  if (isLoggedIn !== true) {
+  if (isLoggedIn === false) {
     return <Navigate to="/login" />;
   }
 

--- a/web/src/context/auth.jsx
+++ b/web/src/context/auth.jsx
@@ -48,7 +48,7 @@ const AuthErrors = Object.freeze({
  * @param {React.ReactNode} [props.children] - content to display within the provider
  */
 function AuthProvider({ children }) {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(undefined);
   const [error, setError] = useState(null);
 
   const login = useCallback(async (password) => {


### PR DESCRIPTION
## Problem

There is an extra redirection to /login route during the short period the login request is being performed. The user does not stuck in the login page because it redirects to the root route as soon as isLoggedIn is set, but it produces both,

* A not needed redirection.
* A quick login screen flickering.

## Solution

Do not set the isLoggedIn value until it is really known.


## Testing

- Tested manually
