### PR TITLE
Use specific flavor of openSUSE-repos

### DIFF
--- a/products.d/agama-products-opensuse.changes
+++ b/products.d/agama-products-opensuse.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Tue Jul  2 13:54:15 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
-- Use specific flavor of openSUSE-repos for each distro 
+- Use specific flavor of openSUSE-repos for each distro
+  (gh#openSUSE/agama#1424).
 
 -------------------------------------------------------------------
 Tue Jul  2 11:33:36 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/products.d/agama-products-opensuse.changes
+++ b/products.d/agama-products-opensuse.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jul  2 13:54:15 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Use specific flavor of openSUSE-repos for each distro 
+
+-------------------------------------------------------------------
 Tue Jul  2 11:33:36 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Enable Leap 16.0 Alpha (gh#openSUSE/agama#1423).

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -35,7 +35,7 @@ software:
     - office
   mandatory_packages:
     - NetworkManager
-    - openSUSE-repos
+    - openSUSE-repos-Leap
   optional_packages: null
   base_product: openSUSE
 

--- a/products.d/microos.yaml
+++ b/products.d/microos.yaml
@@ -120,6 +120,7 @@ software:
     - microos_ra_verifier
   mandatory_packages:
     - NetworkManager
+    - openSUSE-repos-MicroOS
   optional_packages: null
   base_product: MicroOS
 

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -116,7 +116,7 @@ software:
     - office
   mandatory_packages:
     - NetworkManager
-    - openSUSE-repos
+    - openSUSE-repos-Tumbleweed
   optional_packages: null
   base_product: openSUSE
 


### PR DESCRIPTION
## Problem

* It does seem that we might have a problem with openSUSE-repos, in case that we do not specify given flavor
This is an PR to make sure flavor is explicitly listed.

* Add openSUSE-repos also to MicroOS

```
lkocman@localhost:~> rpm -q --provides openSUSE-repos-Leap
openSUSE-repos
openSUSE-repos-Leap = 20240516.5431918-lp156.1.2
openSUSE-repos-Leap(x86-64) = 20240516.5431918-lp156.1.2
```