### PR TITLE
fix(storage): avoid segmentation fault when generating actions

### DIFF
--- a/service/lib/agama/storage/actions_generator.rb
+++ b/service/lib/agama/storage/actions_generator.rb
@@ -29,7 +29,10 @@ module Agama
       # param target_graph [Y2Storage::Devicegraph]
       def initialize(system_graph, target_graph)
         @system_graph = system_graph
-        @target_graph = target_graph
+        # It is important to keep a reference to the actiongraph. Otherwise, the gargabe collector
+        # could kill the actiongraph, leaving the compound actions orphan.
+        # See https://github.com/openSUSE/agama/issues/1377.
+        @actiongraph = target_graph.actiongraph
       end
 
       # All actions properly sorted.
@@ -44,8 +47,8 @@ module Agama
       # @return [Y2Storage::Devicegraph]
       attr_reader :system_graph
 
-      # @return [Y2Storage::Devicegraph]
-      attr_reader :target_graph
+      # @return [Y2Storage::Actiongraph]
+      attr_reader :actiongraph
 
       # Sorted main actions (everything except subvolume actions).
       #
@@ -67,7 +70,7 @@ module Agama
       #
       # @return [Array<Action>]
       def actions
-        @actions ||= target_graph.actiongraph.compound_actions.map do |action|
+        @actions ||= actiongraph.compound_actions.map do |action|
           Action.new(action, system_graph)
         end
       end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 26 09:12:33 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Fix segmentation fault in the storage actions
+  (gh#openSUSE/agama#1377).
+
+-------------------------------------------------------------------
 Wed Jun 26 08:25:56 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Optionally use the local DVD installation source if it is present
@@ -142,7 +148,7 @@ Wed Feb  7 11:49:02 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 -------------------------------------------------------------------
 Thu Feb  1 13:08:39 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
-- Log if multipath probing is misconfigured (bsc#1215598) 
+- Log if multipath probing is misconfigured (bsc#1215598)
 
 -------------------------------------------------------------------
 Mon Jan 29 13:51:30 UTC 2024 - José Iván López González <jlopez@suse.com>
@@ -165,7 +171,7 @@ Thu Jan 18 08:35:01 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 Tue Jan 16 10:49:14 UTC 2024 - Michal Filka <mfilka@suse.com>
 
 - bsc#1210541, gh#openSUSE/agama#516
-  - copy NM's runtime config created on dracut's request to the target 
+  - copy NM's runtime config created on dracut's request to the target
 -------------------------------------------------------------------
 Thu Jan 11 15:32:44 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 


### PR DESCRIPTION
## Problem

In the Agama ISO there is a segmentation fault when generating the storage actions, see https://github.com/openSUSE/agama/issues/1377.

## Solution

Keep a reference to the used actiongraph to avoid the gargabe collector to kill it.  
