### PR TITLE
fix(storage): generate JSON using pretty format

### DIFF
--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -115,7 +115,7 @@ module Agama
         #
         # @return [String]
         def serialized_storage_config
-          @serialized_storage_config || generate_storage_config.to_json
+          @serialized_storage_config || JSON.pretty_generate(generate_storage_config)
         end
 
         def install

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 26 13:54:28 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Generate JSON storage settings using pretty format
+  (gh#openSUSE/agama#1387).
+
+-------------------------------------------------------------------
 Wed Jun 26 10:32:08 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Extend D-Bus storage API to set and get storage config using

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -522,10 +522,14 @@ describe Agama::DBus::Storage::Manager do
   end
 
   describe "#serialized_storage_config" do
+    def pretty_json(value)
+      JSON.pretty_generate(value)
+    end
+
     context "if the storage config has not been set yet" do
       context "and a proposal has not been calculated" do
         it "returns serialized empty storage config" do
-          expect(subject.serialized_storage_config).to eq({}.to_json)
+          expect(subject.serialized_storage_config).to eq(pretty_json({}))
         end
       end
 
@@ -547,7 +551,7 @@ describe Agama::DBus::Storage::Manager do
             }
           }
 
-          expect(subject.serialized_storage_config).to eq(expected_config.to_json)
+          expect(subject.serialized_storage_config).to eq(pretty_json(expected_config))
         end
       end
     end


### PR DESCRIPTION
## Problem

JSON storage settings are generated as a plain string without line breaks. This makes too difficult to edit the settings with the CLI (`agama config edit`). 

Note: This does not happen if the config is previously loaded (`agama config load < file.json`). It keeps the indentation found in the file.

## Solution

Serialize using pretty format, see https://ruby-doc.org/stdlib-2.4.0/libdoc/json/rdoc/JSON.html#method-i-pretty_generate.
