### PR TITLE
fix(Live): Improve interactive root password services

### DIFF
--- a/live/root/etc/systemd/system/agama-certificate-issue.service
+++ b/live/root/etc/systemd/system/agama-certificate-issue.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Generate issue file for Agama SSL certificate
-Before=systemd-user-sessions.service
 
 [Service]
 Type=oneshot

--- a/live/root/etc/systemd/system/live-password-dialog.service
+++ b/live/root/etc/systemd/system/live-password-dialog.service
@@ -22,21 +22,28 @@ Before=serial-getty@ttyS1.service
 Before=serial-getty@ttyS2.service
 Before=serial-getty@ttysclp0.service
 
-# start at the end to avoid overwriting the screen with systemd messages
-After=agama.service
-After=modprobe@drm.service
-
 # kernel command line option
 ConditionKernelCommandLine=live.password_dialog
 
 [Service]
 Type=oneshot
 Environment=TERM=linux
+
+# disable the kernel output on the console
 ExecStartPre=dmesg --console-off
+# disable the systemd status messages on the console
+ExecStartPre=kill -SIGRTMIN+21 1
+
 ExecStart=live-password --dialog
+
+# reset the console state after closing the dialog otherwise the dialog
+# content would stay on the screen
+ExecStartPost=reset
+# enable back the kernel output on the console
 ExecStartPost=dmesg --console-on
-TTYReset=yes
-TTYVHangup=yes
+# enable back the systemd status messages on the console
+ExecStartPost=kill -SIGRTMIN+20 1
+
 StandardInput=tty
 RemainAfterExit=true
 TimeoutSec=0

--- a/live/root/etc/systemd/system/live-password-systemd.service
+++ b/live/root/etc/systemd/system/live-password-systemd.service
@@ -22,18 +22,24 @@ Before=serial-getty@ttyS1.service
 Before=serial-getty@ttyS2.service
 Before=serial-getty@ttysclp0.service
 
-# start at the end to avoid overwriting the screen with systemd messages
-After=agama.service
-After=modprobe@drm.service
-
 # kernel command line option
 ConditionKernelCommandLine=live.password_systemd
 
 [Service]
 Type=oneshot
+
+# disable the kernel output on the console
 ExecStartPre=dmesg --console-off
+# disable the systemd status messages on the console
+ExecStartPre=kill -SIGRTMIN+21 1
+
 ExecStart=live-password --systemd
+
+# enable back the kernel output on the console
 ExecStartPost=dmesg --console-on
+# enable back the systemd status messages on the console
+ExecStartPost=kill -SIGRTMIN+20 1
+
 StandardOutput=tty
 RemainAfterExit=true
 TimeoutSec=0

--- a/live/root/usr/bin/live-password
+++ b/live/root/usr/bin/live-password
@@ -16,6 +16,7 @@ TITLE="Set Login Password"
 
 # functions for entering the password in an interactive dialog
 confirm_exit() {
+  # --keep-tite is not a misspelling of "title"
   if dialog --keep-tite --backtitle "$BTITLE" --defaultno --yesno "Are you sure you want to cancel?" 5 40; then
     exit 1
   fi

--- a/live/root/usr/bin/live-password
+++ b/live/root/usr/bin/live-password
@@ -16,22 +16,22 @@ TITLE="Set Login Password"
 
 # functions for entering the password in an interactive dialog
 confirm_exit() {
-  if dialog --backtitle "$BTITLE" --defaultno --yesno "Are you sure you want to cancel?" 5 40; then
+  if dialog --keep-tite --backtitle "$BTITLE" --defaultno --yesno "Are you sure you want to cancel?" 5 40; then
     exit 1
   fi
 }
 
 msg_box() {
-  dialog --backtitle "$BTITLE" --msgbox "$1" 6 30
+  dialog --keep-tite --backtitle "$BTITLE" --msgbox "$1" 6 30
 }
 
 ask_password() {
-  if ! PWD1=$(dialog --title "$TITLE" --backtitle "$BTITLE" --stdout --insecure --passwordbox "Password:" 8 40); then
+  if ! PWD1=$(dialog --keep-tite --title "$TITLE" --backtitle "$BTITLE" --stdout --insecure --passwordbox "Password:" 8 40); then
     confirm_exit
     ask_password
   fi
 
-  if ! PWD2=$(dialog --title "$TITLE" --backtitle "$BTITLE" --stdout --insecure --passwordbox "Verify Password:" 8 40); then
+  if ! PWD2=$(dialog --keep-tite --title "$TITLE" --backtitle "$BTITLE" --stdout --insecure --passwordbox "Verify Password:" 8 40); then
     confirm_exit
     ask_password
   fi


### PR DESCRIPTION
## Improvements

- Properly disable the systemd console output while the interactive dialog is displayed
- See the [systemd  signals documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.html#Signals)
- I used some workaround before (starting the service at the end) but that is not reliable, if some new service appears or if the service dependencies are changed then it might easily break.
- Clear/restore the screen after closing the interactive dialog so the dialog content is not displayed on the screen after leaving

## Testing

- Tested manually, all services work fine, no systemd output is printed over the interactive dialog

