### PR TITLE
Bring back PXE image for remote installations

### DIFF
--- a/live/Makefile
+++ b/live/Makefile
@@ -18,7 +18,7 @@ OBS_PROJECT = "systemsmanagement:Agama:Devel"
 # files to copy from src/
 COPY_FILES = $(patsubst $(SRCDIR)/%,$(DESTDIR)/%,$(wildcard $(SRCDIR)/*))
 
-all: $(DESTDIR) $(COPY_FILES) $(DESTDIR)/config-cdroot.tar.xz $(DESTDIR)/root.tar.xz
+all: $(DESTDIR) $(COPY_FILES) $(DESTDIR)/config-cdroot.tar.xz $(DESTDIR)/root.tar.xz $(DESTDIR)/root-openSUSE-PXE.tar.xz
 
 # clean the destination directory (but keep the .osc directory if it is present)
 clean:

--- a/live/README.md
+++ b/live/README.md
@@ -32,7 +32,7 @@ This directory contains a set of files that are used to build the Agama Live ISO
 - [src](src) subdirectory contains all source files which are copied unmodified to the OBS project
 - [root](root) subdirectory contains files which are added to the Live ISO root system (inside the
   squashfs image)
-- [root-ALP-PXE](root-ALP-PXE) subdirectory contains specific files for the ALP image used for the
+- [root-openSUSE-PXE](root-openSUSE-PXE) subdirectory contains specific files for the openSUSE image used for the
   PXE boot, see a separate [PXE documentation](PXE.md) for more details about the PXE boot
 - [config-cdroot](config-cdroot) subdirectory contains file which are copied to the uncompressed
   root of the ISO image, the files can be accessed just by mounting the ISO file or the DVD medium
@@ -75,8 +75,8 @@ By default this will build the openSUSE image. If you want to build another imag
 
 ```shell
 make build FLAVOR=<flavor>
-# for building the ALP flavor:
-make build FLAVOR=ALP
+# for building the openSUSE-PXE flavor:
+make build FLAVOR=openSUSE-PXE
 ```
 
 See the [_multibuild](src/_multibuild) file for the list of available build flavors.

--- a/live/root-openSUSE-PXE/etc/dracut.conf.d/90-brd.conf
+++ b/live/root-openSUSE-PXE/etc/dracut.conf.d/90-brd.conf
@@ -1,0 +1,1 @@
+add_drivers+=" brd "

--- a/live/src/_multibuild
+++ b/live/src/_multibuild
@@ -1,4 +1,5 @@
 <multibuild>
   <flavor>openSUSE</flavor>
   <flavor>openSUSE-Playwright</flavor>
+  <flavor>openSUSE-PXE</flavor>
 </multibuild>

--- a/live/src/agama-installer-openSUSE.changes
+++ b/live/src/agama-installer-openSUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul  9 13:26:38 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- Added agama-installer-openSUSE PXE images
+  (gh#openSUSE/agama#1450).
+
+-------------------------------------------------------------------
 Thu Jul  4 11:24:47 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Update src/live to match rename to agama-installer-openSUSE

--- a/live/src/agama-installer-openSUSE.kiwi
+++ b/live/src/agama-installer-openSUSE.kiwi
@@ -11,6 +11,7 @@
     <profiles>
         <profile name="openSUSE" description="openSUSE multiproduct image" import="true" />
         <profile name="openSUSE-Playwright" description="openSUSE image with Playwright integration tests" arch="aarch64,x86_64" />
+        <profile name="openSUSE-PXE" description="openSUSE OEM image for remote instalaltion" import="true" />
     </profiles>
     <preferences>
         <version>9.0.0</version>
@@ -38,6 +39,46 @@
             <bootloader name="custom" />
         </type>
     </preferences>
+    <preferences arch="ppc64le" profiles="openSUSE-PXE">
+        <!-- For some reason the compression results on ppc64le are not as good as on the other archs -->
+        <type image="oem" filesystem="btrfs" fsmountoptions="compress=zstd:15" firmware="ofw" installpxe="true" installboot="install" kernelcmdline="rd.kiwi.ramdisk ramdisk_size=3174400" volid="agama">
+            <bootloader name="grub2" console="serial" timeout="1"/>
+            <oemconfig>
+                <oem-skip-verify>true</oem-skip-verify>
+                <oem-unattended>true</oem-unattended>
+                <oem-unattended-id>/dev/ram1</oem-unattended-id>
+                <oem-swap>false</oem-swap>
+                <oem-multipath-scan>false</oem-multipath-scan>
+            </oemconfig>
+            <size unit="M">3000</size>
+        </type>
+    </preferences>
+    <preferences arch="s390x" profiles="openSUSE-PXE">
+        <type image="oem" filesystem="btrfs" fsmountoptions="compress=zstd:15" installpxe="true" installboot="install" kernelcmdline="rd.kiwi.ramdisk ramdisk_size=2097152" volid="agama">
+            <bootloader name="custom"/>
+            <oemconfig>
+                <oem-skip-verify>true</oem-skip-verify>
+                <oem-unattended>true</oem-unattended>
+                <oem-unattended-id>/dev/ram1</oem-unattended-id>
+                <oem-swap>false</oem-swap>
+                <oem-multipath-scan>false</oem-multipath-scan>
+            </oemconfig>
+            <size unit="M">1900</size>
+        </type>
+    </preferences>
+    <preferences arch="aarch64,x86_64" profiles="openSUSE-PXE">
+        <type image="oem" filesystem="btrfs" fsmountoptions="compress=zstd:15" firmware="uefi" installiso="true" installpxe="true" installboot="install" kernelcmdline="rd.kiwi.ramdisk ramdisk_size=2097152" volid="agama">
+            <bootloader name="grub2" timeout="1"/>
+            <oemconfig>
+                <oem-skip-verify>true</oem-skip-verify>
+                <oem-unattended>true</oem-unattended>
+                <oem-unattended-id>/dev/ram1</oem-unattended-id>
+                <oem-swap>false</oem-swap>
+                <oem-multipath-scan>false</oem-multipath-scan>
+            </oemconfig>
+            <size unit="M">1900</size>
+        </type>
+    </preferences>
     <users>
         <!-- the password is configured during boot -->
         <user password="!*" home="/root" name="root" groups="root"/>
@@ -45,6 +86,11 @@
     <repository type="rpm-md">
         <source path="obsrepositories:/"/>
     </repository>
+    <packages type="image" profiles="openSUSE-PXE">
+        <package name="dracut-kiwi-oem-repart"/>
+        <package name="dracut-kiwi-oem-dump"/>
+        <archive name="root-openSUSE-PXE.tar.xz"/>
+    </packages>
     <packages type="image">
         <package name="avahi"/>
         <package name="bind-utils"/>


### PR DESCRIPTION
## Problem

We dropped PXE images when the ALP images were removed (see https://github.com/openSUSE/agama/pull/1181).

## Solution

Bring back PXE images for remote installations.
