### PR TITLE
fix(service): Fixed libzypp repository cache removal

### DIFF
--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -510,6 +510,9 @@ module Agama
         else
           # delete all, the #probe call will add the new repos
           repositories.delete_all
+          # deleting happens only in memory, to really delete the caches we need
+          # to write the repository setup to the disk
+          Yast::Pkg.SourceSaveAll
         end
       end
     end

--- a/service/test/agama/software/manager_test.rb
+++ b/service/test/agama/software/manager_test.rb
@@ -83,6 +83,7 @@ describe Agama::Software::Manager do
 
   before do
     allow(Yast::Pkg).to receive(:TargetInitialize)
+    allow(Yast::Pkg).to receive(:SourceSaveAll)
     allow(Yast::Pkg).to receive(:ImportGPGKey)
     # allow glob to work for other calls
     allow(Dir).to receive(:glob).and_call_original


### PR DESCRIPTION
## Problem

- The libzypp repository cache was not removed after changing the product


## Solution

- The Pkg bindings just mark the repository removal in memory, the repositories and their caches are really deleted after running the `Pkg.SourceSaveAll` call (kind of "commit" call).

## Testing

- Tested manually
