### PR TITLE
fix(web) improve first user form

### DIFF
--- a/web/src/components/users/FirstUserForm.jsx
+++ b/web/src/components/users/FirstUserForm.jsx
@@ -222,7 +222,6 @@ export default function FirstUserForm() {
                     className="first-username-wrapper"
                     fieldId="userName"
                     label={_("Username")}
-                    isRequired
                   >
                     <TextInput
                       id="userName"

--- a/web/src/components/users/utils.js
+++ b/web/src/components/users/utils.js
@@ -28,6 +28,8 @@
  * @returns {string[]} An array of username suggestions.
  */
 const suggestUsernames = (fullName) => {
+  if (!fullName) return [];
+
   // Cleaning the name.
   const cleanedName = fullName
     .normalize('NFD')

--- a/web/src/components/users/utils.test.js
+++ b/web/src/components/users/utils.test.js
@@ -24,6 +24,11 @@
 import { suggestUsernames } from "./utils";
 
 describe('suggestUsernames', () => {
+  test('returns empty collection if fullName not defined', () => {
+    expect(suggestUsernames(undefined)).toEqual([]);
+    expect(suggestUsernames(null)).toEqual([]);
+  });
+
   test('handles basic single name', () => {
     expect(suggestUsernames('John')).toEqual(expect.arrayContaining(['john']));
   });


### PR DESCRIPTION
## Problem

https://github.com/openSUSE/agama/issues/1364 reported two small problems in the first user form:

* The lack of red asterisk in some mandatory fields
* The presence of "undefined" suggestion for the username field when the name has not been given.

## Solution

To show suggestions only when it make sense and to drop the required mark from the username field. As said in a commit, after Agama 9 the forms and its required fields are going to be improved. 

## Testing

- Tested manually
