### PR TITLE
Leap16 - update install urls

### DIFF
--- a/products.d/leap_160.yaml.disabled
+++ b/products.d/leap_160.yaml.disabled
@@ -19,7 +19,7 @@ software:
     - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-Packages-16.0-x86_64
       archs: x86_64
     - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-Packages-16.0-aarch64
-      arches: aarch64
+      archs: aarch64
     
   mandatory_patterns:
     - enhanced_base # only pattern that is shared among all roles on Leap

--- a/products.d/leap_160.yaml.disabled
+++ b/products.d/leap_160.yaml.disabled
@@ -17,7 +17,7 @@ software:
     - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/standard
       archs: aarch64
     - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-Packages-16.0-x86_64
-      arches: x86_64
+      archs: x86_64
     - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-Packages-16.0-aarch64
       arches: aarch64
     

--- a/products.d/leap_160.yaml.disabled
+++ b/products.d/leap_160.yaml.disabled
@@ -16,6 +16,10 @@ software:
       archs: x86_64
     - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/standard
       archs: aarch64
+    - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/product/repo/SLES-Packages-16.0-x86_64
+      arches: x86_64
+    - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/product/repo/SLES-Packages-16.0-aarch64
+      arches: aarch64
     
   mandatory_patterns:
     - enhanced_base # only pattern that is shared among all roles on Leap

--- a/products.d/leap_160.yaml.disabled
+++ b/products.d/leap_160.yaml.disabled
@@ -16,9 +16,9 @@ software:
       archs: x86_64
     - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/standard
       archs: aarch64
-    - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/product/repo/SLES-Packages-16.0-x86_64
+    - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-Packages-16.0-x86_64
       arches: x86_64
-    - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/product/repo/SLES-Packages-16.0-aarch64
+    - url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-Packages-16.0-aarch64
       arches: aarch64
     
   mandatory_patterns:


### PR DESCRIPTION
Ensure that Leap 16 can install. These are missing product repositories containing packages inherited from SLFO.