### PR TITLE
feat(storage): generate the storage config including all settings

### DIFF
--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -91,14 +91,13 @@ module Agama
           busy_while { backend.probe }
         end
 
-        # Sets the storage config and calculates a proposal (guided or AutoYaST).
+        # Calculates a proposal (guided or AutoYaST) from a given storage config.
         #
         # @raise If config is not valid.
         #
         # @param serialized_config [String] Serialized storage config. It can be storage or legacy
         #   AutoYaST settings: { "storage": ... } vs { "legacyAutoyastStorage": ... }.
         def apply_storage_config(serialized_config)
-          @serialized_storage_config = serialized_config
           config_json = JSON.parse(serialized_config, symbolize_names: true)
 
           if (settings_json = config_json.dig(:storage, :guided))
@@ -115,7 +114,7 @@ module Agama
         #
         # @return [String]
         def serialized_storage_config
-          @serialized_storage_config || JSON.pretty_generate(generate_storage_config)
+          JSON.pretty_generate(storage_config)
         end
 
         def install
@@ -433,10 +432,10 @@ module Agama
           success ? 0 : 1
         end
 
-        # Generates the storage config from the current proposal, if any.
+        # Storage config from the current proposal, if any.
         #
         # @return [Hash] Storage config according to JSON schema.
-        def generate_storage_config
+        def storage_config
           if proposal.strategy?(ProposalStrategy::GUIDED)
             {
               storage: {

--- a/service/lib/agama/storage/proposal_settings_conversions/to_json.rb
+++ b/service/lib/agama/storage/proposal_settings_conversions/to_json.rb
@@ -86,10 +86,16 @@ module Agama
         end
 
         def space_conversion
-          {
-            policy:  settings.space.policy.to_s,
-            actions: settings.space.actions.map { |d, a| { action_key(a) => d } }
-          }
+          if settings.space.policy == :custom
+            {
+              policy:  "custom",
+              actions: settings.space.actions.map { |d, a| { action_key(a) => d } }
+            }
+          else
+            {
+              policy: settings.space.policy.to_s
+            }
+          end
         end
 
         def action_key(action)

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  1 14:30:05 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Always generate storage config including all the proposal
+  settings (gh#openSUSE/agama#1422).
+
+-------------------------------------------------------------------
 Mon Jul  1 10:36:18 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Add yet another fix to avoid error when generating the storage

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -520,53 +520,31 @@ describe Agama::DBus::Storage::Manager do
       JSON.pretty_generate(value)
     end
 
-    context "if the storage config has not been set yet" do
-      context "and a proposal has not been calculated" do
-        it "returns serialized empty storage config" do
-          expect(subject.serialized_storage_config).to eq(pretty_json({}))
-        end
-      end
-
-      context "and a proposal has been calculated" do
-        before do
-          proposal.calculate_guided(settings)
-        end
-
-        let(:settings) do
-          Agama::Storage::ProposalSettings.new.tap do |settings|
-            settings.device = Agama::Storage::DeviceSettings::Disk.new("/dev/vda")
-          end
-        end
-
-        it "returns serialized storage config including guided proposal settings" do
-          expected_config = {
-            storage: {
-              guided: settings.to_json_settings
-            }
-          }
-
-          expect(subject.serialized_storage_config).to eq(pretty_json(expected_config))
-        end
+    context "if a proposal has not been calculated" do
+      it "returns serialized empty storage config" do
+        expect(subject.serialized_storage_config).to eq(pretty_json({}))
       end
     end
 
-    context "if the storage config has been set" do
+    context "if a proposal has been calculated" do
       before do
-        subject.apply_storage_config(storage_config.to_json)
+        proposal.calculate_guided(settings)
       end
 
-      let(:storage_config) do
-        {
+      let(:settings) do
+        Agama::Storage::ProposalSettings.new.tap do |settings|
+          settings.device = Agama::Storage::DeviceSettings::Disk.new("/dev/vda")
+        end
+      end
+
+      it "returns serialized storage config including guided proposal settings" do
+        expected_config = {
           storage: {
-            guided: {
-              disk: "/dev/vdc"
-            }
+            guided: settings.to_json_settings
           }
         }
-      end
 
-      it "returns the serialized storage config" do
-        expect(subject.serialized_storage_config).to eq(storage_config.to_json)
+        expect(subject.serialized_storage_config).to eq(pretty_json(expected_config))
       end
     end
   end

--- a/service/test/agama/software/manager_test.rb
+++ b/service/test/agama/software/manager_test.rb
@@ -335,7 +335,7 @@ describe Agama::Software::Manager do
       expect(proposal).to receive(:set_resolvables)
         .with("agama", :pattern, [], { optional: true })
       expect(proposal).to receive(:set_resolvables)
-        .with("agama", :package, ["NetworkManager"])
+        .with("agama", :package, ["NetworkManager", "openSUSE-repos"])
       expect(proposal).to receive(:set_resolvables)
         .with("agama", :package, [], { optional: true })
       subject.propose

--- a/service/test/agama/storage/proposal_settings_conversions/to_json_test.rb
+++ b/service/test/agama/storage/proposal_settings_conversions/to_json_test.rb
@@ -53,8 +53,7 @@ describe Agama::Storage::ProposalSettingsConversions::ToJSON do
           configure: true
         },
         space:   {
-          policy:  "keep",
-          actions: []
+          policy: "keep"
         },
         volumes: []
       )
@@ -110,8 +109,7 @@ describe Agama::Storage::ProposalSettingsConversions::ToJSON do
             configure: true
           },
           space:   {
-            policy:  "keep",
-            actions: []
+            policy: "keep"
           },
           volumes: []
         )


### PR DESCRIPTION
## Problem

If the storage settings are loaded (`agama config load`) or edited (`agama config edit`), then the `agama config show` command only reports the settings indicated with `load` or `edit`. That is, the rest of default applied settings (e.g., volumes) is not included. Nevertheless, the complete settings are reported if the proposal is calculated from the UI.

## Solution

Always report the complete proposal settings independently on how the reproposal was requested.
