### PR TITLE
web: Bring back installer options when selecting a product

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 26 13:14:06 UTC 2024 - David Diaz <dgonzalez@suse.com>
+
+- Bring back installer options when selecting a product
+  (gh#openSUSE/agama#1384).
+
+-------------------------------------------------------------------
 Wed Jun 26 08:31:31 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use the new SetLocale D-Bus method to change the language and the

--- a/web/src/SimpleLayout.jsx
+++ b/web/src/SimpleLayout.jsx
@@ -21,16 +21,34 @@
 
 import React from "react";
 import { Outlet } from "react-router-dom";
-import { Page } from "@patternfly/react-core";
+import {
+  Masthead, MastheadContent,
+  Page,
+  Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem
+} from "@patternfly/react-core";
+import { InstallerOptions } from "./components/core";
 import { _ } from "~/i18n";
 
 /**
  * Simple layout for displaying content that comes before product configuration
  * TODO: improve documentation
  */
-export default function SimpleLayout({ showOutlet = true, children }) {
+export default function SimpleLayout({ showOutlet = true, showInstallerOptions = false, children }) {
   return (
     <Page>
+      <Masthead backgroundColor="light200">
+        <MastheadContent>
+          <Toolbar>
+            <ToolbarContent>
+              <ToolbarGroup align={{ default: "alignRight" }}>
+                <ToolbarItem>
+                  {showInstallerOptions && <InstallerOptions />}
+                </ToolbarItem>
+              </ToolbarGroup>
+            </ToolbarContent>
+          </Toolbar>
+        </MastheadContent>
+      </Masthead>
       {showOutlet ? <Outlet /> : children}
     </Page>
   );

--- a/web/src/components/core/InstallerOptions.jsx
+++ b/web/src/components/core/InstallerOptions.jsx
@@ -56,7 +56,7 @@ export default function InstallerOptions() {
   const [inProgress, setInProgress] = useState(false);
 
   // FIXME: Installer options should be available in the login too.
-  if (location.pathname.includes("login")) return;
+  if (["/login", "/products/progress"].includes(location.pathname)) return;
 
   const open = () => setIsOpen(true);
   const close = () => setIsOpen(false);
@@ -109,7 +109,7 @@ export default function InstallerOptions() {
               fieldId="keymap"
               label={_("Keyboard layout")}
             >
-              { localConnection()
+              {localConnection()
                 ? (
                   <FormSelect
                     id="keymap"
@@ -123,7 +123,7 @@ export default function InstallerOptions() {
                     )}
                   </FormSelect>
                 )
-                : _("Cannot be changed in remote installation") }
+                : _("Cannot be changed in remote installation")}
             </FormGroup>
           </Form>
         </Flex>

--- a/web/src/components/core/InstallerOptions.jsx
+++ b/web/src/components/core/InstallerOptions.jsx
@@ -128,7 +128,7 @@ export default function InstallerOptions() {
           </Form>
         </Flex>
         <Popup.Actions>
-          <Popup.Confirm form="installer-l10n" type="submit" autoFocus isDisabled={inProgress}>{_("Accept")}</Popup.Confirm>
+          <Popup.Confirm form="installer-l10n" type="submit" autoFocus isDisabled={inProgress} isLoading={inProgress}>{_("Accept")}</Popup.Confirm>
           <Popup.Cancel onClick={close} isDisabled={inProgress} />
         </Popup.Actions>
       </Popup>

--- a/web/src/router.js
+++ b/web/src/router.js
@@ -61,7 +61,7 @@ const protectedRoutes = [
         ]
       },
       {
-        element: <SimpleLayout />,
+        element: <SimpleLayout showInstallerOptions />,
         children: [productsRoute]
       }
     ]


### PR DESCRIPTION
Bring back the installer options in the product selection page, somehow rolling back changes done at https://github.com/openSUSE/agama/commit/93c611b985609bc890e472c944a7527c05e968b6. Additionally, adds a loader indicator close to the `Accept` button once the language change is requested.