### PR TITLE
fix(web): do not lost Storage title in overview

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 27 12:05:19 UTC 2024 - David Diaz <dgonzalez@suse.com>
+
+- Do not lost the storage title in the overview
+  (gh#openSUSE/agama#1402).
+
+-------------------------------------------------------------------
 Wed Jun 26 16:46:58 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
 - Reduce progress report flickering (gh#openSUSE/agama#1395).

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Jun 27 12:05:19 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
-- Do not lost the storage title in the overview
+- Do not lose the storage title in the overview
   (gh#openSUSE/agama#1402).
 
 -------------------------------------------------------------------

--- a/web/src/components/overview/StorageSection.jsx
+++ b/web/src/components/overview/StorageSection.jsx
@@ -155,7 +155,7 @@ export default function StorageSection() {
     const pvDevices = result.settings.targetPVDevices;
 
     if (pvDevices.length > 1) {
-      return <span>{msgLvmMultipleDisks(result.settings.spacePolicy)}</span>;
+      return <Content><span>{msgLvmMultipleDisks(result.settings.spacePolicy)}</span></Content>;
     } else {
       const [msg1, msg2] = msgLvmSingleDisk(result.settings.spacePolicy).split("%s");
 


### PR DESCRIPTION
## Problem

The Overview section is missing the `Storage` title under certain circumstances, see https://github.com/openSUSE/agama/issues/1401


## Solution

Properly wrap the returned text within the internal `Content` component at overview/StorageSection.
