### PR TITLE
fix(storage): avoid segmentation fault when generating actions

### DIFF
--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  1 10:36:18 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Add yet another fix to avoid error when generating the storage
+  actions (gh#openSUSE/agama#1419).
+
+-------------------------------------------------------------------
 Fri Jun 28 11:57:39 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Proper solution to avoid error in storage actions


### PR DESCRIPTION
## Problem

The generation of the storage actions was fixed to avoid a segmentation fault while accessing to the `CompoundAction` objects, see https://github.com/openSUSE/agama/pull/1410. But there is still a chance to reference to an actiongraph removed by the ruby GC.

~~~ruby
target_graph.actiongraph.compound_actions.map do |action|
  GC.start
  Action.new(a)
end
~~~ 

The actiongraph object could be dropped by the garbage collector while iterating the list of compound actions.

## Solution

Keep a reference to the actiongraph, ensuring the actiongraph object is not removed while generating the list of actions.

Note: once the list of actions is generated, the actiongraph is not needed anymore because the `Action` objects do not keep a reference to the source compound action, see https://github.com/openSUSE/agama/pull/1410.
