### PR TITLE
Set the transient hostname instead of the static

### DIFF
--- a/live/root/etc/systemd/system/agama-hostname.service
+++ b/live/root/etc/systemd/system/agama-hostname.service
@@ -9,7 +9,7 @@ Before=avahi-daemon.service
 ConditionHost=localhost
 
 [Service]
-ExecStart=hostnamectl hostname agama
+ExecStart=hostnamectl hostname --transient agama
 Type=oneshot
 User=root
 

--- a/live/src/agama-live.changes
+++ b/live/src/agama-live.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul  3 10:41:32 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- Set agama as a transient hostname instead of an static one
+  (gh#openSUSE/agama#1432).
+
+-------------------------------------------------------------------
 Fri Jun 28 13:40:35 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Syntax highlighting for "agama config edit"


### PR DESCRIPTION
## Problem

It has been reported that a fresh installation sets the hostname to agama after booting the installed system which is ok for the installer but looks weird for the installed system, therefore, we should try to fix the issue avoiding to set agama as the hostname of the installed system if not requested explicitly.

- https://github.com/openSUSE/agama/issues/1414
- https://trello.com/c/3XWqwiAb/3725-issue-agama-hostname-is-used-after-installation

## Solution

Set the transient hostname instead of the static one not sending it when requesting a DHCP address.

**Note** In case that the hostname is set statically, it is not copied to the target system.

## Test

Tested manually

![Screenshot from 2024-07-03 09-38-32](https://github.com/openSUSE/agama/assets/7056681/9dbc582a-27e2-403d-a2a7-a807d22f2430)
![Screenshot from 2024-07-03 09-43-25](https://github.com/openSUSE/agama/assets/7056681/f87fb58f-9f0c-489d-b6b4-e773d52d6661)


