### PR TITLE
fix(i18n): Added missing textdomain

### DIFF
--- a/service/lib/agama/users.rb
+++ b/service/lib/agama/users.rb
@@ -37,6 +37,7 @@ module Agama
     include Yast::I18n
 
     def initialize(logger)
+      textdomain "agama"
       @logger = logger
       update_issues
     end


### PR DESCRIPTION
## Problem

- The POT file update failed: https://github.com/openSUSE/agama/actions/runs/9590615790/job/26446241862#step:22:8

## Solution

- Add the missing `textdomain` call