### PR TITLE
fix(Live): Fixed console messages displayed twice

### DIFF
--- a/live/root/etc/systemd/system/agama-certificate-wait.service
+++ b/live/root/etc/systemd/system/agama-certificate-wait.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Postpone login prompt after the SSL fingerprint issue is generated
+
+After=agama-web-server.service
+
+# copied from YaST2-Second-Stage.service
+Before=getty@tty1.service
+Before=getty@tty2.service
+Before=getty@tty3.service
+Before=getty@tty4.service
+Before=getty@tty5.service
+Before=getty@tty6.service
+Before=serial-getty@hvc0.service
+Before=serial-getty@sclp_line0.service
+Before=serial-getty@ttyAMA0.service
+Before=serial-getty@ttyS0.service
+Before=serial-getty@ttyS1.service
+Before=serial-getty@ttyS2.service
+Before=serial-getty@ttysclp0.service
+
+[Service]
+Type=oneshot
+# wait at most 15 seconds to not block
+ExecStart=agama-issue-generator --wait-for-ssl 15
+
+[Install]
+WantedBy=default.target

--- a/live/root/usr/bin/agama-issue-generator
+++ b/live/root/usr/bin/agama-issue-generator
@@ -149,6 +149,14 @@ generate_network_url() {
   fi
 }
 
+# wait until the SSL fingreprint issue is create, but at most 10 seconds
+wait_for_ssl_issue() {
+  for i in $(seq 1 "$1"); do
+    [ -f "$CERT_ISSUE" ] && exit 0
+    sleep 1
+  done
+}
+
 # make sure the parent directory for the issues exists
 mkdir -p /run/issue.d
 
@@ -159,6 +167,8 @@ elif [ "$1" = "--ssh" ]; then
   generate_ssh_fingerprints
 elif [ "$1" = "--ssl" ]; then
   generate_certificate_fingerprints
+elif [ "$1" = "--wait-for-ssl" ]; then
+  wait_for_ssl_issue "$2"
 elif [ "$1" = "--network" ]; then
   generate_network_url "$2" "$3"
 elif [ "$1" = "--watch-avahi" ]; then

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -29,6 +29,7 @@ systemctl enable agama-auto.service
 systemctl enable agama-hostname.service
 systemctl enable agama-proxy-setup.service
 systemctl enable agama-certificate-issue.path
+systemctl enable agama-certificate-wait.service
 systemctl enable agama-welcome-issue.service
 systemctl enable agama-avahi-issue.service
 systemctl enable agama-ssh-issue.service


### PR DESCRIPTION
## Problem

- The console messages are often displayed twice
- The SSL certificate is generated asynchronously, the login service might be started before the certificate fingerprint message is generated.
- After that the fingerprint message is created then the updated messages are displayed again, resulting in two similar messages which might be confusing

![agama_console_messages_twice](https://github.com/openSUSE/agama/assets/907998/7d2acd26-5890-47da-aa97-3b6d6c04c723)

## Solution

- Added a helper service which postpones the login service until the certificate fingerprint is generated
- However, we cannot wait forever. If the webserver gets stucked or crashes before saving the certificate to disk then you would not be able to login
- So there is a 15 seconds timeout, after that the messages are displayed even if still not complete
- But in most cases the delay is just 2 seconds

## Testing

- Tested manually

## Screenshots

![agama_console_messages_twice_fixed](https://github.com/openSUSE/agama/assets/907998/cbb5ac3c-e933-438b-8c09-c4c9443f248b)

