### PR TITLE
fix(web): postpone creation of the WSClient

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -2,7 +2,7 @@
 Tue Jul  9 08:51:34 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not try to connect to the WebSocket until the user is
-  logged in (gh#openSUSE/agama#).
+  logged in (gh#openSUSE/agama#1449).
 
 -------------------------------------------------------------------
 Mon Jul  8 11:12:13 UTC 2024 - José Iván López González <jlopez@suse.com>

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul  9 08:51:34 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not try to connect to the WebSocket until the user is
+  logged in (gh#openSUSE/agama#).
+
+-------------------------------------------------------------------
 Mon Jul  8 11:12:13 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Improve storage UI for configuring the space policy actions

--- a/web/src/client/http.js
+++ b/web/src/client/http.js
@@ -239,11 +239,24 @@ class HTTPClient {
     const httpUrl = new URL(url.toString());
     httpUrl.pathname = url.pathname.concat("api");
     this.baseUrl = httpUrl.toString();
+    this.url = url;
+  }
 
-    const wsUrl = new URL(url.toString());
+  /**
+   * Return the websocket client
+   *
+   * The WSClient is lazily created in the first call of this method.
+   *
+   * @return {WSClient}
+   */
+  ws() {
+    if (this._ws) return this._ws;
+
+    const wsUrl = new URL(this.url.toString());
     wsUrl.pathname = wsUrl.pathname.concat("api/ws");
-    wsUrl.protocol = (url.protocol === "http:") ? "ws" : "wss";
-    this.ws = new WSClient(wsUrl);
+    wsUrl.protocol = (this.url.protocol === "http:") ? "ws" : "wss";
+    this._ws = new WSClient(wsUrl);
+    return this._ws;
   }
 
   /**
@@ -329,7 +342,7 @@ class HTTPClient {
    * @return {RemoveFn} - Function to remove the handler.
    */
   onClose(func) {
-    return this.ws.onClose(() => {
+    return this.ws().onClose(() => {
       func();
     });
   }
@@ -342,7 +355,7 @@ class HTTPClient {
    * @return {RemoveFn} - Function to remove the handler.
    */
   onError(func) {
-    return this.ws.onError((event) => {
+    return this.ws().onError((event) => {
       func(event);
     });
   }
@@ -354,7 +367,7 @@ class HTTPClient {
    * @return {RemoveFn} - Function to remove the handler.
    */
   onOpen(func) {
-    return this.ws.onOpen((event) => {
+    return this.ws().onOpen((event) => {
       func(event);
     });
   }
@@ -367,7 +380,7 @@ class HTTPClient {
    * @return {RemoveFn} - Function to remove the handler.
    */
   onEvent(type, func) {
-    return this.ws.onEvent((event) => {
+    return this.ws().onEvent((event) => {
       if (event.type === type) {
         func(event);
       }

--- a/web/src/client/index.js
+++ b/web/src/client/index.js
@@ -127,9 +127,8 @@ const createClient = url => {
     };
   };
 
-  const isConnected = () => client.ws?.isConnected() || false;
-  const isRecoverable = () => !!client.ws?.isRecoverable();
-  const ws = () => client.ws;
+  const isConnected = () => client.ws().isConnected() || false;
+  const isRecoverable = () => !!client.ws().isRecoverable();
 
   return {
     l10n,
@@ -145,9 +144,9 @@ const createClient = url => {
     onIssuesChange,
     isConnected,
     isRecoverable,
-    onConnect: handler => client.ws.onOpen(handler),
-    onDisconnect: handler => client.ws.onClose(handler),
-    ws: () => client.ws
+    onConnect: handler => client.ws().onOpen(handler),
+    onDisconnect: handler => client.ws().onClose(handler),
+    ws: () => client.ws()
   };
 };
 

--- a/web/src/client/software.js
+++ b/web/src/client/software.js
@@ -328,7 +328,7 @@ class ProductBaseClient {
    * @param {(registration: Registration) => void} handler - Callback function.
    */
   onRegistrationChange(handler) {
-    return this.client.ws.onEvent((event) => {
+    return this.client.ws().onEvent((event) => {
       if (event.type === "RegistrationChanged" || event.type === "RegistrationRequirementChanged") {
         this.getRegistration().then(handler);
       }

--- a/web/src/client/users.js
+++ b/web/src/client/users.js
@@ -163,7 +163,7 @@ class UsersBaseClient {
    * @return {import ("./dbus").RemoveFn} function to disable the callback
    */
   onUsersChange(handler) {
-    return this.client.ws.onEvent((event) => {
+    return this.client.ws().onEvent((event) => {
       if (event.type === "RootChanged") {
         const res = {};
         if (event.password !== null) {


### PR DESCRIPTION
The web user interface tries to connect to the WebSocket from the very beginning (most likely
because of
[network/routes.js](https://github.com/openSUSE/agama/blob/master/web/src/components/network/routes.js#L32).

This PR introduces an HTTPClient#ws method that builds the WSClient lazily so the initialization is
postponed until it is required.
