### PR TITLE
fix(service): Copy the libzypp caches and credentials to the installed system

### DIFF
--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -506,7 +506,7 @@ module Agama
       # the Live system package manager)
       # @see https://github.com/yast/yast-pkg-bindings/blob/3d314480b70070299f90da4c6e87a5574e9c890c/src/Source_Installation.cc#L213-L267
       def copy_zypp_to_target
-        # copy the zypp "raw" cache 
+        # copy the zypp "raw" cache
         cache = File.join(TARGET_DIR, "/var/cache/zypp/raw")
         if Dir.exist?(cache)
           target_cache = File.join(Yast::Installation.destdir, "/var/cache/zypp")

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -506,9 +506,7 @@ module Agama
       # the Live system package manager)
       # @see https://github.com/yast/yast-pkg-bindings/blob/3d314480b70070299f90da4c6e87a5574e9c890c/src/Source_Installation.cc#L213-L267
       def copy_zypp_to_target
-        # copy the zypp "raw" cache (the "solv" cache will be rebuilt
-        # automatically from the "raw" when calling zypper/YaST in the installed
-        # system for the first time)
+        # copy the zypp "raw" cache 
         cache = File.join(TARGET_DIR, "/var/cache/zypp/raw")
         if Dir.exist?(cache)
           target_cache = File.join(Yast::Installation.destdir, "/var/cache/zypp")

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -201,10 +201,8 @@ module Agama
         progress.step(_("Writing repositories to the target system")) do
           Yast::Pkg.SourceSaveAll
           Yast::Pkg.TargetFinish
-          # FIXME: Pkg.SourceCacheCopyTo works correctly only from the inst-sys
-          # (original target "/"), it does not work correctly when using
-          # "chroot" /run/agama/zypp, it needs to be reimplemented :-(
-          # Yast::Pkg.SourceCacheCopyTo(Yast::Installation.destdir)
+          # copy the libzypp caches to the target
+          copy_zypp_to_target
           registration.finish
         end
       end
@@ -501,6 +499,48 @@ module Agama
 
       def pattern_exist?(pattern_name)
         !Y2Packager::Resolvable.find(kind: :pattern, name: pattern_name).empty?
+      end
+
+      # this reimplements the Pkg.SourceCacheCopyTo call which works correctly
+      # only from the inst-sys (it copies the data from "/" where is actually
+      # the Live system package manager)
+      # @see https://github.com/yast/yast-pkg-bindings/blob/3d314480b70070299f90da4c6e87a5574e9c890c/src/Source_Installation.cc#L213-L267
+      def copy_zypp_to_target
+        # copy the zypp "raw" cache (the "solv" cache will be rebuilt
+        # automatically from the "raw" when calling zypper/YaST in the installed
+        # system for the first time)
+        cache = File.join(TARGET_DIR, "/var/cache/zypp/raw")
+        if Dir.exist?(cache)
+          target_cache = File.join(Yast::Installation.destdir, "/var/cache/zypp")
+          FileUtils.mkdir_p(target_cache)
+          FileUtils.cp_r(cache, target_cache)
+        end
+
+        # copy the "solv" cache but skip the "@System" directory because it
+        # contains empty installed packages (there were no installed packages
+        # before moving the target to "/mnt")
+        solv_cache = File.join(TARGET_DIR, "/var/cache/zypp/solv")
+        target_solv = File.join(Yast::Installation.destdir, "/var/cache/zypp/solv")
+        solvs = Dir.entries(solv_cache) - [".", "..", "@System"]
+        solvs.each do |s|
+          FileUtils.cp_r(File.join(solv_cache, s), target_solv)
+        end
+
+        # copy the zypp credentials if present
+        credentials = File.join(TARGET_DIR, "/etc/zypp/credentials.d")
+        if Dir.exist?(credentials)
+          target_credentials = File.join(Yast::Installation.destdir, "/etc/zypp")
+          FileUtils.mkdir_p(target_credentials)
+          FileUtils.cp_r(credentials, target_credentials)
+        end
+
+        # copy the global credentials if present
+        glob_credentials = File.join(TARGET_DIR, "/etc/zypp/credentials.cat")
+        return unless File.exist?(glob_credentials)
+
+        target_dir = File.join(Yast::Installation.destdir, "/etc/zypp")
+        FileUtils.mkdir_p(target_dir)
+        FileUtils.copy(glob_credentials, target_dir)
       end
 
       # update the zypp repositories for the new product, either delete them

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jun 19 06:04:46 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Use a different libzypp target for Agama, do not use the Live
+  system package management (gh#openSUSE/agama#1329)
+- Properly delete the libzypp cache when changing the products
+  (gh#openSUSE/agama#1349)
+
+-------------------------------------------------------------------
 Thu Jun 13 10:53:27 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Replace the Validations with the Issues API in the users-related

--- a/service/test/agama/software/manager_test.rb
+++ b/service/test/agama/software/manager_test.rb
@@ -372,40 +372,54 @@ describe Agama::Software::Manager do
 
     it "copies the libzypp cache and credentials to the target system" do
       allow(Dir).to receive(:exist?).and_call_original
+      allow(Dir).to receive(:entries).and_call_original
 
       # copying the raw cache
-      expect(Dir).to receive(:exist?).with("/run/agama/zypp/var/cache/zypp/raw").and_return(true)
-      expect(FileUtils).to receive(:mkdir_p).with("/mnt/var/cache/zypp")
-      expect(FileUtils).to receive(:cp_r).with("/run/agama/zypp/var/cache/zypp/raw",
-        "/mnt/var/cache/zypp")
+      expect(Dir).to receive(:exist?).with(
+        File.join(target_dir, "/var/cache/zypp/raw")
+      ).and_return(true)
+      expect(FileUtils).to receive(:mkdir_p).with(
+        File.join(Yast::Installation.destdir, "/var/cache/zypp")
+      )
+      expect(FileUtils).to receive(:cp_r).with(
+        File.join(target_dir, "/var/cache/zypp/raw"),
+        File.join(Yast::Installation.destdir, "/var/cache/zypp")
+      )
 
       # copy the solv cache
       repo_alias = "https-download.opensuse.org-94cc89aa"
-      expect(Dir).to receive(:entries).with("/run/agama/zypp/var/cache/zypp/solv")
+      expect(Dir).to receive(:entries)
+        .with(File.join(target_dir, "/var/cache/zypp/solv"))
         .and_return([".", "..", "@System", repo_alias])
       expect(FileUtils).to receive(:cp_r).with(
-        File.join("/run/agama/zypp/var/cache/zypp/solv/", repo_alias),
-        "/mnt/var/cache/zypp/solv"
+        File.join(target_dir, "/var/cache/zypp/solv/", repo_alias),
+        File.join(Yast::Installation.destdir, "/var/cache/zypp/solv")
       )
       # ensure the @System cache is not copied
       expect(FileUtils).to_not receive(:cp_r).with(
-        "/run/agama/zypp/var/cache/zypp/solv/@System",
-        "/mnt/var/cache/zypp/solv"
+        File.join(target_dir, "/var/cache/zypp/solv/@System"),
+        File.join(Yast::Installation.destdir, "/var/cache/zypp/solv")
       )
 
       # copying the credentials.d directory
-      expect(Dir).to receive(:exist?).with("/run/agama/zypp/etc/zypp/credentials.d")
+      expect(Dir).to receive(:exist?)
+        .with(File.join(target_dir, "/etc/zypp/credentials.d"))
         .and_return(true)
-      expect(FileUtils).to receive(:mkdir_p).with("/mnt/etc/zypp")
-      expect(FileUtils).to receive(:cp_r).with("/run/agama/zypp/etc/zypp/credentials.d",
-        "/mnt/etc/zypp")
+      expect(FileUtils).to receive(:mkdir_p)
+        .with(File.join(Yast::Installation.destdir, "/etc/zypp"))
+      expect(FileUtils).to receive(:cp_r).with(
+        File.join(target_dir, "/etc/zypp/credentials.d"),
+        File.join(Yast::Installation.destdir, "/etc/zypp")
+      )
 
       # copying the global credentials file
-      expect(File).to receive(:exist?).with("/run/agama/zypp/etc/zypp/credentials.cat")
+      expect(File).to receive(:exist?)
+        .with(File.join(target_dir, "/etc/zypp/credentials.cat"))
         .and_return(true)
-      expect(FileUtils).to receive(:mkdir_p).with("/mnt/etc/zypp")
-      expect(FileUtils).to receive(:copy).with("/run/agama/zypp/etc/zypp/credentials.cat",
-        "/mnt/etc/zypp")
+      expect(FileUtils).to receive(:copy).with(
+        File.join(target_dir, "/etc/zypp/credentials.cat"),
+        File.join(Yast::Installation.destdir, "/etc/zypp")
+      )
 
       subject.finish
     end


### PR DESCRIPTION
## Problem

- The libzypp caches and credentials are not copied to the installed system
- Installing any package or even simple `zypper refresh` triggers full repository reload

## Solution

- Just copy the files from the Live ISO zypp repository to the installed system

## Testing

- Added a new unit test
- Tested manually, after installation all caches are copied and `zypper refresh` does nothing