### PR TITLE
Experimental Live ISO self-update

### DIFF
--- a/doc/live_iso.md
+++ b/doc/live_iso.md
@@ -8,6 +8,7 @@
 - [Agama Live ISO (*only for development and testing*)](#agama-live-iso-only-for-development-and-testing)
   - [Description](#description)
   - [Hardware Requirements](#hardware-requirements)
+- [Experimental Self-update](#experimental-self-update)
 - [The Access Password](#the-access-password)
   - [Using Custom Password](#using-custom-password)
   - [Boot Command Line](#boot-command-line)
@@ -70,6 +71,22 @@ Notes:
 * 2 GiB of RAM memory
 * Internet connection to download packages of the product to install.
 * Around 10 GiB of disk size, although it depends on the selected product to install.
+
+## Experimental Self-update
+
+> [!WARNING]
+> This feature is experimental and untested!
+
+The Agama packages on the Live ISO can be automatically updated from the OBS
+Staging project.
+
+* Use the `agama.self_update` boot parameter to run the self-update
+automatically during boot.
+* Or run the `agama-self-update` script anytime later in a running Live system.
+
+> [!NOTE]
+> After updating the packages the Agama servers need to be restarted. This will
+> reset all you current Agama settings, you will need to start from scratch!
 
 ## The Access Password
 

--- a/live/root/etc/systemd/system/agama-self-update.service
+++ b/live/root/etc/systemd/system/agama-self-update.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Agama self-update
+
+After=network-online.target
+
+# before starting the Agama servers so they use the new packages
+Before=agama-web-server.service
+Before=agama.service
+Before=x11-autologin.service
+# before interactive password services
+Before=live-password-dialog.service
+Before=live-password-systemd.service
+
+# kernel command line option
+ConditionKernelCommandLine=|agama.self_update
+# linuxrc/YaST backward compatibility
+ConditionKernelCommandLine=|agama.selfupdate
+
+[Service]
+Type=oneshot
+Environment=TERM=linux
+ExecStartPre=dmesg --console-off
+ExecStart=agama-self-update
+ExecStartPost=dmesg --console-on
+TTYReset=yes
+TTYVHangup=yes
+StandardInput=tty
+TimeoutSec=0
+
+[Install]
+WantedBy=default.target

--- a/live/root/usr/bin/agama-self-update
+++ b/live/root/usr/bin/agama-self-update
@@ -1,0 +1,26 @@
+#! /bin/sh
+
+# Experimental Agama self-update script
+#
+# This script updates the Agama packages in the Live system from the
+# Agama Staging OBS project.
+
+
+# first try a quick and simple solution, refreshing the OSS repository takes a
+# lot of time so try using only the agama-staging for update
+zypper modifyrepo --disable repo-oss
+zypper refresh
+zypper --non-interactive dup --details --from agama-staging
+STATUS=$?
+
+# enable OSS back
+zypper modifyrepo --enable repo-oss
+
+# if it failed try it again with the OSS repo enabled, maybe there was some
+# dependency problem which hopefully will be OK now
+if [ "$?" != "0" ]; then
+  zypper --non-interactive dup --details --from agama-staging
+fi
+
+# clean all repository caches to save space in RAM disk
+zypper clean --all

--- a/live/src/agama-live.changes
+++ b/live/src/agama-live.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jun 14 10:36:52 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Experimental Agama self-update (gh#openSUSE/agama#1341)
+
+-------------------------------------------------------------------
 Thu Jun 13 16:07:08 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Added Tumbleweed OSS and Agama Staging repositories to the Live

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -32,6 +32,7 @@ systemctl enable agama-certificate-issue.path
 systemctl enable agama-welcome-issue.service
 systemctl enable agama-avahi-issue.service
 systemctl enable agama-ssh-issue.service
+systemctl enable agama-self-update.service
 systemctl enable live-password-cmdline.service
 systemctl enable live-password-dialog.service
 systemctl enable live-password-iso.service


### PR DESCRIPTION
## Problem

- Agama cannot be easily updated on the Live medium
- For testing it is annoying to download the latest image again and again

## Solution

- Let's try a simple approach using `zypper dup`

## Notes

- By default it is disabled, can be enabled by the `agama.self_update` boot option or executed manually via the `agama-self-update` script in a running system.
- Compared to the YaST self-update it uses RPM DB and evaluates the dependencies, this should avoid installing inconsistent updates as we have seen in YaST recently.
- On the other hand YaST compares the individual files from the updated RPMs and overwrites only the changed files. That means it is more space efficient. But as for the initial PoC it is OK I think.

## Testing

- Tested manually

## Screenshots

Updated Agama web UI package during boot:

[agama-self-update-screen0.webm](https://github.com/openSUSE/agama/assets/907998/504a0305-ae13-486a-a416-541633c7cb50)

