### PR TITLE
feat: unify progress handling

### DIFF
--- a/rust/agama-lib/src/progress.rs
+++ b/rust/agama-lib/src/progress.rs
@@ -54,6 +54,7 @@ use zbus::Connection;
 
 /// Represents the progress for an Agama service.
 #[derive(Clone, Default, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Progress {
     /// Current step
     pub current_step: u32,

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -23,6 +23,10 @@ trait Progress {
     /// TotalSteps property
     #[dbus_proxy(property)]
     fn total_steps(&self) -> zbus::Result<u32>;
+
+    /// Steps property
+    #[dbus_proxy(property)]
+    fn steps(&self) -> zbus::Result<Vec<String>>;
 }
 
 #[dbus_proxy(

--- a/rust/agama-server/src/web/common.rs
+++ b/rust/agama-server/src/web/common.rs
@@ -165,10 +165,21 @@ struct ProgressState<'a> {
     proxy: ProgressProxy<'a>,
 }
 
-async fn progress(State(state): State<ProgressState<'_>>) -> Result<Json<Progress>, Error> {
+/// Information about the current progress sequence.
+#[derive(Clone, Default, Serialize)]
+pub struct ProgressSequence {
+    /// Sequence steps if known in advance
+    steps: Vec<String>,
+    #[serde(flatten)]
+    progress: Progress,
+}
+
+async fn progress(State(state): State<ProgressState<'_>>) -> Result<Json<ProgressSequence>, Error> {
     let proxy = state.proxy;
     let progress = Progress::from_proxy(&proxy).await?;
-    Ok(Json(progress))
+    let steps = proxy.steps().await?;
+    let sequence = ProgressSequence { steps, progress };
+    Ok(Json(sequence))
 }
 
 #[pin_project]

--- a/rust/agama-server/src/web/common.rs
+++ b/rust/agama-server/src/web/common.rs
@@ -167,6 +167,7 @@ struct ProgressState<'a> {
 
 /// Information about the current progress sequence.
 #[derive(Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProgressSequence {
     /// Sequence steps if known in advance
     steps: Vec<String>,

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun 20 05:32:42 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for progress sequences with pre-defined descriptions
+  (gh#openSUSE/agama#1356).
+- Fix the "Progress" signal to use camelCase
+  (gh#openSUSE/agama#1356).
+
+-------------------------------------------------------------------
 Fri Jun 14 06:17:52 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Remove references to the old "config add/set" subcommands

--- a/service/lib/agama/dbus/interfaces/progress.rb
+++ b/service/lib/agama/dbus/interfaces/progress.rb
@@ -78,6 +78,15 @@ module Agama
           backend.progress.finished?
         end
 
+        # Returns the known step descriptions
+        #
+        # @return [Array<String>]
+        def progress_steps
+          return [] unless backend.progress
+
+          backend.progress.descriptions
+        end
+
         # D-Bus properties of the Progress interface
         #
         # @return [Hash]
@@ -104,6 +113,7 @@ module Agama
               dbus_reader :progress_total_steps, "u", dbus_name: "TotalSteps"
               dbus_reader :progress_current_step, "(us)", dbus_name: "CurrentStep"
               dbus_reader :progress_finished, "b", dbus_name: "Finished"
+              dbus_reader :progress_steps, "as", dbus_name: "Steps"
             end
           end
         end

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -85,7 +85,7 @@ module Agama
       installation_phase.config
 
       start_progress_with_descriptions(
-        _("Probing Storage"), _("Probing Software")
+        _("Analyze disks"), _("Configure software")
       )
       progress.step { storage.probe }
       progress.step { software.probe }
@@ -105,9 +105,9 @@ module Agama
       service_status.busy
       installation_phase.install
       start_progress_with_descriptions(
-        _("Partitioning"),
-        _("Installing software"),
-        _("Configuring the system")
+        _("Prepare disks"),
+        _("Install software"),
+        _("Configure the system")
       )
 
       Yast::Installation.destdir = "/mnt"

--- a/service/lib/agama/progress.rb
+++ b/service/lib/agama/progress.rb
@@ -192,7 +192,7 @@ module Agama
   private
 
     def description_for(step)
-      @descriptions[step - 1] || format(_("Step %s/%s"), step, total_steps)
+      @descriptions[step - 1] || ""
     end
   end
 end

--- a/service/lib/agama/software/callbacks/progress.rb
+++ b/service/lib/agama/software/callbacks/progress.rb
@@ -41,8 +41,8 @@ module Agama
         end
 
         def setup
-          Yast::Pkg.CallbackDonePackage(
-            fun_ref(method(:package_installed), "string (integer, string)")
+          Yast::Pkg.CallbackStartPackage(
+            fun_ref(method(:start_package), "void (string, string, string, integer, boolean)")
           )
         end
 
@@ -55,12 +55,8 @@ module Agama
           Yast::FunRef.new(method, signature)
         end
 
-        # TODO: error handling
-        def package_installed(_error, _reason)
-          @installed += 1
-          progress.step(msg)
-
-          ""
+        def start_package(package, _file, _summary, _size, _other)
+          progress.step("Installing #{package}")
         end
 
         def msg

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -132,11 +132,11 @@ module Agama
         logger.info "Probing software"
 
         if repositories.empty?
-          start_progress(3)
+          start_progress_with_size(3)
           Yast::PackageCallbacks.InitPackageCallbacks(logger)
           progress.step(_("Initializing sources")) { add_base_repos }
         else
-          start_progress(2)
+          start_progress_with_size(2)
         end
 
         progress.step(_("Refreshing repositories metadata")) { repositories.load }
@@ -178,7 +178,7 @@ module Agama
         Yast::Pkg.TargetLoad
 
         steps = proposal.packages_count
-        start_progress(steps)
+        start_progress_with_size(steps)
         Callbacks::Progress.setup(steps, progress)
 
         # TODO: error handling
@@ -197,16 +197,13 @@ module Agama
 
       # Writes the repositories information to the installed system
       def finish
-        start_progress(1)
-        progress.step(_("Writing repositories to the target system")) do
-          Yast::Pkg.SourceSaveAll
-          Yast::Pkg.TargetFinish
-          # FIXME: Pkg.SourceCacheCopyTo works correctly only from the inst-sys
-          # (original target "/"), it does not work correctly when using
-          # "chroot" /run/agama/zypp, it needs to be reimplemented :-(
-          # Yast::Pkg.SourceCacheCopyTo(Yast::Installation.destdir)
-          registration.finish
-        end
+        Yast::Pkg.SourceSaveAll
+        Yast::Pkg.TargetFinish
+        # FIXME: Pkg.SourceCacheCopyTo works correctly only from the inst-sys
+        # (original target "/"), it does not work correctly when using
+        # "chroot" /run/agama/zypp, it needs to be reimplemented :-(
+        # Yast::Pkg.SourceCacheCopyTo(Yast::Installation.destdir)
+        registration.finish
       end
 
       # Determine whether the given tag is provided by the selected packages

--- a/service/lib/agama/storage/finisher.rb
+++ b/service/lib/agama/storage/finisher.rb
@@ -50,7 +50,7 @@ module Agama
       # Execute the final storage actions, reporting the progress
       def run
         steps = possible_steps.select(&:run?)
-        start_progress(steps.size)
+        start_progress_with_size(steps.size)
 
         on_target do
           steps.each do |step|

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -107,7 +107,7 @@ module Agama
 
       # Probes storage devices and performs an initial proposal
       def probe
-        start_progress(4)
+        start_progress_with_size(4)
         config.pick_product(software.selected_product)
         check_multipath
         progress.step(_("Activating storage devices")) { activate_devices }
@@ -120,7 +120,7 @@ module Agama
 
       # Prepares the partitioning to install the system
       def install
-        start_progress(4)
+        start_progress_with_size(4)
         progress.step(_("Preparing bootloader proposal")) do
           # first make bootloader proposal to be sure that required packages are installed
           proposal = ::Bootloader::ProposalClient.new.make_proposal({})

--- a/service/lib/agama/with_progress.rb
+++ b/service/lib/agama/with_progress.rb
@@ -30,7 +30,7 @@ module Agama
     # @return [Progress, nil]
     attr_reader :progress
 
-    # Creates a new progress with a give number of steps
+    # Creates a new progress with a given number of steps
     #
     # @param size [Integer] Number of steps
     def start_progress_with_size(size)
@@ -46,8 +46,6 @@ module Agama
 
     # Creates a new progress
     #
-    # Prefer using #start_progress_with_Size or #start_progress_with_descriptions.
-    #
     # @raise [RuntimeError] if there is an unfinished progress.
     #
     # @param args [*Hash] Progress constructor arguments.
@@ -62,6 +60,7 @@ module Agama
         progress.on_finish { on_finish_callbacks.each(&:call) }
       end
     end
+    private :start_progress
 
     # Finishes the current progress
     def finish_progress

--- a/service/lib/agama/with_progress.rb
+++ b/service/lib/agama/with_progress.rb
@@ -30,18 +30,34 @@ module Agama
     # @return [Progress, nil]
     attr_reader :progress
 
+    # Creates a new progress with a give number of steps
+    #
+    # @param size [Integer] Number of steps
+    def start_progress_with_size(size)
+      start_progress(size: size)
+    end
+
+    # Creates a new progress with a given set of steps
+    #
+    # @param descriptions [Array<String>] Steps descriptions
+    def start_progress_with_descriptions(*descriptions)
+      start_progress(descriptions: descriptions)
+    end
+
     # Creates a new progress
+    #
+    # Prefer using #start_progress_with_Size or #start_progress_with_descriptions.
     #
     # @raise [RuntimeError] if there is an unfinished progress.
     #
-    # @param total_steps [Integer] total number of the steps for the progress.
-    def start_progress(total_steps)
+    # @param args [*Hash] Progress constructor arguments.
+    def start_progress(args)
       raise NotFinishedProgress if progress && !progress.finished?
 
       on_change_callbacks = @on_progress_change_callbacks || []
       on_finish_callbacks = @on_progress_finish_callbacks || []
 
-      @progress = Progress.new(total_steps).tap do |progress|
+      @progress = Progress.new(**args).tap do |progress|
         progress.on_change { on_change_callbacks.each(&:call) }
         progress.on_finish { on_finish_callbacks.each(&:call) }
       end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 20 05:25:49 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for progress sequences with pre-defined descriptions
+  (gh#openSUSE/agama#1356).
+
+-------------------------------------------------------------------
 Wed Jun 19 06:04:46 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Use a different libzypp target for Agama, do not use the Live

--- a/service/test/agama/dbus/interfaces/progress_test.rb
+++ b/service/test/agama/dbus/interfaces/progress_test.rb
@@ -59,7 +59,7 @@ describe DBusObjectWithProgressInterface do
 
     context " if there is a progress" do
       before do
-        subject.backend.start_progress(2)
+        subject.backend.start_progress_with_size(2)
       end
 
       it "returns the total number of steps of the progress" do
@@ -77,7 +77,7 @@ describe DBusObjectWithProgressInterface do
 
     context " if there is a progress" do
       before do
-        subject.backend.start_progress(2)
+        subject.backend.start_progress_with_size(2)
       end
 
       before do
@@ -99,7 +99,7 @@ describe DBusObjectWithProgressInterface do
 
     context " if there is a progress" do
       before do
-        subject.backend.start_progress(2)
+        subject.backend.start_progress_with_size(2)
       end
 
       context "and the progress is not started" do
@@ -133,7 +133,7 @@ describe DBusObjectWithProgressInterface do
 
   describe "#progress_properties" do
     before do
-      subject.backend.start_progress(2)
+      subject.backend.start_progress_with_size(2)
       progress.step("step 1")
     end
 
@@ -141,7 +141,8 @@ describe DBusObjectWithProgressInterface do
       expected_properties = {
         "TotalSteps"  => 2,
         "CurrentStep" => [1, "step 1"],
-        "Finished"    => false
+        "Finished"    => false,
+        "Steps"       => []
       }
       expect(subject.progress_properties).to eq(expected_properties)
     end
@@ -150,7 +151,7 @@ describe DBusObjectWithProgressInterface do
   describe "#register_progress_callbacks" do
     it "register callbacks to be called when the progress changes" do
       subject.register_progress_callbacks
-      subject.backend.start_progress(2)
+      subject.backend.start_progress_with_size(2)
 
       expect(subject).to receive(:dbus_properties_changed)
         .with(progress_interface, anything, anything)
@@ -160,7 +161,7 @@ describe DBusObjectWithProgressInterface do
 
     it "register callbacks to be called when the progress finishes" do
       subject.register_progress_callbacks
-      subject.backend.start_progress(2)
+      subject.backend.start_progress_with_size(2)
 
       expect(subject).to receive(:dbus_properties_changed)
         .with(progress_interface, anything, anything)

--- a/service/test/agama/dbus/interfaces/progress_test.rb
+++ b/service/test/agama/dbus/interfaces/progress_test.rb
@@ -132,19 +132,38 @@ describe DBusObjectWithProgressInterface do
   end
 
   describe "#progress_properties" do
-    before do
-      subject.backend.start_progress_with_size(2)
-      progress.step("step 1")
+    context "when steps are not known in advance" do
+      before do
+        subject.backend.start_progress_with_size(2)
+        progress.step("step 1")
+      end
+
+      it "returns de D-Bus properties of the progress interface" do
+        expected_properties = {
+          "TotalSteps"  => 2,
+          "CurrentStep" => [1, "step 1"],
+          "Finished"    => false,
+          "Steps"       => []
+        }
+        expect(subject.progress_properties).to eq(expected_properties)
+      end
     end
 
-    it "returns de D-Bus properties of the progress interface" do
-      expected_properties = {
-        "TotalSteps"  => 2,
-        "CurrentStep" => [1, "step 1"],
-        "Finished"    => false,
-        "Steps"       => []
-      }
-      expect(subject.progress_properties).to eq(expected_properties)
+    context "when steps are known in advance" do
+      before do
+        subject.backend.start_progress_with_descriptions("step 1", "step 2")
+        progress.step
+      end
+
+      it "includes the steps" do
+        expected_properties = {
+          "TotalSteps"  => 2,
+          "CurrentStep" => [1, "step 1"],
+          "Finished"    => false,
+          "Steps"       => ["step 1", "step 2"]
+        }
+        expect(subject.progress_properties).to eq(expected_properties)
+      end
     end
   end
 

--- a/service/test/agama/progress_test.rb
+++ b/service/test/agama/progress_test.rb
@@ -23,7 +23,27 @@ require_relative "../test_helper"
 require "agama/progress"
 
 describe Agama::Progress do
-  subject { described_class.new(steps) }
+  subject { described_class.with_size(steps) }
+
+  describe "when the steps are known in advance" do
+    subject do
+      described_class.with_descriptions(
+        ["Partitioning", "Installing", "Configuring"]
+      )
+    end
+
+    it "sets the total_steps to the number of steps" do
+      expect(subject.total_steps).to eq(3)
+    end
+
+    it "uses the given descriptions" do
+      subject.step
+      expect(subject.current_step.description).to eq("Partitioning")
+
+      subject.step
+      expect(subject.current_step.description).to eq("Installing")
+    end
+  end
 
   describe "#current_step" do
     let(:steps) { 3 }
@@ -56,8 +76,28 @@ describe Agama::Progress do
         subject.step("step 3")
       end
 
-      it "returns nil" do
+      it "returns the last step" do
         expect(subject.current_step).to be_nil
+      end
+    end
+
+    context "if the descriptions are known in advance" do
+      subject do
+        described_class.with_descriptions(
+          ["Partitioning", "Installing", "Configuring"]
+        )
+      end
+
+      it "uses the descriptions" do
+        subject.step
+        expect(subject.current_step.description).to eq("Partitioning")
+      end
+
+      context "but a description is given" do
+        it "uses the given descriptions" do
+          subject.step("Finishing")
+          expect(subject.current_step.description).to eq("Finishing")
+        end
       end
     end
   end

--- a/service/test/agama/storage/finisher_test.rb
+++ b/service/test/agama/storage/finisher_test.rb
@@ -53,7 +53,7 @@ describe Agama::Storage::Finisher do
     end
 
     it "runs the possible steps that must be run" do
-      expect(subject).to receive(:start_progress).with(1)
+      expect(subject).to receive(:start_progress_with_size).with(1)
       expect(subject.progress).to receive(:step) do |label, &block|
         expect(label).to eql(copy_files.label)
         expect(copy_files).to receive(:run)

--- a/service/test/agama/with_progress_examples.rb
+++ b/service/test/agama/with_progress_examples.rb
@@ -31,7 +31,7 @@ shared_examples "progress" do
 
     context "if a progress was started" do
       before do
-        subject.start_progress(1)
+        subject.start_progress_with_size(1)
       end
 
       it "returns the progress object" do
@@ -40,27 +40,27 @@ shared_examples "progress" do
     end
   end
 
-  describe "#start_progress" do
+  describe "#start_progress_with_size" do
     context "if there is an unfinished progress" do
       before do
-        subject.start_progress(1)
+        subject.start_progress_with_size(1)
       end
 
       it "raises an error" do
-        expect { subject.start_progress(1) }
+        expect { subject.start_progress_with_size(1) }
           .to raise_error(Agama::WithProgress::NotFinishedProgress)
       end
     end
 
     context "if there is no unfinished progress" do
       before do
-        subject.start_progress(1)
+        subject.start_progress_with_size(1)
         subject.progress.finish
       end
 
       it "creates a new progress" do
         previous_progress = subject.progress
-        subject.start_progress(1)
+        subject.start_progress_with_size(1)
         expect(subject.progress).to_not eq(previous_progress)
         expect(subject.progress.finished?).to eq(false)
       end
@@ -71,7 +71,7 @@ shared_examples "progress" do
 
         expect(callback).to receive(:call)
 
-        subject.start_progress(1)
+        subject.start_progress_with_size(1)
         subject.progress.step("step 1")
       end
 
@@ -81,7 +81,7 @@ shared_examples "progress" do
 
         expect(callback).to receive(:call)
 
-        subject.start_progress(1)
+        subject.start_progress_with_size(1)
         subject.progress.finish
       end
     end
@@ -90,7 +90,7 @@ shared_examples "progress" do
   describe "#finish" do
     context "when the current progress is not finished" do
       before do
-        subject.start_progress(1)
+        subject.start_progress_with_size(1)
       end
 
       it "finishes the current progress" do
@@ -102,7 +102,7 @@ shared_examples "progress" do
 
     context "when the current progress is already finished" do
       before do
-        subject.start_progress(1)
+        subject.start_progress_with_size(1)
         subject.progress.step("") { nil }
       end
 

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 20 05:33:29 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Adapt the installation progress screen to look like the
+  product selection one (gh#openSUSE/agama#1356).
+
+-------------------------------------------------------------------
 Fri Jun 14 13:55:27 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
 - Do not render the overview page when selecting a product

--- a/web/src/client/mixins.js
+++ b/web/src/client/mixins.js
@@ -177,6 +177,15 @@ const WithStatus = (superclass, status_path, service_name) =>
  */
 
 /**
+ * @typedef {object} ProgressSequence
+ * @property {string[]} steps - sequence steps if known in advance
+ * @property {number} total - number of steps
+ * @property {number} current - current step
+ * @property {string} message - message of the current step
+ * @property {boolean} finished - whether the progress already finished
+ */
+
+/**
  * @callback ProgressHandler
  * @param {Progress} progress - progress status
  * @return {void}
@@ -195,7 +204,7 @@ const WithProgress = (superclass, progress_path, service_name) =>
     /**
      * Returns the service progress
      *
-     * @return {Promise<Progress>} an object containing the total steps,
+     * @return {Promise<ProgressSequence>} an object containing the total steps,
      *   the current step and whether the service finished or not.
      */
     async getProgress() {
@@ -203,14 +212,16 @@ const WithProgress = (superclass, progress_path, service_name) =>
       if (!response.ok) {
         console.log("get progress failed with:", response);
         return {
+          steps: [],
           total: 0,
           current: 0,
           message: "Failed to get progress",
           finished: false,
         };
       } else {
-        const { current_step, max_steps, current_title, finished } = await response.json();
+        const { steps, current_step, max_steps, current_title, finished } = await response.json();
         return {
+          steps,
           total: max_steps,
           current: current_step,
           message: current_title,

--- a/web/src/client/mixins.js
+++ b/web/src/client/mixins.js
@@ -219,12 +219,13 @@ const WithProgress = (superclass, progress_path, service_name) =>
           finished: false,
         };
       } else {
-        const { steps, current_step, max_steps, current_title, finished } = await response.json();
+        const { steps, currentStep, maxSteps, currentTitle, finished } =
+          await response.json();
         return {
           steps,
-          total: max_steps,
-          current: current_step,
-          message: current_title,
+          total: maxSteps,
+          current: currentStep,
+          message: currentTitle,
           finished,
         };
       }
@@ -239,11 +240,11 @@ const WithProgress = (superclass, progress_path, service_name) =>
     onProgressChange(handler) {
       return this.client.onEvent("Progress", ({ service, ...progress }) => {
         if (service === service_name) {
-          const { current_step, max_steps, current_title, finished } = progress;
+          const { currentStep, maxSteps, currentTitle, finished } = progress;
           handler({
-            total: max_steps,
-            current: current_step,
-            message: current_title,
+            total: maxSteps,
+            current: currentStep,
+            message: currentTitle,
             finished,
           });
         }

--- a/web/src/components/core/InstallationProgress.jsx
+++ b/web/src/components/core/InstallationProgress.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022] SUSE LLC
+ * Copyright (c) [2022-2024] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -20,26 +20,24 @@
  */
 
 import React from "react";
-import { Card, CardBody, Grid, GridItem } from "@patternfly/react-core";
-import SimpleLayout from "~/SimpleLayout";
-import ProgressReport from "./ProgressReport";
-import { Center } from "~/components/layout";
+import { useProduct } from "~/context/product";
+import { sprintf } from "sprintf-js";
 import { _ } from "~/i18n";
+import ProgressReport from "./ProgressReport";
+import SimpleLayout from "~/SimpleLayout";
 
 function InstallationProgress() {
+  const { selectedProduct } = useProduct();
+
+  if (!selectedProduct) {
+    return;
+  }
+
+  // TRANSLATORS: %s is replaced by a product name (e.g., openSUSE Tumbleweed)
+  const title = sprintf(_("Installing %s, please wait ..."), selectedProduct.name);
   return (
-    <SimpleLayout showOutlet={false}>
-      <Center>
-        <Grid hasGutter>
-          <GridItem sm={8} smOffset={2}>
-            <Card>
-              <CardBody>
-                <ProgressReport />
-              </CardBody>
-            </Card>
-          </GridItem>
-        </Grid>
-      </Center>
+    <SimpleLayout showOutlet={false} showInstallerOptions={false}>
+      <ProgressReport title={title} />
     </SimpleLayout>
   );
 }

--- a/web/src/components/core/InstallationProgress.jsx
+++ b/web/src/components/core/InstallationProgress.jsx
@@ -36,7 +36,7 @@ function InstallationProgress() {
   // TRANSLATORS: %s is replaced by a product name (e.g., openSUSE Tumbleweed)
   const title = sprintf(_("Installing %s, please wait ..."), selectedProduct.name);
   return (
-    <SimpleLayout showOutlet={false} showInstallerOptions={true}>
+    <SimpleLayout showOutlet={false} showInstallerOptions>
       <ProgressReport title={title} />
     </SimpleLayout>
   );

--- a/web/src/components/core/InstallationProgress.jsx
+++ b/web/src/components/core/InstallationProgress.jsx
@@ -36,7 +36,7 @@ function InstallationProgress() {
   // TRANSLATORS: %s is replaced by a product name (e.g., openSUSE Tumbleweed)
   const title = sprintf(_("Installing %s, please wait ..."), selectedProduct.name);
   return (
-    <SimpleLayout showOutlet={false} showInstallerOptions={false}>
+    <SimpleLayout showOutlet={false} showInstallerOptions={true}>
       <ProgressReport title={title} />
     </SimpleLayout>
   );

--- a/web/src/components/core/ProgressReport.jsx
+++ b/web/src/components/core/ProgressReport.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022] SUSE LLC
+ * Copyright (c) [2022-2024] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -19,80 +19,125 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useState, useEffect } from "react";
-import { Flex, Progress, Spinner, Text } from "@patternfly/react-core";
-import { useCancellablePromise } from "~/utils";
+import React, { useEffect, useState } from "react";
+import {
+  Card,
+  CardBody,
+  Grid,
+  GridItem,
+  ProgressStepper,
+  ProgressStep,
+  Spinner,
+  Stack,
+} from "@patternfly/react-core";
+
+import { _ } from "~/i18n";
+import { Center } from "~/components/layout";
 import { useInstallerClient } from "~/context/installer";
 
-const ProgressReport = () => {
-  const client = useInstallerClient();
-  const { cancellablePromise } = useCancellablePromise();
-  // progress and subprogress are basically objects containing { message, step, steps }
-  const [progress, setProgress] = useState({});
-  const [subProgress, setSubProgress] = useState(undefined);
+const Progress = ({ steps, step, firstStep, detail }) => {
+  const variant = (index) => {
+    if (index < step.current) return "success";
+    if (index === step.current) return "info";
+    if (index > step.current) return "pending";
+  };
 
-  useEffect(() => {
-    cancellablePromise(client.manager.getProgress()).then(({ message, current, total }) => {
-      setProgress({ message, step: current, steps: total });
-    });
-  }, [client.manager, cancellablePromise]);
+  const stepProperties = (stepNumber) => {
+    const properties = {
+      variant: variant(stepNumber),
+      isCurrent: stepNumber === step.current,
+      id: `step-${stepNumber}-id`,
+      titleId: `step-${stepNumber}-title`,
+    };
 
-  useEffect(() => {
-    return client.manager.onProgressChange(({ message, current, total, finished }) => {
-      if (!finished) setProgress({ message, step: current, steps: total });
-    });
-  }, [client.manager]);
-
-  useEffect(() => {
-    return client.software.onProgressChange(({ message, current, total, finished }) => {
-      if (finished) {
-        setSubProgress(undefined);
-      } else {
-        setSubProgress({ message, step: current, steps: total });
+    if (properties.isCurrent) {
+      properties.icon = <Spinner />;
+      if (detail && detail.message !== "") {
+        const { message, current, total } = detail;
+        properties.description = `${message} (${current}/${total})`;
       }
-    });
-  }, [client.software]);
+    }
 
-  if (!progress.steps) {
-    return (
-      <Flex
-        direction={{ default: "column" }}
-        rowGap={{ default: "rowGapXl" }}
-        alignItems={{ default: "alignItemsCenter" }}
-        justifyContent={{ default: "justifyContentCenter" }}
-      >
-        <Spinner />
-        <Text component="h1">Waiting for progress status...</Text>
-      </Flex>
-    );
-  }
+    return properties;
+  };
 
   return (
-    <Flex
-      direction={{ default: "column" }}
-      rowGap={{ default: "rowGapMd" }}
-    >
-      <Progress
-        min={0}
-        max={progress.steps}
-        value={progress.step}
-        title={progress.message}
-        measureLocation="none"
-      />
-
-      {
-        subProgress &&
-        <Progress
-          min={0}
-          max={subProgress.steps}
-          value={subProgress.step}
-          title={subProgress.message}
-          measureLocation="none"
-          size="sm"
-        />
-      }
-    </Flex>
+    <ProgressStepper isCenterAligned>
+      {firstStep && (
+        <ProgressStep key="initial" variant="success">
+          {firstStep}
+        </ProgressStep>
+      )}
+      {steps.map((description, idx) => {
+        return (
+          <ProgressStep key={idx} {...stepProperties(idx + 1)}>
+            {description}
+          </ProgressStep>
+        );
+      })}
+    </ProgressStepper>
   );
 };
+
+/**
+ * @component
+ *
+ * Shows progress steps when a product is selected.
+ */
+function ProgressReport({ title, firstStep }) {
+  const { manager, storage, software } = useInstallerClient();
+  const [steps, setSteps] = useState();
+  const [step, setStep] = useState();
+  const [detail, setDetail] = useState();
+
+  useEffect(() => software.onProgressChange(setDetail), [software, setDetail]);
+  useEffect(() => storage.onProgressChange(setDetail), [storage, setDetail]);
+
+  useEffect(() => {
+    manager.getProgress().then((progress) => {
+      setSteps(progress.steps);
+      setStep(progress);
+    });
+
+    return manager.onProgressChange(setStep);
+  }, [manager, setSteps]);
+
+  const Content = () => {
+    if (!steps) {
+      return;
+    }
+
+    return (
+      <Progress
+        titleId="progress-title"
+        steps={steps}
+        step={step}
+        detail={detail}
+        firstStep={firstStep}
+        currentStep={false}
+      />
+    );
+  };
+
+  const progressTitle = !steps ? _("Waiting for progress status...") : title;
+  return (
+    <Center>
+      <Grid hasGutter>
+        <GridItem sm={8} smOffset={2}>
+          <Card isPlain>
+            <CardBody>
+              <Stack hasGutter>
+                <h1 id="progress-title" style={{ textAlign: "center" }}>
+                  {progressTitle}
+                </h1>
+                <Content />
+              </Stack>
+            </CardBody>
+          </Card>
+        </GridItem>
+      </Grid>
+    </Center>
+  );
+}
 
 export default ProgressReport;

--- a/web/src/components/overview/OverviewPage.jsx
+++ b/web/src/components/overview/OverviewPage.jsx
@@ -59,12 +59,12 @@ const ReadyForInstallation = () => (
 const IssuesList = ({ issues }) => {
   const { isEmpty, ...scopes } = issues;
   const list = [];
-  Object.entries(scopes).forEach(([scope, issues]) => {
-    issues.forEach((issue, idx) => {
+  Object.entries(scopes).forEach(([scope, issues], idx) => {
+    issues.forEach((issue, subIdx) => {
       const variant = issue.severity === "error" ? "warning" : "info";
 
       const link = (
-        <NotificationDrawerListItem key={idx} variant={variant} isHoverable={false}>
+        <NotificationDrawerListItem key={`${idx}-${subIdx}`} variant={variant} isHoverable={false}>
           <NotificationDrawerListItemHeader title={SCOPE_HEADERS[scope]} variant={variant} headingLevel="h4" />
           <NotificationDrawerListItemBody>
             <Link to={`/${scope}`}>{issue.description}</Link>

--- a/web/src/components/product/ProductSelectionProgress.jsx
+++ b/web/src/components/product/ProductSelectionProgress.jsx
@@ -21,97 +21,20 @@
 
 import React, { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
-import {
-  Card, CardBody,
-  Grid, GridItem,
-  ProgressStepper, ProgressStep,
-  Spinner,
-  Stack
-} from "@patternfly/react-core";
-
 import { _ } from "~/i18n";
-import { Center } from "~/components/layout";
-import { useCancellablePromise } from "~/utils";
-import { useInstallerClient } from "~/context/installer";
 import { useProduct } from "~/context/product";
+import { ProgressReport } from "~/components/core";
 import { IDLE } from "~/client/status";
-
-const Progress = ({ selectedProduct, storageProgress, softwareProgress }) => {
-  const variant = (progress) => {
-    if (progress.start && progress.current === 0) return "success";
-    if (!progress.start) return "pending";
-    if (progress.current > 0) return "info";
-  };
-
-  const isCurrent = (progress) => progress.current > 0;
-
-  const description = ({ message, current, total }) => {
-    if (!message) return "";
-
-    return (current === 0) ? message : `${message} (${current}/${total})`;
-  };
-
-  const stepProperties = (progress) => {
-    const properties = {
-      variant: variant(progress),
-      isCurrent: isCurrent(progress),
-      description: description(progress)
-    };
-
-    if (properties.isCurrent) properties.icon = <Spinner />;
-
-    return properties;
-  };
-
-  // Emulates progress for product selection step.
-  const productProgress = () => {
-    if (!storageProgress.start) return { start: true, current: 1 };
-
-    return { start: true, current: 0 };
-  };
-
-  /** @todo Add aria-label to steps, describing its status and variant. */
-  return (
-    <ProgressStepper isCenterAligned>
-      <ProgressStep
-        id="product-step"
-        titleId="product-step-title"
-        {...stepProperties(productProgress())}
-      >
-        {selectedProduct.name}
-      </ProgressStep>
-      <ProgressStep
-        id="storage-step"
-        titleId="storage-step-title"
-        {...stepProperties(storageProgress)}
-      >
-        {_("Analyze disks")}
-      </ProgressStep>
-      <ProgressStep
-        id="software-step"
-        titleId="software-step-title"
-        {...stepProperties(softwareProgress)}
-      >
-        {_("Configure software")}
-      </ProgressStep>
-    </ProgressStepper>
-  );
-};
+import { useInstallerClient } from "~/context/installer";
 
 /**
  * @component
  *
  * Shows progress steps when a product is selected.
- *
- * @note Some details are hardcoded (e.g., the steps, the order, etc). The progress API has to be
- *  improved.
  */
 function ProductSelectionProgress() {
-  const { cancellablePromise } = useCancellablePromise();
-  const { manager, storage, software } = useInstallerClient();
   const { selectedProduct } = useProduct();
-  const [storageProgress, setStorageProgress] = useState({});
-  const [softwareProgress, setSoftwareProgress] = useState({});
+  const { manager } = useInstallerClient();
   const [status, setStatus] = useState();
 
   useEffect(() => {
@@ -119,54 +42,17 @@ function ProductSelectionProgress() {
     return manager.onStatusChange(setStatus);
   }, [manager, setStatus]);
 
-  useEffect(() => {
-    const updateProgress = (progress) => {
-      if (progress.current > 0) progress.start = true;
-      setStorageProgress(p => ({ ...p, ...progress }));
-    };
-
-    cancellablePromise(storage.getProgress()).then(updateProgress);
-
-    return storage.onProgressChange(updateProgress);
-  }, [cancellablePromise, setStorageProgress, storage]);
-
-  useEffect(() => {
-    const updateProgress = (progress) => {
-      if (progress.current > 0) progress.start = true;
-      setSoftwareProgress(p => ({ ...p, ...progress }));
-      // Let's assume storage was started too.
-      setStorageProgress(p => ({ ...p, start: progress.start }));
-    };
-
-    cancellablePromise(software.getProgress()).then(updateProgress);
-
-    return software.onProgressChange(updateProgress);
-  }, [cancellablePromise, setSoftwareProgress, software]);
+  if (!selectedProduct) {
+    return;
+  }
 
   if (status === IDLE) return <Navigate to="/" replace />;
 
   return (
-    <Center>
-      <Grid hasGutter>
-        <GridItem sm={8} smOffset={2}>
-          <Card isPlain>
-            <CardBody>
-              <Stack hasGutter>
-                <h1 style={{ textAlign: "center" }}>
-                  {_("Configuring the product, please wait ...")}
-                </h1>
-                { status &&
-                <Progress
-                  selectedProduct={selectedProduct}
-                  storageProgress={storageProgress}
-                  softwareProgress={softwareProgress}
-                />}
-              </Stack>
-            </CardBody>
-          </Card>
-        </GridItem>
-      </Grid>
-    </Center>
+    <ProgressReport
+      title={_("Configuring the product, please wait ...")}
+      firstStep={selectedProduct.name}
+    />
   );
 }
 


### PR DESCRIPTION
Trello: https://trello.com/c/Miuvai6N/3706-5-better-progress-report-during-installation

The main goal of this PR is to implement a better mechanism for displaying progress in the web UI. It takes the product selection progress as inspiration but eliminates hardcoded values.

## Progress API problem

When we designed the initial progress API, Agama was quite different. While working on this PR, we have identified a relevant problem: there is no way to have a subprogress in the same service.

The manager service defines the main steps (e.g., "Probing Software") and the details are just the progress from software and storage services (e.g., "Refreshing repositories metadata").

As a consequence, we cannot have a detailed "Configuring system" step at the end of the installation with its details (e.g., "Writing users"). You can only have either 1) a "Configuring system" with no details or several separate steps, which is too much.

In general, we are telling people that they can use the WS to track the progress, so we should decide on a stable API as soon as possible.

## Screenshots

<details>
<summary>Installation progress</summary>

![Captura desde 2024-06-19 15-07-24](https://github.com/openSUSE/agama/assets/15836/2c9f5a93-4984-484a-a5b7-8b66a6eeeb19)
</details>

<details>
<summary>Product selection selection progress</summary>

As you may see in the following screenshot, some texts have been changed. The reason is that now it uses the texts from the backend. We should consider adjusting them.
![Captura desde 2024-06-19 15-06-57](https://github.com/openSUSE/agama/assets/15836/d7c820e7-2335-4f78-9bd5-c63b26add285)
</details>