### PR TITLE
fix(auto): remove scriptlets section

### DIFF
--- a/autoinstallation/package/agama-auto.changes
+++ b/autoinstallation/package/agama-auto.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul  3 07:14:39 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Remove scriptlets section from the spec file
+  (gh#openSUSE/agama#1430).
+
+-------------------------------------------------------------------
 Thu Jun 27 13:58:17 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 9

--- a/autoinstallation/package/agama-auto.spec
+++ b/autoinstallation/package/agama-auto.spec
@@ -38,18 +38,6 @@ install -D -d -m 0755 %{buildroot}%{_bindir}
 install -m 0755 %{_builddir}/agama/bin/agama-auto %{buildroot}%{_bindir}/agama-auto
 install -D -m 0644 %{_builddir}/agama/systemd/agama-auto.service %{buildroot}%{_unitdir}/agama-auto.service
 
-%pre
-%service_add_pre agama-web-server.service
-
-%post
-%service_add_post agama-web-server.service
-
-%preun
-%service_del_preun agama-web-server.service
-
-%postun
-%service_del_preun agama-web-server.service
-
 %files
 %{_bindir}/agama-auto
 %{_unitdir}/agama-auto.service


### PR DESCRIPTION
`agama-auto` is a one-shot service and does not need an scriptlets section in the spec. Not to
mention that it was wrongly referring to the `agama-web-server` service.
