### PR TITLE
Leap 16.0 Alpha

### DIFF
--- a/products.d/agama-products-opensuse.spec
+++ b/products.d/agama-products-opensuse.spec
@@ -42,5 +42,6 @@ install -m 0644 *.yaml %{buildroot}%{_datadir}/agama/products.d
 %dir %{_datadir}/agama/products.d
 %{_datadir}/agama/products.d/microos.yaml
 %{_datadir}/agama/products.d/tumbleweed.yaml
+%{_datadir}/agama/products.d/leap_160.yaml
 
 %changelog

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -23,7 +23,6 @@ software:
   user_patterns:
     - basic_desktop
     - xfce
-    - kde
     - gnome
     - yast2_basis
     - yast2_desktop

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -1,0 +1,142 @@
+id: Leap
+name: Leap 16.0 Alpha
+# ------------------------------------------------------------------------------
+# WARNING: When changing the product description delete the translations located
+# at the at translations/description key below to avoid using obsolete
+# translations!!
+# ------------------------------------------------------------------------------
+description: 'Leap 16.0 is the latest version of a community distribution based on the latest SUSE Linux Enterprise Server.'
+# Do not manually change any translations! See README.md for more details.
+translations:
+  description:
+   
+software:
+  installation_repositories:
+    - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/standard
+      archs: x86_64
+    - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/standard
+      archs: aarch64
+    
+  mandatory_patterns:
+    - enhanced_base # only pattern that is shared among all roles on TW
+  optional_patterns: null # no optional pattern shared
+  user_patterns:
+    - basic_desktop
+    - xfce
+    - kde
+    - gnome
+    - yast2_basis
+    - yast2_desktop
+    - yast2_server
+    - multimedia
+    - office
+  mandatory_packages:
+    - NetworkManager
+  optional_packages: null
+  base_product: openSUSE
+
+security:
+  lsm: apparmor
+  available_lsms:
+    apparmor:
+      patterns:
+        - apparmor
+    selinux:
+      patterns:
+        - selinux
+      policy: permissive
+    none:
+      patterns: null
+
+storage:
+  space_policy: delete
+  volumes:
+    - "/"
+    - "swap"
+  volume_templates:
+    - mount_path: "/"
+      filesystem: btrfs
+      btrfs:
+        snapshots: true
+        read_only: false
+        default_subvolume: "@"
+        subvolumes:
+          - path: home
+          - path: opt
+          - path: root
+          - path: srv
+          - path: usr/local
+          # Unified var subvolume - https://lists.opensuse.org/opensuse-packaging/2017-11/msg00017.html
+          - path: var
+            copy_on_write: false
+          # Architecture specific subvolumes
+          - path: boot/grub2/arm64-efi
+            archs: aarch64
+          - path: boot/grub2/arm-efi
+            archs: arm
+          - path: boot/grub2/i386-pc
+            archs: x86_64
+          - path: boot/grub2/powerpc-ieee1275
+            archs: ppc,!board_powernv
+          - path: boot/grub2/s390x-emu
+            archs: s390
+          - path: boot/grub2/x86_64-efi
+            archs: x86_64
+          - path: boot/grub2/riscv64-efi
+            archs: riscv64
+      size:
+        auto: true
+      outline:
+        required: true
+        filesystems:
+          - btrfs
+          - ext2
+          - ext3
+          - ext4
+          - xfs
+        auto_size:
+          base_min: 5 GiB
+          base_max: 15 GiB
+          snapshots_increment: 250%
+          max_fallback_for:
+            - "/home"
+        snapshots_configurable: true
+    - mount_path: "swap"
+      filesystem: swap
+      size:
+        auto: true
+      outline:
+        auto_size:
+          base_min: 1 GiB
+          base_max: 2 GiB
+          adjust_by_ram: true
+        required: false
+        filesystems:
+          - swap
+    - mount_path: "/home"
+      filesystem: xfs
+      size:
+        auto: false
+        min: 10 GiB
+        max: unlimited
+      outline:
+        required: false
+        filesystems:
+          - btrfs
+          - ext2
+          - ext3
+          - ext4
+          - xfs
+    - filesystem: xfs
+      size:
+        auto: false
+        min: 1 GiB
+      outline:
+        required: false
+        filesystems:
+          - btrfs
+          - ext2
+          - ext3
+          - ext4
+          - xfs
+          - vfat

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -18,7 +18,7 @@ software:
       archs: aarch64
     
   mandatory_patterns:
-    - enhanced_base # only pattern that is shared among all roles on TW
+    - enhanced_base # only pattern that is shared among all roles on Leap
   optional_patterns: null # no optional pattern shared
   user_patterns:
     - basic_desktop

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -44,7 +44,7 @@ security:
     selinux:
       patterns:
         - selinux
-      policy: permissive
+      policy: enforcing
     none:
       patterns: null
 

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -1,4 +1,4 @@
-id: Leap
+id: Leap_16.0
 name: Leap 16.0 Alpha
 # ------------------------------------------------------------------------------
 # WARNING: When changing the product description delete the translations located

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Jun 24 20:35:00 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Add Leap 16 (gh#openSUSE/agama#1371)
+
+-------------------------------------------------------------------
 Thu Jun 21 15:00:00 UTC 2024 - Clemens Famulla-Conrad <cfamullaconrad@suse.de>
 
 - Add tun/tap model (gh#openSUSE/agama#1353)


### PR DESCRIPTION
## Problem

Add back Leap 16.0 Alpha as a product. Repository paths will change soon.

https://build.opensuse.org/project/show/openSUSE:Leap:16.0:Images
https://src.opensuse.org/openSUSE/Leap/src/branch/16.0/agama-live

![Uploading image.png…]()
