### PR TITLE
fix(RPM): Fixed RPM systemd scripts, restart the services after upgrade

### DIFF
--- a/rust/package/agama.spec
+++ b/rust/package/agama.spec
@@ -113,7 +113,7 @@ echo $PATH
 %service_del_preun agama-web-server.service
 
 %postun
-%service_del_preun agama-web-server.service
+%service_del_postun_with_restart agama-web-server.service
 
 %files
 %{_bindir}/agama-dbus-server

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -84,3 +84,8 @@
     %{_datadir}/agama/conf.d\n
     %dir /usr/share/YaST2\n
     /usr/share/YaST2/locale\n"
+:scripts:
+  :pre: "%service_add_pre agama.service"
+  :post: "%service_add_post agama.service"
+  :preun: "%service_del_preun agama.service"
+  :postun: "%service_del_postun_with_restart agama.service"


### PR DESCRIPTION
## Problem

- The systemd services are not automatically restarted after upgrading the RPM packages

## Solution

- Restart the Agama webserver after upgrading the package
- Add the systemd handling also to the Ruby service package
