### PR TITLE
fix(web): keep installer options initial status on cancel

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 26 13:45:36 UTC 2024 - David Diaz <dgonzalez@suse.com>
+
+- Reset installer options to its initial values before closing
+  the dialog on cancel (gh#openSUSE/agama#1386).
+
+-------------------------------------------------------------------
 Wed Jun 26 13:38:32 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
 - Fix routes translations (gh#openSUSE/agama#1385).

--- a/web/src/components/core/InstallerOptions.jsx
+++ b/web/src/components/core/InstallerOptions.jsx
@@ -59,7 +59,11 @@ export default function InstallerOptions() {
   if (["/login", "/products/progress"].includes(location.pathname)) return;
 
   const open = () => setIsOpen(true);
-  const close = () => setIsOpen(false);
+  const close = () => {
+    setLanguage(initialLanguage);
+    setKeymap(initialKeymap);
+    setIsOpen(false);
+  };
 
   const onSubmit = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
Reset the installer options to its initial values if users cancels.