### PR TITLE
fix(web) do not crash when rendering affected systems

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 26 07:52:22 UTC 2024 - David Diaz <dgonzalez@suse.com>
+
+- Do not crash when trying to render affected systems by deletion
+  actions (gh#/openSUSE/agama#1380).
+
+-------------------------------------------------------------------
 Tue Jun 25 15:05:05 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
 - Integrate actions with space policy in storage proposal page

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -2,7 +2,7 @@
 Wed Jun 26 07:52:22 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
 - Do not crash when trying to render affected systems by deletion
-  actions (gh#/openSUSE/agama#1380).
+  actions (gh#openSUSE/agama#1380).
 
 -------------------------------------------------------------------
 Tue Jun 25 15:05:05 UTC 2024 - David Diaz <dgonzalez@suse.com>

--- a/web/src/components/storage/ProposalActionsSummary.jsx
+++ b/web/src/components/storage/ProposalActionsSummary.jsx
@@ -48,6 +48,7 @@ import textStyles from '@patternfly/react-styles/css/utilities/Text/text';
 const DeletionsInfo = ({ policy, manager, spaceActions }) => {
   let label;
   let systemsLabel;
+  const systems = manager.deletedSystems();
   const deleteActions = manager.actions.filter(a => a.delete && !a.subvol).length;
   const isDeletePolicy = policy?.id === "delete";
   const hasDeleteActions = deleteActions !== 0;
@@ -71,11 +72,11 @@ const DeletionsInfo = ({ policy, manager, spaceActions }) => {
     );
   }
 
-  if (manager.deletedSystems()?.length) {
+  if (systems.length) {
     // FIXME: Use the Intl.ListFormat instead of the `join(", ")` used below.
     // Most probably, a `listFormat` or similar wrapper should live in src/i18n.js or so.
     // Read https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat
-    systemsLabel = <>{_("affecting")} <strong>{manager.deletedSystems.join(", ")}</strong></>;
+    systemsLabel = <>{_("affecting")} <strong>{systems.join(", ")}</strong></>;
   }
 
   return (

--- a/web/src/components/storage/ProposalActionsSummary.test.jsx
+++ b/web/src/components/storage/ProposalActionsSummary.test.jsx
@@ -26,6 +26,7 @@ import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import { SPACE_POLICIES } from "~/components/storage/utils";
 import ProposalActionsSummary from "~/components/storage/ProposalActionsSummary";
+import { devices, actions } from "./test-data/full-result-example";
 
 const sda = {
   sid: 59,
@@ -50,21 +51,52 @@ const sda = {
 };
 
 const keepPolicy = SPACE_POLICIES.find(p => p.id === "keep");
+const deletePolicy = SPACE_POLICIES.find(p => p.id === "delete");
+const resizePolicy = SPACE_POLICIES.find(p => p.id === "resize");
 
-const props = {
+const defaultProps = {
   isLoading: false,
   policy: keepPolicy,
-  devices: [sda],
-  actions: [
-    { device: "/dev/sda", action: "force_delete" },
-  ],
   onActionsClick: jest.fn(),
+  system: devices.system,
+  staging: devices.staging,
+  actions
 };
 
 describe("ProposalActionsSummary", () => {
   it("renders a button for navigating to the space policy selection", async () => {
-    const { user } = installerRender(<ProposalActionsSummary {...props} />);
-    const button = screen.getByRole("link", { name: "Change" });
+    installerRender(<ProposalActionsSummary {...defaultProps} />);
+    screen.getByRole("link", { name: "Change" });
+  });
+
+  it("renders the affected systems in the deletion reminder, if any", () => {
+    // NOTE: simulate the deletion of vdc2 (sid: 79) for checking that
+    // affected systems are rendered in the warning summary
+    const props = {
+      ...defaultProps,
+      policy: deletePolicy,
+      actions: [{ device: 79, subvol: false, delete: true, text: "" }]
+    };
+
+    installerRender(<ProposalActionsSummary {...props} />);
+    screen.getByText(/destructive/);
+    screen.getByText(/affecting/);
+    screen.getByText(/openSUSE/);
+  });
+
+  it("renders the affected systems in the resize reminder, if any", () => {
+    // NOTE: simulate the deletion of vdc2 (sid: 79) for checking that
+    // affected systems are rendered in the warning summary
+    const props = {
+      ...defaultProps,
+      policy: resizePolicy,
+      actions: [{ device: 79, subvol: false, delete: false, resize: true, text: "" }]
+    };
+
+    installerRender(<ProposalActionsSummary {...props} />);
+    screen.getByText(/shrunk/);
+    screen.getByText(/affecting/);
+    screen.getByText(/openSUSE/);
   });
 
   it.todo("test the actions and drawer behaviour");


### PR DESCRIPTION
Avoid the user interface crashing when trying to render the affected systems by deletion actions.