### PR TITLE
Use gzip (.gz) instead of bzip2 (.bz2) to compress logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /*.pot
 *.mo
 *.bz2
+# Do NOT ignore .github: for git this is a no-op
+# but it helps ripgrep (rg) which would otherwise ignore dotfiles and dotdirs
+!/.github/

--- a/rust/agama-cli/src/logs.rs
+++ b/rust/agama-cli/src/logs.rs
@@ -115,7 +115,7 @@ const DEFAULT_PATHS: [&str; 14] = [
 const DEFAULT_RESULT: &str = "/tmp/agama-logs";
 // what compression is used by default:
 // (<compression as distinguished by tar>, <an extension for resulting archive>)
-const DEFAULT_COMPRESSION: (&str, &str) = ("bzip2", "tar.bz2");
+const DEFAULT_COMPRESSION: (&str, &str) = ("gzip", "tar.gz");
 const TMP_DIR_PREFIX: &str = "agama-logs.";
 
 /// A wrapper around println which shows (or not) the text depending on the boolean variable

--- a/rust/agama-server/src/manager/web.rs
+++ b/rust/agama-server/src/manager/web.rs
@@ -218,6 +218,6 @@ async fn generate_logs() -> Result<String, Error> {
         .status()
         .map_err(|e| ServiceError::CannotGenerateLogs(e.to_string()))?;
 
-    let full_path = format!("{path}.tar.bz2");
+    let full_path = format!("{path}.tar.gz");
     Ok(full_path)
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 28 06:56:02 UTC 2024 - Martin Vidner <mvidner@suse.com>
+
+- Use gzip (.gz) instead of bzip2 (.bz2) to compress logs
+  so that they can be attached to GitHub issues
+  (gh#openSUSE/agama#1378)
+
+-------------------------------------------------------------------
 Thu Jun 27 13:22:51 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 9

--- a/rust/package/agama.spec
+++ b/rust/package/agama.spec
@@ -40,7 +40,7 @@ BuildRequires:  pkgconfig(pam)
 Requires:       jsonnet
 Requires:       lshw
 # required by "agama logs store"
-Requires:       bzip2
+Requires:       gzip
 Requires:       tar
 # required for translating the keyboards descriptions
 BuildRequires:  xkeyboard-config-lang

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -124,8 +124,8 @@ which cargo || $SUDO zypper --non-interactive install cargo
 
 # Packages required by Rust code (see ./rust/package/agama.spec)
 $SUDO zypper --non-interactive install \
-  bzip2 \
   clang-devel \
+  gzip \
   jsonnet \
   lshw \
   pam-devel \

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 28 06:56:02 UTC 2024 - Martin Vidner <mvidner@suse.com>
+
+- Use gzip (.gz) instead of bzip2 (.bz2) to compress logs
+  so that they can be attached to GitHub issues
+  (gh#openSUSE/agama#1378)
+
+-------------------------------------------------------------------
 Thu Jun 27 13:23:08 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 9

--- a/web/src/components/core/LogsButton.jsx
+++ b/web/src/components/core/LogsButton.jsx
@@ -27,7 +27,7 @@ import { Alert, Button } from "@patternfly/react-core";
 import { Popup } from "~/components/core";
 import { _ } from "~/i18n";
 
-const FILENAME = "agama-installation-logs.tar.bzip2";
+const FILENAME = "agama-installation-logs.tar.gz";
 
 /**
  * Button for collecting and downloading YaST logs


### PR DESCRIPTION
## Problem

Quoting #1378:

GitHub does not allow attaching `bzip2` files. In order to make error reporting easier, `agama logs store` should use a different format (e.g., `.gz` and `.tgz` are supported). Otherwise, you need to uncompress and compress the logs again before submitting them.

## Solution

Use `gzip` and `.gz` instead.


## Testing

- [x] *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

