### PR TITLE
feat(Live): Syntax highlighting for `agama config edit` in the Live system

### DIFF
--- a/live/src/agama-live.changes
+++ b/live/src/agama-live.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 28 13:40:35 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Syntax highlighting for "agama config edit"
+  (gh#openSUSE/agama#1411)
+
+-------------------------------------------------------------------
 Thu Jun 27 14:33:24 UTC 2024 -Steffen Winterfeldt <snwint@suse.com>
 
 - Enable checksum generation for s390x agama live images

--- a/live/src/agama-live.kiwi
+++ b/live/src/agama-live.kiwi
@@ -54,6 +54,7 @@
         <package name="procps4"/>
         <package name="iputils"/>
         <package name="vim"/>
+        <package name="vim-data"/>
         <package name="grub2"/>
         <package name="grub2-arm64-efi" arch="aarch64"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -82,6 +82,11 @@ sed -i -e "s/@@LIVE_MEDIUM_LABEL@@/$label/g" /usr/bin/live-password
 # Clean-up logs
 rm /var/log/zypper.log /var/log/zypp/history
 
+# reduce the "vim-data" content, this package is huge (37MB unpacked!), keep only
+# support for JSON (for "agama config edit") and Ruby (fixing/debugging the Ruby
+# service)
+rpm -ql vim-data | grep -v -e '/ruby.vim$' -e '/json.vim$' -e colors | xargs rm 2> /dev/null || true
+
 du -h -s /usr/{share,lib}/locale/
 
 # Agama expects that the same locales available in the installation system can


### PR DESCRIPTION
Syntax highlighting for `agama config edit`.

## Screenshots

### Before

![agama_config_edit](https://github.com/openSUSE/agama/assets/907998/f8e30164-9946-47b4-aaae-6061d1184621)

### After

![agama_config_edit_hl](https://github.com/openSUSE/agama/assets/907998/04d33fd9-3371-4500-a3cc-8f7f6ece4920)
