### PR TITLE
enable checksum generation for s390x agama live images

### DIFF
--- a/live/src/agama-live.changes
+++ b/live/src/agama-live.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 27 14:33:24 UTC 2024 -Steffen Winterfeldt <snwint@suse.com>
+
+- Enable checksum generation for s390x agama live images
+  (gh#openSUSE/agama#1406).
+
+-------------------------------------------------------------------
 Thu Jun 27 13:24:19 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 9

--- a/live/src/agama-live.kiwi
+++ b/live/src/agama-live.kiwi
@@ -34,7 +34,7 @@
         </type>
     </preferences>
     <preferences arch="s390x" profiles="openSUSE">
-        <type image="iso" flags="dmsquash" volid="agama" editbootconfig="fix_bootconfig">
+        <type image="iso" flags="dmsquash" mediacheck="true" volid="agama" editbootconfig="fix_bootconfig">
             <bootloader name="custom" />
         </type>
     </preferences>


### PR DESCRIPTION
## Problem

For s390x live images no image embedded checksums are generated. This makes media checking impossible.

This also means that the build service will not sign the images.

For some reason this has been enabled for all architectures but s390x. It should be enabled for all.

## Solution

Add `mediacheck` attribute to kiwi config for s390x.

## Testing

Manually verified that built isos are ok after this change.