### PR TITLE
fix(storage): avoid error in storage actions (hot-fix)

### DIFF
--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -171,7 +171,26 @@ module Agama
 
         probed = Y2Storage::StorageManager.instance.probed
         staging = Y2Storage::StorageManager.instance.staging
-        ActionsGenerator.new(probed, staging).generate
+        # FIXME: This is a hot-fix to avoid segmentation fault in the actions, see
+        #   https://github.com/openSUSE/agama/issues/1396.
+        #
+        #   Source of the problem:
+        #   * An actiongraph is generated from the target devicegraph.
+        #   * The list of compound actions is recovered from the actiongraph.
+        #   * No refrence to the actiongraph is kept, so the object is a candidate to be cleaned by
+        #     the ruby GC.
+        #   * Accessing to the generated actions raises a segmentation fault if the actiongraph was
+        #     cleaned.
+        #
+        #   There was a previous attempt of fixing the issue by keeping a reference to the
+        #   actiongraph in the ActionsGenerator object. But that solution is not enough because
+        #   the ActionGenerator object is also cleaned up.
+        #
+        #   As a hot-fix, the generator is kept in an instance variable to avoid the GC to kill it.
+        #   A better solution is needed, for example, by avoiding to store an instance of a compound
+        #   action in the Action object.
+        @generator = ActionsGenerator.new(probed, staging)
+        @generator.generate
       end
 
       # Changes the service's locale

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 27 08:36:13 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Avoid error in storage actions (hot-fix)
+  (gh#openSUSE/agama#1400).
+
+-------------------------------------------------------------------
 Wed Jun 26 13:54:28 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Generate JSON storage settings using pretty format


### PR DESCRIPTION
## Problem

Generating storage actions crashes, see:

* https://github.com/openSUSE/agama/issues/1396
* https://github.com/openSUSE/agama/pull/1379

## Solution

Avoid actiongraph clean-up by the ruby GC. 

Note: This is a hot-fix. A better solution is required.
