### PR TITLE
fix(web): drop header link

### DIFF
--- a/web/src/MainLayout.jsx
+++ b/web/src/MainLayout.jsx
@@ -53,7 +53,7 @@ const Header = () => {
         </PageToggleButton>
       </MastheadToggle>
       <MastheadMain>
-        <MastheadBrand component="h1"><NavLink to="/">{title}</NavLink></MastheadBrand>
+        <MastheadBrand component="h1">{title}</MastheadBrand>
       </MastheadMain>
       <MastheadContent>
         <Toolbar>


### PR DESCRIPTION
## Problem

While [remaking the UI](https://github.com/openSUSE/agama/pull/1202), an extra link to the overview page was added to the selected product name acting as page title. Although at some point we realized that it was not really useful, it was forgotten and got merged to the master branch letting us to confirm ours suspicions by gathering feedback about being kind of confusing (thanks @jreidinger!)

## Solution

Drop such a link.

## Testing

Tested manually

## Notes

There are to worth mentioning notes related to this:

* This is just an example of what we've said (at least internally) a bunch of times: the new UI layout still needing love at several levels (layout, code, testing, etc). It was just in a good enough shape for get merged into master and avoid diverging too much and, more important, stop maintaining two completely different UIs.
* Maybe the product title should include the "installation" word apart of the product name. Something to think about.
