### PR TITLE
openSUSE MicroOS does not include 32bit pattern

### DIFF
--- a/products.d/agama-products-opensuse.changes
+++ b/products.d/agama-products-opensuse.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 26 08:25:00 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Remove the "32bit" pattern from openSUSE MicroOS
+  (gh#openSUSE/agama#1381)
+
+-------------------------------------------------------------------
 Tue May 21 11:35:51 UTC 2024 - Richard Brown <rbrown@suse.com>
 
 - Remove definitions for MicroOS Desktop (gh#openSUSE/agama#1243).

--- a/products.d/microos.yaml
+++ b/products.d/microos.yaml
@@ -113,8 +113,6 @@ software:
     - microos_base_zypper
     - microos_defaults
     - microos_hardware
-    - pattern: 32bit
-      archs: x86_64
   optional_patterns: null
   user_patterns:
     - container_runtime

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 26 08:25:56 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Optionally use the local DVD installation source if it is present
+  (gh#openSUSE/agama#1372)
+
+-------------------------------------------------------------------
 Tue Jun 25 15:03:05 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
 - Add support for retrieving the storage resize actions


### PR DESCRIPTION
## Problem

- The MicroOS does not contain the 32bit pattern
- This was included in the [install_from_2nd_DVD](https://github.com/openSUSE/agama/compare/install_from_2nd_DVD?expand=1) branch

## Solution

- Remove it
