### PR TITLE
Install from local DVD if it is present

### DIFF
--- a/doc/yaml_config.md
+++ b/doc/yaml_config.md
@@ -30,6 +30,16 @@ Array of url for installation repositories. Map can be used instead of string.
 In such case map should contain url and archs keys. Archs key is used to limit
 usage of repository on matching hardware architectures.
 
+#### installation\_labels
+
+Array of disk labels used for finding the local installation repository. Instead
+of array of strings it is possible to use an array of maps with `label` and
+`archs` keys where `archs` is a string with comma separated list of supported
+hardware architectures.
+
+If the matching disk label is not found then the online installation repository
+from the `installation_repositories` section is used.
+
 #### mandatory\_patterns
 
 Array of patterns that have to be selected.

--- a/products.d/microos.yaml
+++ b/products.d/microos.yaml
@@ -98,6 +98,15 @@ software:
       archs: s390
     - url: https://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/
       archs: ppc
+  installation_labels:
+    - label: openSUSE-MicroOS-DVD-x86_64
+      archs: x86_64
+    - label: openSUSE-MicroOS-DVD-aarch64
+      archs: aarch64
+    - label: openSUSE-MicroOS-DVD-s390x
+      archs: s390
+    - label: openSUSE-MicroOS-DVD-ppc64le
+      archs: ppc
   mandatory_patterns:
     - microos_base
     - microos_base_zypper

--- a/products.d/microos.yaml
+++ b/products.d/microos.yaml
@@ -98,6 +98,7 @@ software:
       archs: s390
     - url: https://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/
       archs: ppc
+  # device labels for offline installation media
   installation_labels:
     - label: openSUSE-MicroOS-DVD-x86_64
       archs: x86_64

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -91,6 +91,15 @@ software:
       archs: s390
     - url: https://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/
       archs: ppc
+  installation_labels:
+    - label: openSUSE-Tumbleweed-DVD-x86_64
+      archs: x86_64
+    - label: openSUSE-Tumbleweed-DVD-aarch64
+      archs: aarch64
+    - label: openSUSE-Tumbleweed-DVD-s390x
+      archs: s390
+    - label: openSUSE-Tumbleweed-DVD-ppc64le
+      archs: ppc
   mandatory_patterns:
     - enhanced_base # only pattern that is shared among all roles on TW
   optional_patterns: null # no optional pattern shared

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -91,6 +91,7 @@ software:
       archs: s390
     - url: https://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/
       archs: ppc
+  # device labels for offline installation media
   installation_labels:
     - label: openSUSE-Tumbleweed-DVD-x86_64
       archs: x86_64

--- a/service/lib/agama/product_reader.rb
+++ b/service/lib/agama/product_reader.rb
@@ -49,7 +49,7 @@ module Agama
     def load_products
       glob = File.join(default_path, "*.{yaml,yml}")
       Dir.glob(glob).each_with_object([]) do |path, result|
-        products = YAML.safe_load_file(path)
+        products = YAML.safe_load(File.read(path))
         products = [products] unless products.is_a?(Array)
         result.concat(products)
       end

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -445,7 +445,9 @@ module Agama
       # returns empty list if there is no device with the required label
       def disks_with_label(label)
         data = list_disks
-        disks = data.fetch("blockdevices", []).map { |device| device["kname"] if device["label"] == label }
+        disks = data.fetch("blockdevices", []).map do |device|
+          device["kname"] if device["label"] == label
+        end
         disks.compact!
         logger.info "Disks with the installation label: #{disks.inspect}"
         disks
@@ -457,7 +459,7 @@ module Agama
         # we need only the kernel device name and the label
         output = `lsblk --paths --json --output kname,label`
         JSON.parse(output)
-      rescue RuntimeError e
+      rescue RuntimeError => e
         logger.error "ERROR: Cannot read disk devices: #{e}"
         {}
       end

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -459,7 +459,7 @@ module Agama
         # we need only the kernel device name and the label
         output = `lsblk --paths --json --output kname,label`
         JSON.parse(output)
-      rescue RuntimeError => e
+      rescue StandardError => e
         logger.error "ERROR: Cannot read disk devices: #{e}"
         {}
       end

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -421,7 +421,7 @@ module Agama
       end
 
       def add_base_repos
-        # support multiple labels/installation media?
+        # NOTE: support multiple labels/installation media?
         label = product.labels.first
 
         if label

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "fileutils"
+require "json"
 require "yast"
 require "y2packager/product"
 require "y2packager/resolvable"
@@ -420,7 +421,53 @@ module Agama
       end
 
       def add_base_repos
+        # support multiple labels/installation media?
+        label = product.labels.first
+
+        if label
+          logger.info "Installation repository label: #{label.inspect}"
+          # we cannot use the simple /dev/disk/by-label/* device file as there
+          # might be multiple devices with the same label
+          device = installation_device(label)
+          if device
+            logger.info "Installation device: #{device}"
+            repositories.add("hd:/?device=" + device)
+            return
+          end
+        end
+
+        # disk label not found or not configured, use the online repositories
         product.repositories.each { |url| repositories.add(url) }
+      end
+
+      def disks_with_label(label)
+        data = list_disks
+        disks = data["blockdevices"].map { |device| device["kname"] if device["label"] == label }
+        disks.compact!
+        logger.info "Disks with the installation label: #{disks.inspect}"
+        disks
+      end
+
+      # get list of disks
+      def list_disks
+        # we need only the kernel device name and the label
+        output = `lsblk --paths --json --output kname,label`
+        JSON.parse(output)
+      end
+
+      def installation_device(label)
+        disks = disks_with_label(label)
+
+        # multiple installation media?
+        if disks.size > 1
+          # prefer optical media (/dev/srX) to disk so the disk can be used as
+          # the installation target
+          optical = disks.find { |d| d.match(/\A\/dev\/sr[0-9]+\z/) }
+          optical || disks.first
+        else
+          # none or just one disk
+          disks.first
+        end
       end
 
       # Adds resolvables for selected product
@@ -538,16 +585,23 @@ module Agama
         FileUtils.copy(glob_credentials, target_dir)
       end
 
+      # Is any local repository (CD/DVD, disk) currently used?
+      # @return [Boolean] true if any local repository is used
+      def local_repo?
+        Agama::Software::Repository.all.any?(&:local?)
+      end
+
       # update the zypp repositories for the new product, either delete them
       # or keep them untouched
       # @param new_product [Agama::Software::Product] the new selected product
       def update_repositories(new_product)
         # reuse the repositories when they are the same as for the previously
-        # selected product
+        # selected product and no local repository is currently used
+        # (local repositories are usually product specific)
         # TODO: what about registered products?
         # TODO: allow a partial match? i.e. keep the same repositories, delete
         # additional repositories and add missing ones
-        if product&.repositories&.sort == new_product.repositories.sort
+        if product&.repositories&.sort == new_product.repositories.sort && !local_repo?
           # the same repositories, we just needed to reset the package selection
           Yast::Pkg.PkgReset()
         else

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -445,7 +445,7 @@ module Agama
       # returns empty list if there is no device with the required label
       def disks_with_label(label)
         data = list_disks
-        disks = data["blockdevices"].map { |device| device["kname"] if device["label"] == label }
+        disks = data.fetch("blockdevices", []).map { |device| device["kname"] if device["label"] == label }
         disks.compact!
         logger.info "Disks with the installation label: #{disks.inspect}"
         disks
@@ -457,6 +457,9 @@ module Agama
         # we need only the kernel device name and the label
         output = `lsblk --paths --json --output kname,label`
         JSON.parse(output)
+      rescue RuntimeError e
+        logger.error "ERROR: Cannot read disk devices: #{e}"
+        {}
       end
 
       # find the installation device with the required label

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -440,6 +440,9 @@ module Agama
         product.repositories.each { |url| repositories.add(url) }
       end
 
+      # find all devices with the required disk label
+      # @return [Array<String>] returns list of devices, e.g. `["/dev/sr1"]`,
+      # returns empty list if there is no device with the required label
       def disks_with_label(label)
         data = list_disks
         disks = data["blockdevices"].map { |device| device["kname"] if device["label"] == label }
@@ -448,13 +451,16 @@ module Agama
         disks
       end
 
-      # get list of disks
+      # get list of disks, returns parsed data from the `lsblk` call
+      # @return [Hash] parsed data
       def list_disks
         # we need only the kernel device name and the label
         output = `lsblk --paths --json --output kname,label`
         JSON.parse(output)
       end
 
+      # find the installation device with the required label
+      # @return [String,nil] Device name (`/dev/sr1`) or `nil` if not found
       def installation_device(label)
         disks = disks_with_label(label)
 

--- a/service/lib/agama/software/product.rb
+++ b/service/lib/agama/software/product.rb
@@ -53,6 +53,11 @@ module Agama
       # @return [Array<String>] Empty if the product requires registration.
       attr_accessor :repositories
 
+      # List of disk labels used for installation repository.
+      #
+      # @return [Array<String>] Empty if the product does not support offline installation.
+      attr_accessor :labels
+
       # Mandatory packages.
       #
       # @return [Array<String>]
@@ -95,6 +100,7 @@ module Agama
       def initialize(id)
         @id = id
         @repositories = []
+        @labels = []
         @mandatory_packages = []
         @optional_packages = []
         @mandatory_patterns = []

--- a/service/lib/agama/software/product_builder.rb
+++ b/service/lib/agama/software/product_builder.rb
@@ -36,20 +36,7 @@ module Agama
       def build
         config.products.map do |id, attrs|
           data = product_data_from_config(id)
-
-          Agama::Software::Product.new(id).tap do |product|
-            product.display_name = attrs["name"]
-            product.description = attrs["description"]
-            product.name = data[:name]
-            product.version = data[:version]
-            product.repositories = data[:repositories]
-            product.mandatory_packages = data[:mandatory_packages]
-            product.optional_packages = data[:optional_packages]
-            product.mandatory_patterns = data[:mandatory_patterns]
-            product.optional_patterns = data[:optional_patterns]
-            product.user_patterns = data[:user_patterns]
-            product.translations = attrs["translations"] || {}
-          end
+          create_product(id, data, attrs)
         end
       end
 
@@ -57,6 +44,23 @@ module Agama
 
       # @return [Agama::Config]
       attr_reader :config
+
+      def create_product(id, data, attrs)
+        Agama::Software::Product.new(id).tap do |product|
+          product.display_name = attrs["name"]
+          product.description = attrs["description"]
+          product.name = data[:name]
+          product.version = data[:version]
+          product.repositories = data[:repositories]
+          product.labels = data[:labels]
+          product.mandatory_packages = data[:mandatory_packages]
+          product.optional_packages = data[:optional_packages]
+          product.mandatory_patterns = data[:mandatory_patterns]
+          product.optional_patterns = data[:optional_patterns]
+          product.user_patterns = data[:user_patterns]
+          product.translations = attrs["translations"] || {}
+        end
+      end
 
       # Data from config, filtering by arch.
       #
@@ -66,6 +70,9 @@ module Agama
         {
           name:               config.products.dig(id, "software", "base_product"),
           version:            config.products.dig(id, "software", "version"),
+          labels:             config.arch_elements_from(
+            id, "software", "installation_labels", property: :label
+          ),
           repositories:       config.arch_elements_from(
             id, "software", "installation_repositories", property: :url
           ),

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -74,6 +74,8 @@
     Requires:       udftools
     Requires:       xfsprogs
     Requires:       yast2-schema
+    # lsblk
+    Requires:       util-linux-systemd
   :filelist: "%{_datadir}/dbus-1/agama.conf\n
     %dir %{_datadir}/dbus-1/agama-services\n
     %{_datadir}/dbus-1/agama-services/org.opensuse.Agama*.service\n

--- a/service/test/agama/software/manager_test.rb
+++ b/service/test/agama/software/manager_test.rb
@@ -215,6 +215,7 @@ describe Agama::Software::Manager do
   describe "#probe" do
     before do
       subject.select_product("Tumbleweed")
+      allow(subject).to receive(:list_disks).and_return({})
     end
 
     it "creates a packages proposal" do
@@ -225,6 +226,21 @@ describe Agama::Software::Manager do
     it "registers the repository from config" do
       expect(repositories).to receive(:add).with(/tumbleweed/)
       expect(repositories).to receive(:load)
+      subject.probe
+    end
+
+    it "uses the offline medium if available" do
+      device = "/dev/sr1"
+      expect(subject).to receive(:list_disks).and_return({
+        "blockdevices" => [
+          {
+            "kname" => device,
+            "label" => "openSUSE-Tumbleweed-DVD-x86_64"
+          }
+        ]
+      })
+
+      expect(repositories).to receive(:add).with("hd:/?device=" + device)
       subject.probe
     end
 


### PR DESCRIPTION
## Problem

- Local DVD cannot be used for installation, offline installation is not possible
- We have a [special branch](https://github.com/openSUSE/agama/compare/install_from_2nd_DVD?expand=1) with this feature and build special ISO but I think it should work out of box with upstream Agama
- Sooner or later we will need to support installation from the local media anyway

## Solution

- A disk label defines the installation repository name for each product
- If such disk label is found then that disk is used as the installation repository
- If no label is found in the system it uses the online repositories
- If multiple labels are found then the DVD device is preferred

## TODO

- [x] Update unit tests
- [x] Add more comments
- [x] Update documentation

## Testing

- Tested manually, when the Tumbleweed DVD is present it is automatically used instead of the online repositories
- When the product is switched to MicroOS and the DVD is not present it uses the online repositories
