### PR TITLE
Filter only external connections

### DIFF
--- a/rust/agama-server/src/network/nm/client.rs
+++ b/rust/agama-server/src/network/nm/client.rs
@@ -173,7 +173,7 @@ impl<'a> NetworkManagerClient<'a> {
                 .build()
                 .await?;
             let flags = proxy.flags().await?;
-            if flags > 0 {
+            if flags >= 8 {
                 log::warn!("Skipped connection because of flags: {}", flags);
                 continue;
             }

--- a/rust/agama-server/src/network/nm/client.rs
+++ b/rust/agama-server/src/network/nm/client.rs
@@ -173,7 +173,7 @@ impl<'a> NetworkManagerClient<'a> {
                 .build()
                 .await?;
             let flags = proxy.flags().await?;
-            # https://networkmanager.dev/docs/api/latest/nm-dbus-types.html#NMSettingsConnectionFlags
+            // https://networkmanager.dev/docs/api/latest/nm-dbus-types.html#NMSettingsConnectionFlags
             if flags & 8 != 0 {
                 log::warn!("Skipped connection because of flags: {}", flags);
                 continue;

--- a/rust/agama-server/src/network/nm/client.rs
+++ b/rust/agama-server/src/network/nm/client.rs
@@ -173,7 +173,8 @@ impl<'a> NetworkManagerClient<'a> {
                 .build()
                 .await?;
             let flags = proxy.flags().await?;
-            if flags >= 8 {
+            # https://networkmanager.dev/docs/api/latest/nm-dbus-types.html#NMSettingsConnectionFlags
+            if flags & 8 != 0 {
                 log::warn!("Skipped connection because of flags: {}", flags);
                 continue;
             }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jun 26 12:56:31 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- Filter only external configured connections
+  (gh#openSUSE/agama#1383).
+- Expose more details about devices status in the API
+  (gh#openSUSE/agama#1365).
+
+-------------------------------------------------------------------
 Wed Jun 26 10:29:05 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Set and get storage config (gh#openSUSE/agama#1293).

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 26 11:54:41 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- Adapt the network page to the new UI guidelines
+  (gh#openSUSE/agama#1365).
+
+-------------------------------------------------------------------
 Wed Jun 26 08:31:31 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use the new SetLocale D-Bus method to change the language and the


### PR DESCRIPTION
## Problem

During the installation the default NetworkManager profile tries to apply DHCP over the wired and connected interfaces but the profile is a volatile or only in memory one being skipped by agama.

In order to show the connection we should skip only the external configured ones.

## Solution

Only skip external configured connections by now.

## Screenshots

| Before the fix| After the fix |
| --- | --- |
| ![image](https://github.com/openSUSE/agama/assets/7056681/e3f343b4-e272-4cfb-9989-d5917ef871a1) | ![image](https://github.com/openSUSE/agama/assets/7056681/6d1d915c-495a-4322-a47d-ead1662d7176) |

