### PR TITLE
fix(web): display the installation progress when connecting late

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 26 15:57:52 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Display the installation progress when connecting in the middle
+  of the process (gh#openSUSE/agama#1394).
+
+-------------------------------------------------------------------
 Wed Jun 26 14:17:30 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
 - Use similar look&feel for sections at network page

--- a/web/src/components/core/InstallationProgress.jsx
+++ b/web/src/components/core/InstallationProgress.jsx
@@ -25,12 +25,9 @@ import ProgressReport from "./ProgressReport";
 import SimpleLayout from "~/SimpleLayout";
 
 function InstallationProgress() {
-  console.log("INSTALATION ISSUE");
-
-  const title = _("Installing the system, please wait ...");
   return (
     <SimpleLayout showOutlet={false}>
-      <ProgressReport title={title} />
+      <ProgressReport title={_("Installing the system, please wait ...")} />
     </SimpleLayout>
   );
 }

--- a/web/src/components/core/InstallationProgress.jsx
+++ b/web/src/components/core/InstallationProgress.jsx
@@ -20,21 +20,14 @@
  */
 
 import React from "react";
-import { useProduct } from "~/context/product";
-import { sprintf } from "sprintf-js";
 import { _ } from "~/i18n";
 import ProgressReport from "./ProgressReport";
 import SimpleLayout from "~/SimpleLayout";
 
 function InstallationProgress() {
-  const { selectedProduct } = useProduct();
+  console.log("INSTALATION ISSUE");
 
-  if (!selectedProduct) {
-    return;
-  }
-
-  // TRANSLATORS: %s is replaced by a product name (e.g., openSUSE Tumbleweed)
-  const title = sprintf(_("Installing %s, please wait ..."), selectedProduct.name);
+  const title = _("Installing the system, please wait ...");
   return (
     <SimpleLayout showOutlet={false}>
       <ProgressReport title={title} />


### PR DESCRIPTION
## Problem

If you connect when the installation has started, the software service cannot tell ou what you are installing, hence the progress screen is not shown.

## Solution

Until we have a responsive software service, let's omit the product's name.