### PR TITLE
Use openSUSE-repos for repo definitions on both Leap16 and Tumbleweed

### DIFF
--- a/products.d/leap_160.yaml.disabled
+++ b/products.d/leap_160.yaml.disabled
@@ -35,6 +35,7 @@ software:
     - office
   mandatory_packages:
     - NetworkManager
+    - openSUSE-repos
   optional_packages: null
   base_product: openSUSE
 

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -116,6 +116,7 @@ software:
     - office
   mandatory_packages:
     - NetworkManager
+    - openSUSE-repos
   optional_packages: null
   base_product: openSUSE
 


### PR DESCRIPTION
## Use openSUSE-repos for repo definitions on systems deployed by agama

* Avoid default installation on all systems by not adding it to patterns and add it to mandatory packages instead\

I do have agreement with @DimStar77 to get Agama early-adopters test openSUSE-repos before it hits Leap 16, hopefully as default just like in Leap Micro 6.0. It will help me with migration.



This would significally help with testing of https://news.opensuse.org/2023/07/31/try-out-cdn-with-opensuse-repos/