### PR TITLE
feat(schema): basic storage settings

### DIFF
--- a/doc/auto_storage.md
+++ b/doc/auto_storage.md
@@ -15,7 +15,7 @@ JSON validation will be performed for it.
 ### Implementation Considerations for AutoYaST Specification
 
 In principle, implementing the legacy AutoYaST module is as simple as converting the corresponding
-section of the profile into a `Y2Storage::PartitioningSection` object and use 
+section of the profile into a `Y2Storage::PartitioningSection` object and use
 `Y2Storage::AutoInstProposal` to calculate the result.
 
 But there are some special cases in which AutoYaST fallbacks to read some settings from the YaST
@@ -142,12 +142,24 @@ LogicalVolume
 
 Encryption
   reuse <Boolean>
-  method <string>
-  key [<string>]
+  type <EncryptionType>
+
+EncryptionType <EncryptionLUKS1|EncryptionLUKS2|EncryptionPervasiveLUKS2|"protected_swap"|"secure_swap"|"random_swap">
+
+EncryptionLUKS1
+  password <string>
+  keySize [<number>]
+  cipher [<string>]
+
+EncryptionLUKS2
+  password <string>
+  keySize [<number>]
+  cipher [<string>]
   pdkdf [<string>]
   label [<string>]
-  cipher [<string>]
-  keySize [<number>]
+
+EncryptionPervasiveLUKS2
+  password <string>
 
 Filesystem
   reuse <Boolean>
@@ -191,13 +203,12 @@ it) to allocate two file systems.
     "drives": [
         {
             "partitions": [
-                { 
+                {
                     "alias": "pv",
                     "id": "lvm",
                     "size": { "min": "12 GiB" },
                     "encryption": {
-                        "method": "luks2",
-                        "key": "my secret passphrase"
+                        "luks2": { "password": "my secret passphrase" }
                     }
                 }
               ]
@@ -214,7 +225,7 @@ it) to allocate two file systems.
                 },
                 {
                     "size":   "2 GiB",
-                    "format": { "path": "swap", "type": "swap" }
+                    "filesystem": { "path": "swap", "type": "swap" }
                 }
             ]
         }
@@ -325,7 +336,7 @@ within them and create new partitions of type RAID.
                     },
                     "delete": true
                 },
-                { 
+                {
                     "alias": "newRaidPart",
                     "id": "raid",
                     "size": { "min": "1 GiB" }
@@ -597,7 +608,7 @@ TargetDevice <string|TargetDisk|TargetNewLvm|TargetReusedLvm>
 
 TargetDisk
   disk <string>
- 
+
 TargetNewLvm
   newLvmVg <string[]>
 
@@ -618,10 +629,10 @@ VolumeTarget <'default'|NewPartition|NewVg|UseDevice|UseFilesystem>
 
 NewPartition
   newPartition <string>
-  
+
 NewVg
   newVg <string>
-  
+
 UseDevice
   device <string>
 

--- a/rust/agama-lib/share/examples/autoyast.json
+++ b/rust/agama-lib/share/examples/autoyast.json
@@ -1,0 +1,8 @@
+{
+  "legacyAutoyastStorage": [
+    {
+      "device": "/dev/vdc",
+      "use": "all"
+    }
+  ]
+}

--- a/rust/agama-lib/share/examples/profile_tw.json
+++ b/rust/agama-lib/share/examples/profile_tw.json
@@ -26,7 +26,7 @@
   },
   "root": {
     "password": "nots3cr3t",
-    "sshKey": "..."
+    "sshPublicKey": "..."
   },
   "network": {
     "connections": [

--- a/rust/agama-lib/share/examples/storage-guided.json
+++ b/rust/agama-lib/share/examples/storage-guided.json
@@ -1,0 +1,63 @@
+{
+  "storage": {
+    "guided": {
+      "target": {
+        "disk": "/dev/vdc"
+      },
+      "boot": {
+        "configure": true,
+        "device": "/dev/vda"
+      },
+      "encryption": {
+        "password": "notsecret",
+        "method": "luks2",
+        "pbkdFunction": "argon2i"
+      },
+      "space": {
+        "policy": "custom",
+        "actions": [
+          { "resize": "/dev/vda" },
+          { "forceDelete": "/dev/vdb1" }
+        ]
+      },
+      "volumes": [
+        {
+          "mount": {
+            "path": "/",
+            "options": ["ro"]
+          },
+          "filesystem": {
+            "btrfs": {
+              "snapshots": true
+            }
+          },
+          "size": [1024, "5 Gib"],
+          "target": "default"
+        },
+        {
+          "mount": {
+            "path": "/home"
+          },
+          "filesystem": "xfs",
+          "size": {
+            "min": "5 GiB",
+            "max": "20 GiB"
+          },
+          "target": {
+            "newVg": "/dev/vda"
+          }
+        },
+        {
+          "mount": {
+            "path": "swap"
+          },
+          "filesystem": "swap",
+          "size": "8 GiB",
+          "target": {
+            "newPartition": "/dev/vda"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/rust/agama-lib/share/examples/storage.json
+++ b/rust/agama-lib/share/examples/storage.json
@@ -26,6 +26,11 @@
             }
           },
           {
+            "create": {
+              "id": "linux",
+              "type": "primary",
+              "size": "10 GiB"
+            },
             "encrypt": {
               "password": "notsecret",
               "method": "luks2"
@@ -38,6 +43,9 @@
             }
           },
           {
+            "create": {
+              "size": "2 GiB"
+            },
             "encrypt": {
               "password": "notsecret",
               "method": "luks2"

--- a/rust/agama-lib/share/examples/storage.json
+++ b/rust/agama-lib/share/examples/storage.json
@@ -13,6 +13,11 @@
         "partitions": [
           {
             "search": { "name": "/dev/vda2" },
+            "encryption": {
+              "luks1": {
+                "password": "notsecret"
+              }
+            },
             "filesystem": {
               "reuse": false,
               "type": "btrfs",
@@ -27,8 +32,10 @@
             "id": "linux",
             "size": "10 GiB",
             "encryption": {
-              "key": "notsecret",
-              "method": "luks2"
+              "luks2": {
+                "password": "notsecret",
+                "label": "data"
+              }
             },
             "filesystem": {
               "type": "xfs",
@@ -37,10 +44,7 @@
           },
           {
             "size": "2 GiB",
-            "encryption": {
-              "key": "notsecret",
-              "method": "luks2"
-            },
+            "encryption": "random_swap",
             "filesystem": {
               "type": "swap",
               "path": "swap"
@@ -51,10 +55,6 @@
       {
         "search": {
           "name": "/dev/vdb"
-        },
-        "encryption": {
-          "key": "notsecret",
-          "method": "luks2"
         },
         "filesystem": {
           "type": "ext4",

--- a/rust/agama-lib/share/examples/storage.json
+++ b/rust/agama-lib/share/examples/storage.json
@@ -1,63 +1,71 @@
 {
   "storage": {
-    "guided": {
-      "target": {
-        "disk": "/dev/vdc"
-      },
-      "boot": {
-        "configure": true,
-        "device": "/dev/vda"
-      },
-      "encryption": {
-        "password": "notsecret",
-        "method": "luks2",
-        "pbkdFunction": "argon2i"
-      },
-      "space": {
-        "policy": "custom",
-        "actions": [
-          { "resize": "/dev/vda" },
-          { "forceDelete": "/dev/vdb1" }
-        ]
-      },
-      "volumes": [
-        {
-          "mount": {
-            "path": "/",
-            "options": ["ro"]
-          },
-          "filesystem": {
-            "btrfs": {
-              "snapshots": true
+    "boot": {
+      "configure": true,
+      "device": "/dev/vda"
+    },
+    "drives": [
+      {
+        "search": {
+          "name": "/dev/vda"
+        },
+        "ptableType": "gpt",
+        "partitions": [
+          {
+            "search": { "name": "/dev/vda2" },
+            "format": {
+              "filesystem": {
+                "btrfs": {
+                  "snapshots": true
+                }
+              }
+            },
+            "mount": {
+              "path": "/",
+              "options": ["ro"]
             }
           },
-          "size": [1024, "5 Gib"],
-          "target": "default"
-        },
-        {
-          "mount": {
-            "path": "/home"
+          {
+            "encrypt": {
+              "password": "notsecret",
+              "method": "luks2"
+            },
+            "format": {
+              "filesystem": "xfs"
+            },
+            "mount": {
+              "path": "/home"
+            }
           },
-          "filesystem": "xfs",
-          "size": {
-            "min": "5 GiB",
-            "max": "20 GiB"
-          },
-          "target": {
-            "newVg": "/dev/vda"
+          {
+            "encrypt": {
+              "password": "notsecret",
+              "method": "luks2"
+            },
+            "format": {
+              "filesystem": "swap"
+            },
+            "mount": {
+              "path": "swap"
+            }
           }
+        ]
+      },
+      {
+        "search": {
+          "name": "/dev/vdb"
         },
-        {
-          "mount": {
-            "path": "swap"
-          },
-          "filesystem": "swap",
-          "size": "8 GiB",
-          "target": {
-            "newPartition": "/dev/vda"
-          }
+        "encrypt": {
+          "password": "notsecret",
+          "method": "luks2"
+        },
+        "format": {
+          "filesystem": "ext4"
+        },
+        "mount": {
+          "path": "/var/log"
         }
-      ]
-    }
+      }
+    ]
   }
 }

--- a/rust/agama-lib/share/examples/storage.json
+++ b/rust/agama-lib/share/examples/storage.json
@@ -28,7 +28,6 @@
           {
             "create": {
               "id": "linux",
-              "type": "primary",
               "size": "10 GiB"
             },
             "encrypt": {

--- a/rust/agama-lib/share/examples/storage.json
+++ b/rust/agama-lib/share/examples/storage.json
@@ -20,9 +20,10 @@
             },
             "filesystem": {
               "reuse": false,
-              "type": "btrfs",
-              "btrfsOptions": {
-                "snapshots": true
+              "type": {
+                "btrfs": {
+                  "snapshots": true
+                }
               },
               "path": "/",
               "mountOptions": ["ro"]

--- a/rust/agama-lib/share/examples/storage.json
+++ b/rust/agama-lib/share/examples/storage.json
@@ -26,6 +26,7 @@
                 }
               },
               "path": "/",
+              "mountBy": "uuid",
               "mountOptions": ["ro"]
             }
           },

--- a/rust/agama-lib/share/examples/storage.json
+++ b/rust/agama-lib/share/examples/storage.json
@@ -13,46 +13,36 @@
         "partitions": [
           {
             "search": { "name": "/dev/vda2" },
-            "format": {
-              "filesystem": {
-                "btrfs": {
-                  "snapshots": true
-                }
-              }
-            },
-            "mount": {
+            "filesystem": {
+              "reuse": false,
+              "type": "btrfs",
+              "btrfsOptions": {
+                "snapshots": true
+              },
               "path": "/",
-              "options": ["ro"]
+              "mountOptions": ["ro"]
             }
           },
           {
-            "create": {
-              "id": "linux",
-              "size": "10 GiB"
-            },
-            "encrypt": {
-              "password": "notsecret",
+            "id": "linux",
+            "size": "10 GiB",
+            "encryption": {
+              "key": "notsecret",
               "method": "luks2"
             },
-            "format": {
-              "filesystem": "xfs"
-            },
-            "mount": {
+            "filesystem": {
+              "type": "xfs",
               "path": "/home"
             }
           },
           {
-            "create": {
-              "size": "2 GiB"
-            },
-            "encrypt": {
-              "password": "notsecret",
+            "size": "2 GiB",
+            "encryption": {
+              "key": "notsecret",
               "method": "luks2"
             },
-            "format": {
-              "filesystem": "swap"
-            },
-            "mount": {
+            "filesystem": {
+              "type": "swap",
               "path": "swap"
             }
           }
@@ -62,14 +52,12 @@
         "search": {
           "name": "/dev/vdb"
         },
-        "encrypt": {
-          "password": "notsecret",
+        "encryption": {
+          "key": "notsecret",
           "method": "luks2"
         },
-        "format": {
-          "filesystem": "ext4"
-        },
-        "mount": {
+        "filesystem": {
+          "type": "ext4",
           "path": "/var/log"
         }
       }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -761,6 +761,10 @@
               "type": {
                 "title": "Partition type",
                 "enum": ["primary", "logical"]
+              },
+              "size": {
+                "title": "Partition size",
+                "$ref": "#/$defs/sizeValue"
               }
             }
           },

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -340,9 +340,6 @@
                     "description": "The search is limited to drives scope.",
                     "$ref": "#/$defs/search"
                   },
-                  "encryption": {
-                    "$ref": "#/$defs/encryption"
-                  },
                   "ptableType": {
                     "title": "Partition table type",
                     "description": "The partition table is created only if all the current partitions are deleted.",
@@ -358,7 +355,7 @@
         },
         "guided": {
           "title": "Guided proposal settings",
-          "$comment": "Guided settings will be removed from this schema.",
+          "$comment": "This guided section will be extracted to a separate schema. Only storage and legacyAutoyastStorage will be offered as valid schemas for the storage config.",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -646,7 +643,7 @@
           "$ref": "#/$defs/sizeValue"
         },
         {
-          "title": "Size range (tuple systax)",
+          "title": "Size range (tuple syntax)",
           "description": "Lower size limit and optionally upper size limit.",
           "type": "array",
           "items": {

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -299,7 +299,7 @@
       }
     },
     "storage": {
-      "title": "Storage settings.",
+      "title": "Storage settings",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -307,12 +307,14 @@
           "$ref": "#/$defs/boot"
         },
         "drives": {
-          "title": "Section describing drives (disks, BIOS RAIDs and multipath devices).",
+          "title": "Drive devices",
+          "description": "Section describing drives (disks, BIOS RAIDs and multipath devices).",
           "type": "array",
           "items": {
-            "title": "Drive description.",
             "anyOf": [
               {
+                "title": "Unpartitioned drive",
+                "description": "Drive without a partition table (e.g., directly formatted).",
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
@@ -330,6 +332,7 @@
                 }
               },
               {
+                "title": "Partitioned drive",
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
@@ -341,7 +344,7 @@
                     "$ref": "#/$defs/encryption"
                   },
                   "ptableType": {
-                    "title": "Partition table type.",
+                    "title": "Partition table type",
                     "description": "The partition table is created only if all the current partitions are deleted.",
                     "enum": ["gpt", "msdos", "dasd"]
                   },
@@ -354,42 +357,44 @@
           }
         },
         "guided": {
-          "title": "Settings to execute a Guided Proposal.",
-          "deprecated": true,
-          "$comment": "Guided settings will be removed from the schema.",
+          "title": "Guided proposal settings",
+          "$comment": "Guided settings will be removed from this schema.",
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "target": {
-              "title": "Target device.",
               "anyOf": [
                 {
+                  "title": "Target for installing",
+                  "description": "Indicates whether to install in a disk or a new LVM.",
                   "enum": ["disk", "newLvmVg"]
                 },
                 {
-                  "title": "Disk device for installing.",
+                  "title": "Target disk",
+                  "description": "Indicates to install in a specific disk device.",
                   "type": "object",
                   "additionalProperties": false,
                   "required": ["disk"],
                   "properties": {
                     "disk": {
-                      "title": "Disk device name.",
+                      "title": "Device name",
                       "type": "string",
                       "examples": ["/dev/vda"]
                     }
                   }
                 },
                 {
-                  "title": "New LVM for installing.",
+                  "title": "New LVM",
+                  "description": "Indicates to install in a new LVM created over some specific devices.",
                   "type": "object",
                   "additionalProperties": false,
                   "required": ["newLvmVg"],
                   "properties": {
                     "newLvmVg": {
-                      "title": "Devices in which to create the physical volumes.",
+                      "description": "List of devices in which to create the physical volumes.",
                       "type": "array",
                       "items": {
-                        "title": "Disk device name.",
+                        "title": "Device name",
                         "type": "string",
                         "examples": ["/dev/vda"]
                       }
@@ -402,7 +407,8 @@
               "$ref": "#/$defs/boot"
             },
             "encryption": {
-              "title": "Encryption options.",
+              "title": "Encryption",
+              "description": "Indicates the options for encrypting the new partitions.",
               "type": "object",
               "additionalProperties": false,
               "required": ["password"],
@@ -411,7 +417,8 @@
                   "$ref": "#/$defs/encryptionPassword"
                 },
                 "method": {
-                  "title": "Method used to encrypt the devices.",
+                  "title": "Encryption method",
+                  "description": "Method used to encrypt the devices.",
                   "enum": ["luks2", "tpm_fde"]
                 },
                 "pbkdFunction": {
@@ -420,7 +427,8 @@
               }
             },
             "space": {
-              "title": "Policy to find space for the new partitions.",
+              "title": "Space policy",
+              "description": "Indicates how to find space for the new partitions.",
               "type": "object",
               "additionalProperties": false,
               "properties": {
@@ -440,33 +448,34 @@
                 "required": ["policy", "actions"],
                 "properties": {
                   "actions": {
-                    "title": "Actions to find space if policy is 'custom'.",
+                    "title": "Custom actions",
+                    "description": "Indicates what to do with specific devices.",
                     "type": "array",
                     "items": {
                       "anyOf": [
                         {
-                          "title": "Delete device.",
-                          "description": "Force device deletion.",
+                          "title": "Force delete",
+                          "description": "Indicates to delete a specific device.",
                           "type": "object",
                           "required": ["forceDelete"],
                           "additionalProperties": false,
                           "properties": {
                             "forceDelete": {
-                              "title": "Device to delete.",
+                              "description": "Name of the device to delete.",
                               "type": "string",
                               "examples": ["/dev/vda"]
                             }
                           }
                         },
                         {
-                          "title": "Allow shinking.",
-                          "description": "Indicate the device can be shrunk in needed.",
+                          "title": "Allow shinking",
+                          "description": "Indicates whether a specific device can be shrunk if needed.",
                           "type": "object",
                           "required": ["resize"],
                           "additionalProperties": false,
                           "properties": {
                             "resize": {
-                              "title": "Device to allow resizing",
+                              "description": "Name of the shrinkable device.",
                               "type": "string",
                               "examples": ["/dev/vda"]
                             }
@@ -488,7 +497,8 @@
               }
             },
             "volumes": {
-              "title": "Set of volumes (file systems) to create.",
+              "title": "System volumes",
+              "description": "List of volumes (file systems) to create.",
               "type": "array",
               "items": {
                 "type": "object",
@@ -496,20 +506,23 @@
                 "required": ["mount"],
                 "properties": {
                   "mount": {
-                    "title": "Mount options.",
+                    "title": "Mount properties",
                     "type": "object",
                     "additionalProperties": false,
                     "required": ["path"],
                     "properties": {
                       "path": {
-                        "title": "Mount path.",
+                        "title": "Mount path",
                         "type": "string",
                         "examples": ["/dev/vda"]
                       },
                       "options": {
-                        "title": "Options to add to the fourth field of fstab.",
+                        "title": "Mount options",
+                        "description": "Options to add to the fourth field of fstab.",
                         "type": "array",
-                        "items": { "type": "string" }
+                        "items": {
+                          "type": "string"
+                        }
                       }
                     }
                   },
@@ -520,63 +533,65 @@
                     "$ref": "#/$defs/size"
                   },
                   "target": {
-                    "title": "Location of the file system.",
-                    "description": "Options to indicate the location of a file system.",
+                    "title": "Volume target",
+                    "description": "Options to indicate the location of a volume.",
                     "anyOf": [
                       {
+                        "title": "Default target",
+                        "description": "The volume is created in the target device for installing.",
                         "const": "default"
                       },
                       {
-                        "title": "New partition.",
-                        "description": "The file system is created over a new partition.",
+                        "title": "New partition",
+                        "description": "The volume is created over a new partition in a specific disk.",
                         "type": "object",
                         "required": ["newPartition"],
                         "additionalProperties": false,
                         "properties": {
                           "newPartition": {
-                            "title": "Name of a disk device.",
+                            "description": "Name of a disk device.",
                             "type": "string",
                             "examples": ["/dev/vda"]
                             }
                         }
                       },
                       {
-                        "title": "Dedicated LVM volume group.",
-                        "description": "The file system is created over a dedicated LVM.",
+                        "title": "Dedicated LVM volume group",
+                        "description": "The volume is created over a new dedicated LVM.",
                         "type": "object",
                         "additionalProperties": false,
                         "required": ["newVg"],
                         "properties": {
                           "newVg": {
-                            "title": "Name of a disk device.",
+                            "description": "Name of a disk device.",
                             "type": "string",
                             "examples": ["/dev/vda"]
                           }
                         }
                       },
                       {
-                        "title": "Re-used existing device.",
-                        "description": "The file system is created over an existing device.",
+                        "title": "Re-used existing device",
+                        "description": "The volume is created over an existing device.",
                         "type": "object",
                         "additionalProperties": false,
                         "required": ["device"],
                         "properties": {
                           "device": {
-                            "title": "Name of a device.",
+                            "description": "Name of a device.",
                             "type": "string",
                             "examples": ["/dev/vda1"]
                           }
                         }
                       },
                       {
-                        "title": "Re-used existing file system.",
+                        "title": "Re-used existing file system",
                         "description": "An existing file system is reused (without formatting).",
                         "type": "object",
                         "additionalProperties": false,
                         "required": ["filesystem"],
                         "properties": {
                           "filesystem": {
-                            "title": "Name of a device containing the file system.",
+                            "description": "Name of a device containing the file system.",
                             "type": "string",
                             "examples": ["/dev/vda1"]
                           }
@@ -593,7 +608,7 @@
     },
     "legacyAutoyastStorage": {
       "title": "Legacy AutoYaST storage settings",
-      "description": "Accepts all options of the AutoYaST partitioning section (XML to JSON)",
+      "description": "Accepts all options of the AutoYaST partitioning section (i.e., XML to JSON)",
       "type": "array",
       "items": {
         "type": "object"
@@ -620,19 +635,18 @@
       ]
     },
     "size": {
-      "title": "Size options.",
+      "title": "Size options",
       "anyOf": [
         {
-          "title": "Automatic size.",
+          "title": "Automatic size",
           "description": "The size is auto calculated according to the product.",
           "const": "auto"
         },
         {
-          "title": "Size unit.",
           "$ref": "#/$defs/sizeValue"
         },
         {
-          "title": "Size range.",
+          "title": "Size range (tuple systax)",
           "description": "Lower size limit and optionally upper size limit.",
           "type": "array",
           "items": {
@@ -643,17 +657,17 @@
           "examples": [[1024, 2048], ["1 GiB", "5 GiB"], [1024, "2 GiB"], ["2 GiB"]]
         },
         {
-          "title": "Size range.",
+          "title": "Size range",
           "type": "object",
           "additionalProperties": false,
           "required": ["min"],
           "properties": {
             "min": {
-              "title": "Mandatory lower size limit.",
+              "title": "Mandatory lower size limit",
               "$ref": "#/$defs/sizeValue"
             },
             "max": {
-              "title": "Optional upper size limit.",
+              "title": "Optional upper size limit",
               "$ref": "#/$defs/sizeValue"
             }
           }
@@ -674,43 +688,46 @@
       }
     },
     "boot": {
-      "title": "Boot options.",
+      "title": "Boot options",
+      "description": "Allows configuring boot partitions automatically.",
       "type": "object",
       "additionalProperties": false,
       "required": ["configure"],
       "properties": {
         "configure": {
-          "title": "Whether to configure partitions for booting.",
+          "title": "Configure boot",
+          "description": "Whether to configure partitions for booting.",
           "type": "boolean"
         },
         "device": {
-          "title": "Device to use for booting.",
-          "description": "The installation device is used by default for booting.",
+          "title": "Boot device",
+          "description": "The target installation device is used by default.",
           "type": "string",
           "examples": ["/dev/vda"]
         }
       }
     },
     "encryptionPassword": {
-      "title": "Passphrase to use when creating a new encryption device.",
+      "title": "Encryption password",
+      "description": "Password to use when creating a new encryption device.",
       "type": "string"
     },
     "encryptionCipher": {
-      "title": "Cipher used for LUKS encryption.",
+      "title": "LUKS cipher",
       "description": "The value must be compatible with the --cipher argument of the command cryptsetup.",
       "type": "string"
     },
     "encryptionKeySize": {
-      "title": "Key size, in bits, used for LUKS encryption.",
-      "description": "The value has to be a multiple of 8. The possible key sizes are limited by the used cipher.",
+      "title": "LUKS key size",
+      "description": "The value (in bits) has to be a multiple of 8. The possible key sizes are limited by the used cipher.",
       "type": "integer"
     },
     "encryptionPbkdFunction": {
-      "title": "Password-based key derivation function to use for LUKS2.",
+      "title": "LUKS2 password-based key derivation",
       "enum": ["pbkdf2", "argon2i", "argon2id"]
     },
     "encryptionLUKS1": {
-      "title": "LUKS1 encryption.",
+      "title": "LUKS1 encryption",
       "type": "object",
       "additionalProperties": false,
       "required": ["luks1"],
@@ -734,7 +751,7 @@
       }
     },
     "encryptionLUKS2": {
-      "title": "LUKS2 encryption.",
+      "title": "LUKS2 encryption",
       "type": "object",
       "additionalProperties": false,
       "required": ["luks2"],
@@ -757,7 +774,7 @@
               "$ref": "#/$defs/encryptionPbkdFunction"
             },
             "label": {
-              "title": "LUKS label for the encrypted device.",
+              "title": "LUKS2 label",
               "type": "string"
             }
           }
@@ -765,7 +782,7 @@
       }
     },
     "encryptionPervasiveLUKS2": {
-      "title": "LUKS2 pervasive encryption.",
+      "title": "LUKS2 pervasive encryption",
       "type": "object",
       "additionalProperties": false,
       "required": ["pervasiveLuks2"],
@@ -783,11 +800,10 @@
       }
     },
     "encryptionSwap": {
-      "title": "Swap encryption.",
+      "title": "Swap encryptions",
       "enum": ["protected_swap", "secure_swap", "random_swap"]
     },
     "encryption": {
-      "title": "Encryption options.",
       "anyOf": [
         { "$ref": "#/$defs/encryptionLUKS1" },
         { "$ref": "#/$defs/encryptionLUKS2" },
@@ -796,9 +812,9 @@
       ]
     },
     "filesystemType": {
-      "title": "File system type",
       "anyOf": [
         {
+          "title": "File system type",
           "enum": [
             "bcachefs", "btrfs", "exfat", "ext2", "ext3", "ext4", "f2fs", "jfs",
             "nfs", "nilfs2", "ntfs", "reiserfs", "swap", "tmpfs", "vfat", "xfs"
@@ -816,7 +832,7 @@
               "properties": {
                 "snapshots": {
                   "title": "Btrfs snapshots",
-                  "description": "Whether Btrfs snapshots should be configured.",
+                  "description": "Whether to configrue Btrfs snapshots.",
                   "type": "boolean"
                 }
               }
@@ -826,12 +842,13 @@
       ]
     },
     "filesystem": {
-      "title": "File system options.",
+      "title": "File system options",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "reuse": {
-          "title": "Whether to reuse the existing file system (if any).",
+          "title": "Reuse file system",
+          "description": "Whether to reuse the existing file system (if any).",
           "type": "boolean",
           "default": false
         },
@@ -839,31 +856,36 @@
           "$ref": "#/$defs/filesystemType"
         },
         "label": {
-          "title": "File system label.",
+          "title": "File system label",
           "type": "string"
         },
         "path": {
-          "title": "Mount path.",
+          "title": "Mount path",
           "type": "string",
           "examples": ["/dev/vda"]
         },
         "mkfsOptions": {
-          "title": "Options for creating the file system.",
+          "title": "mkfs options",
+          "description": "Options for creating the file system.",
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "mountOptions": {
-          "title": "Options to add to the fourth field of fstab.",
+          "title": "Mount options",
+          "description": "Options to add to the fourth field of fstab.",
           "type": "array",
           "items": { "type": "string" }
         }
       }
     },
     "partitions": {
-      "title": "Partitions to create, reuse or delete.",
+      "title": "Partitions",
+      "description": "Partitions to create, reuse or delete.",
       "type": "array",
       "items": {
-        "title": "Partition options.",
+        "title": "Partition options",
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -872,12 +894,12 @@
             "$ref": "#/$defs/search"
           },
           "id": {
-            "title": "Partition ID.",
+            "title": "Partition ID",
             "enum": ["linux", "swap", "lvm", "raid", "esp", "prep", "bios_boot"]
           },
           "size": {
-            "$ref": "#/$defs/sizeValue",
-            "title": "Partition size."
+            "title": "Partition size",
+            "$ref": "#/$defs/sizeValue"
           },
           "encryption": {
             "$ref": "#/$defs/encryption"

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -299,7 +299,7 @@
       }
     },
     "storage": {
-      "title": "Storage settings",
+      "title": "Storage settings.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -307,75 +307,87 @@
           "$ref": "#/$defs/boot"
         },
         "drives": {
-          "title": "Section describing drives (disks, BIOS RAIDs and multipath devices)",
+          "title": "Section describing drives (disks, BIOS RAIDs and multipath devices).",
           "type": "array",
           "items": {
-            "title": "Drive description",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "search": {
-                "description": "The search is applied only to drive devices",
-                "$ref": "#/$defs/search"
+            "title": "Drive description.",
+            "anyOf": [
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "search": {
+                    "description": "The search is limited to drives scope.",
+                    "$ref": "#/$defs/search"
+                  },
+                  "encryption": {
+                    "$ref": "#/$defs/encryption"
+                  },
+                  "filesystem": {
+                    "description": "The partition table (if any) is deleted.",
+                    "$ref": "#/$defs/filesystem"
+                  }
+                }
               },
-              "encrypt": {
-                "description": "The device is encrypted only if the current partitions are deleted and no new partitions are created",
-                "$ref": "#/$defs/encrypt"
-              },
-              "format": {
-                "description": "The device is formatted only if the current partitions are deleted and no new partitions are created",
-                "$ref": "#/$defs/format"
-              },
-              "mount": {
-                "description": "The device is mounted only if it is formatted",
-                "$ref": "#/$defs/mount"
-              },
-              "ptableType": {
-                "title": "Partition table type",
-                "description": "The partition table is created only if all the current partitions are deleted",
-                "enum": ["gpt", "msdos", "dasd"]
-              },
-              "partitions": {
-                "$ref": "#/$defs/partitions"
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "search": {
+                    "description": "The search is limited to drives scope.",
+                    "$ref": "#/$defs/search"
+                  },
+                  "encryption": {
+                    "$ref": "#/$defs/encryption"
+                  },
+                  "ptableType": {
+                    "title": "Partition table type.",
+                    "description": "The partition table is created only if all the current partitions are deleted.",
+                    "enum": ["gpt", "msdos", "dasd"]
+                  },
+                  "partitions": {
+                    "$ref": "#/$defs/partitions"
+                  }
+                }
               }
-            }
+            ]
           }
         },
         "guided": {
-          "title": "Settings to execute a Guided Proposal",
+          "title": "Settings to execute a Guided Proposal.",
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "target": {
-              "title": "Target device",
+              "title": "Target device.",
               "anyOf": [
                 {
                   "enum": ["disk", "newLvmVg"]
                 },
                 {
-                  "title": "Disk device for installing",
+                  "title": "Disk device for installing.",
                   "type": "object",
                   "additionalProperties": false,
                   "required": ["disk"],
                   "properties": {
                     "disk": {
-                      "title": "Disk device name",
+                      "title": "Disk device name.",
                       "type": "string",
                       "examples": ["/dev/vda"]
                     }
                   }
                 },
                 {
-                  "title": "New LVM for installing",
+                  "title": "New LVM for installing.",
                   "type": "object",
                   "additionalProperties": false,
                   "required": ["newLvmVg"],
                   "properties": {
                     "newLvmVg": {
-                      "title": "Devices in which to create the physical volumes",
+                      "title": "Devices in which to create the physical volumes.",
                       "type": "array",
                       "items": {
-                        "title": "Disk device name",
+                        "title": "Disk device name.",
                         "type": "string",
                         "examples": ["/dev/vda"]
                       }
@@ -388,10 +400,25 @@
               "$ref": "#/$defs/boot"
             },
             "encryption": {
-              "$ref": "#/$defs/encrypt"
+              "title": "Encryption options.",
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["password"],
+              "properties": {
+                "password": {
+                  "title": "Passphrase to use when creating a new encryption device.",
+                  "type": "string"
+                },
+                "method": {
+                  "$ref": "#/$defs/encryptionMethod"
+                },
+                "pbkdFunction": {
+                  "$ref": "#/$defs/encryptionPbkdFunction"
+                }
+              }
             },
             "space": {
-              "title": "Policy to find space for the new partitions",
+              "title": "Policy to find space for the new partitions.",
               "type": "object",
               "additionalProperties": false,
               "properties": {
@@ -411,27 +438,27 @@
                 "required": ["policy", "actions"],
                 "properties": {
                   "actions": {
-                    "title": "Actions to find space if policy is 'custom'",
+                    "title": "Actions to find space if policy is 'custom'.",
                     "type": "array",
                     "items": {
                       "anyOf": [
                         {
-                          "title": "Delete device",
-                          "description": "Force device deletion",
+                          "title": "Delete device.",
+                          "description": "Force device deletion.",
                           "type": "object",
                           "required": ["forceDelete"],
                           "additionalProperties": false,
                           "properties": {
                             "forceDelete": {
-                              "title": "Device to delete",
+                              "title": "Device to delete.",
                               "type": "string",
                               "examples": ["/dev/vda"]
                             }
                           }
                         },
                         {
-                          "title": "Allow shinking",
-                          "description": "Indicate the device can be shrunk in needed",
+                          "title": "Allow shinking.",
+                          "description": "Indicate the device can be shrunk in needed.",
                           "type": "object",
                           "required": ["resize"],
                           "additionalProperties": false,
@@ -459,7 +486,7 @@
               }
             },
             "volumes": {
-              "title": "Set of volumes (file systems) to create",
+              "title": "Set of volumes (file systems) to create.",
               "type": "array",
               "items": {
                 "type": "object",
@@ -467,112 +494,103 @@
                 "required": ["mount"],
                 "properties": {
                   "mount": {
-                    "$ref": "#/$defs/mount"
+                    "title": "Mount options.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["path"],
+                    "properties": {
+                      "path": {
+                        "title": "Mount path.",
+                        "type": "string",
+                        "examples": ["/dev/vda"]
+                      },
+                      "options": {
+                        "title": "Options to add to the fourth field of fstab.",
+                        "type": "array",
+                        "items": { "type": "string" }
+                      }
+                    }
                   },
                   "filesystem": {
-                    "title": "File system of the volume",
-                    "$ref": "#/$defs/filesystemValue"
-                  },
-                  "size": {
-                    "title": "Size limits",
-                    "description": "Options to indicate the size of a device",
+                    "title": "File system of the volume.",
                     "anyOf": [
                       {
-                        "title": "Automatic size",
-                        "description": "The size is auto calculated according to the product",
-                        "const": "auto"
+                        "$ref": "#/$defs/filesystemType"
                       },
                       {
-                        "title": "Size unit",
-                        "$ref": "#/$defs/sizeValue"
-                      },
-                      {
-                        "title": "Size range (e.g., [1024, '2 GiB'])",
-                        "description": "Lower size limit and optionally upper size limit",
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/$defs/sizeValue"
-                        },
-                        "minItems": 1,
-                        "maxItems": 2,
-                        "examples": [[1024, "2 GiB"]]
-                      },
-                      {
-                        "title": "Size range",
+                        "title": "Btrfs file system.",
                         "type": "object",
                         "additionalProperties": false,
+                        "required": ["btrfs"],
                         "properties": {
-                          "min": {
-                            "title": "Mandatory lower size limit",
-                            "$ref": "#/$defs/sizeValue"
-                          },
-                          "max": {
-                            "title": "Optional upper size limit",
-                            "$ref": "#/$defs/sizeValue"
+                          "btrfs": {
+                            "$ref": "#/$defs/btrfsOptions"
                           }
-                        },
-                        "required": ["min"]
+                        }
                       }
                     ]
                   },
+                  "size": {
+                    "$ref": "#/$defs/size"
+                  },
                   "target": {
-                    "title": "Location of the file system",
-                    "description": "Options to indicate the location of a file system",
+                    "title": "Location of the file system.",
+                    "description": "Options to indicate the location of a file system.",
                     "anyOf": [
                       {
                         "const": "default"
                       },
                       {
-                        "title": "New partition",
-                        "description": "The file system is created over a new partition",
+                        "title": "New partition.",
+                        "description": "The file system is created over a new partition.",
                         "type": "object",
                         "required": ["newPartition"],
                         "additionalProperties": false,
                         "properties": {
                           "newPartition": {
-                            "title": "Name of a disk device",
+                            "title": "Name of a disk device.",
                             "type": "string",
                             "examples": ["/dev/vda"]
-                          }
+                            }
                         }
                       },
                       {
-                        "title": "Dedicated LVM volume group",
-                        "description": "The file system is created over a dedicated LVM",
+                        "title": "Dedicated LVM volume group.",
+                        "description": "The file system is created over a dedicated LVM.",
                         "type": "object",
                         "additionalProperties": false,
                         "required": ["newVg"],
                         "properties": {
                           "newVg": {
-                            "title": "Name of a disk device",
+                            "title": "Name of a disk device.",
                             "type": "string",
                             "examples": ["/dev/vda"]
                           }
                         }
                       },
                       {
-                        "title": "Re-used existing device",
-                        "description": "The file system is created over an existing device",
+                        "title": "Re-used existing device.",
+                        "description": "The file system is created over an existing device.",
                         "type": "object",
                         "additionalProperties": false,
                         "required": ["device"],
                         "properties": {
                           "device": {
-                            "title": "Name of a device",
+                            "title": "Name of a device.",
                             "type": "string",
                             "examples": ["/dev/vda1"]
                           }
                         }
                       },
                       {
-                        "title": "Re-used existing file system",
-                        "description": "An existing file system is reused (without formatting)",
+                        "title": "Re-used existing file system.",
+                        "description": "An existing file system is reused (without formatting).",
                         "type": "object",
                         "additionalProperties": false,
                         "required": ["filesystem"],
                         "properties": {
                           "filesystem": {
-                            "title": "Name of a device containing the file system",
+                            "title": "Name of a device containing the file system.",
                             "type": "string",
                             "examples": ["/dev/vda1"]
                           }
@@ -615,54 +633,46 @@
         { "$ref": "#/$defs/sizeInteger" }
       ]
     },
-    "filesystemValue": {
+    "size": {
+      "title": "Size options.",
       "anyOf": [
         {
-          "title": "File system type",
-          "enum": [
-            "bcachefs", "btrfs", "exfat", "ext2", "ext3", "ext4", "f2fs", "jfs",
-            "nfs", "nilfs2", "ntfs", "reiserfs", "swap", "tmpfs", "vfat", "xfs"
-          ]
+          "title": "Automatic size.",
+          "description": "The size is auto calculated according to the product.",
+          "const": "auto"
         },
         {
-          "title": "Btrfs file system",
-          "description": "Indicates properties of the Btrfs file system",
+          "title": "Size unit.",
+          "$ref": "#/$defs/sizeValue"
+        },
+        {
+          "title": "Size range.",
+          "description": "Lower size limit and optionally upper size limit.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/sizeValue"
+          },
+          "minItems": 1,
+          "maxItems": 2,
+          "examples": [[1024, 2048], ["1 GiB", "5 GiB"], [1024, "2 GiB"], ["2 GiB"]]
+        },
+        {
+          "title": "Size range.",
           "type": "object",
           "additionalProperties": false,
-          "required": ["btrfs"],
+          "required": ["min"],
           "properties": {
-            "btrfs": {
-              "title": "Specification of a Btrfs file system",
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "snapshots": {
-                  "title": "Whether Btrfs snapshots should be configured",
-                  "type": "boolean"
-                }
-              }
+            "min": {
+              "title": "Mandatory lower size limit.",
+              "$ref": "#/$defs/sizeValue"
+            },
+            "max": {
+              "title": "Optional upper size limit.",
+              "$ref": "#/$defs/sizeValue"
             }
           }
         }
       ]
-    },
-    "boot": {
-      "title": "Boot options",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["configure"],
-      "properties": {
-        "configure": {
-          "title": "Whether to configure partitions for booting",
-          "type": "boolean"
-        },
-        "device": {
-          "title": "Device to use for booting",
-          "description": "The installation device is used by default for booting",
-          "type": "string",
-          "examples": ["/dev/vda"]
-        }
-      }
     },
     "search": {
       "title": "Search options",
@@ -677,103 +687,144 @@
         }
       }
     },
-    "encrypt": {
-      "title": "Encryption options",
+    "boot": {
+      "title": "Boot options.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["password"],
+      "required": ["configure"],
       "properties": {
-        "password": {
-          "title": "Passphrase to use when creating a new encryption device",
+        "configure": {
+          "title": "Whether to configure partitions for booting.",
+          "type": "boolean"
+        },
+        "device": {
+          "title": "Device to use for booting.",
+          "description": "The installation device is used by default for booting.",
+          "type": "string",
+          "examples": ["/dev/vda"]
+        }
+      }
+    },
+    "encryptionMethod": {
+      "title": "Method used to create the encryption device.",
+      "enum": ["luks2", "tpm_fde"]
+    },
+    "encryptionPbkdFunction": {
+      "title": "Password-based key derivation function to use for LUKS2.",
+      "enum": ["pbkdf2", "argon2i", "argon2id"]
+    },
+    "encryption": {
+      "title": "Encryption options.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key"],
+      "properties": {
+        "key": {
+          "title": "Passphrase to use when creating a new encryption device.",
           "type": "string"
         },
         "method": {
-          "title": "Method used to create the encryption device",
-          "enum": ["luks2", "tpm_fde"]
+          "$ref": "#/$defs/encryptionMethod"
         },
         "pbkdFunction": {
-          "title": "Password-based key derivation function to use for LUKS2",
-          "enum": ["pbkdf2", "argon2i", "argon2id"]
-        }
-      }
-    },
-    "format": {
-      "title": "Format options",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["filesystem"],
-      "properties": {
-        "filesystem": {
-          "title": "File system to use for formatting the device",
-          "$ref": "#/$defs/filesystemValue"
+          "$ref": "#/$defs/encryptionPbkdFunction"
         },
         "label": {
-          "title": "File system label",
+          "title": "LUKS label for the encrypted device.",
           "type": "string"
         },
-        "mkfsOptions": {
-          "title": "Options for creating the file system",
-          "type": "array",
-          "items": { "type": "string" }
+        "cipher": {
+          "title": "Cipher used for LUKS encryption.",
+          "description": "The value must be compatible with the --cipher argument of the command cryptsetup.",
+          "type": "string"
+        },
+        "key_size": {
+          "title": "Key size, in bits, used for LUKS encryption.",
+          "description": "The value has to be a multiple of 8. The possible key sizes are limited by the used cipher.",
+          "type": "integer"
         }
       }
     },
-    "mount": {
-      "title": "Mount options",
+    "filesystemType": {
+      "title": "File system type.",
+      "enum": [
+        "bcachefs", "btrfs", "exfat", "ext2", "ext3", "ext4", "f2fs", "jfs",
+        "nfs", "nilfs2", "ntfs", "reiserfs", "swap", "tmpfs", "vfat", "xfs"
+      ]
+    },
+    "btrfsOptions": {
+      "title": "Btrfs file system options.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["path"],
       "properties": {
+        "snapshots": {
+          "title": "Whether Btrfs snapshots should be configured.",
+          "type": "boolean"
+        }
+      }
+    },
+    "filesystem": {
+      "title": "File system options.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reuse": {
+          "title": "Whether to reuse the existing file system (if any).",
+          "type": "boolean",
+          "default": false
+        },
+        "type": {
+          "$ref": "#/$defs/filesystemType"
+        },
+        "label": {
+          "title": "File system label.",
+          "type": "string"
+        },
         "path": {
-          "title": "Mount path",
+          "title": "Mount path.",
           "type": "string",
           "examples": ["/dev/vda"]
         },
-        "options": {
-          "title": "Options to add to the fourth field of fstab",
+        "btrfsOptions": {
+          "$ref": "#/$defs/btrfsOptions"
+        },
+        "mkfsOptions": {
+          "title": "Options for creating the file system.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "mountOptions": {
+          "title": "Options to add to the fourth field of fstab.",
           "type": "array",
           "items": { "type": "string" }
         }
       }
     },
     "partitions": {
-      "title": "Partitions to create, reuse or delete",
+      "title": "Partitions to create, reuse or delete.",
       "type": "array",
       "items": {
-        "title": "Partition options",
+        "title": "Partition options.",
         "type": "object",
         "additionalProperties": false,
         "properties": {
           "search": {
-            "description": "The search is applied only to the partitions of the selected device",
+            "description": "The search is limited to the partitions of the selected device scope.",
             "$ref": "#/$defs/search"
           },
-          "create": {
-            "title": "Options to create the partition",
-            "description": "These options are ignored if the partition already exists",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "id": {
-                "title": "Partition ID",
-                "enum": ["linux", "swap", "lvm", "raid", "esp", "prep", "biosBoot"]
-              },
-              "size": {
-                "title": "Partition size",
-                "$ref": "#/$defs/sizeValue"
-              }
-            }
+          "id": {
+            "title": "Partition ID.",
+            "enum": ["linux", "swap", "lvm", "raid", "esp", "prep", "bios_boot"]
           },
-          "encrypt": {
-            "description": "The partition is encrypted only if it is going to be created",
-            "$ref": "#/$defs/encrypt"
+          "size": {
+            "$ref": "#/$defs/sizeValue",
+            "title": "Partition size."
           },
-          "format": {
-            "$ref": "#/$defs/format"
+          "encryption": {
+            "$ref": "#/$defs/encryption"
           },
-          "mount": {
-            "description": "The partition is mounted only if it is formatted",
-            "$ref": "#/$defs/mount"
+          "filesystem": {
+            "$ref": "#/$defs/filesystem"
           }
         }
       }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -303,6 +303,44 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "boot": {
+          "$ref": "#/$defs/boot"
+        },
+        "drives": {
+          "title": "Section describing drives (disks, BIOS RAIDs and multipath devices)",
+          "type": "array",
+          "items": {
+            "title": "Drive description",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "search": {
+                "description": "The search is applied only to drive devices",
+                "$ref": "#/$defs/search"
+              },
+              "encrypt": {
+                "description": "The device is encrypted only if the current partitions are deleted and no new partitions are created",
+                "$ref": "#/$defs/encrypt"
+              },
+              "format": {
+                "description": "The device is formatted only if the current partitions are deleted and no new partitions are created",
+                "$ref": "#/$defs/format"
+              },
+              "mount": {
+                "description": "The device is mounted only if it is formatted",
+                "$ref": "#/$defs/mount"
+              },
+              "ptableType": {
+                "title": "Partition table type",
+                "description": "The partition table is created only if all the current partitions are deleted",
+                "enum": ["gpt", "msdos", "dasd"]
+              },
+              "partitions": {
+                "$ref": "#/$defs/partitions"
+              }
+            }
+          }
+        },
         "guided": {
           "title": "Settings to execute a Guided Proposal",
           "type": "object",
@@ -347,42 +385,10 @@
               ]
             },
             "boot": {
-              "title": "Configuration of the boot settings",
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["configure"],
-              "properties": {
-                "configure": {
-                  "title": "Whether to configure partitions for booting",
-                  "type": "boolean"
-                },
-                "device": {
-                  "title": "Device to use for booting",
-                  "description": "The installation device is used by default for booting",
-                  "type": "string",
-                  "examples": ["/dev/vda"]
-                }
-              }
+              "$ref": "#/$defs/boot"
             },
             "encryption": {
-              "title": "Encryption settings",
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["password"],
-              "properties": {
-                "password": {
-                  "title": "Passphrase to use when creating new encryption devices",
-                  "type": "string"
-                },
-                "method": {
-                  "title": "Method used to create the encryption devices",
-                  "enum": ["luks2", "tpm_fde"]
-                },
-                "pbkdFunction": {
-                  "title": "Password-based key derivation function to use for LUKS2",
-                  "enum": ["pbkdf2", "argon2i", "argon2id"]
-                }
-              }
+              "$ref": "#/$defs/encrypt"
             },
             "space": {
               "title": "Policy to find space for the new partitions",
@@ -461,53 +467,11 @@
                 "required": ["mount"],
                 "properties": {
                   "mount": {
-                    "title": "Mount point",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": ["path"],
-                    "properties": {
-                      "path": {
-                        "title": "Mount path",
-                        "type": "string"
-                      },
-                      "options": {
-                        "title": "Options to add to the fourth field of fstab",
-                        "type": "array",
-                        "items": { "type": "string" }
-                      }
-                    }
+                    "$ref": "#/$defs/mount"
                   },
                   "filesystem": {
                     "title": "File system of the volume",
-                    "anyOf": [
-                      {
-                        "title": "File system type",
-                        "enum": [
-                          "bcachefs", "btrfs", "exfat", "ext2", "ext3", "ext4", "f2fs", "jfs",
-                          "nfs", "nilfs2", "ntfs", "reiserfs", "swap", "tmpfs", "vfat", "xfs"
-                        ]
-                      },
-                      {
-                        "title": "Btrfs file system",
-                        "description": "Indicates properties of the Btrfs file system",
-                        "type": "object",
-                        "additionalProperties": false,
-                        "required": ["btrfs"],
-                        "properties": {
-                          "btrfs": {
-                            "title": "Specification of a Btrfs file system",
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                              "snapshots": {
-                                "title": "Whether Btrfs snapshots should be configured",
-                                "type": "boolean"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    ]
+                    "$ref": "#/$defs/filesystemValue"
                   },
                   "size": {
                     "title": "Size limits",
@@ -625,13 +589,16 @@
     },
     "legacyAutoyastStorage": {
       "title": "Legacy AutoYaST storage settings",
-      "description": "Accepts all options of the AutoYaST profile (XML to JSON)",
-      "type": "object"
+      "description": "Accepts all options of the AutoYaST partitioning section (XML to JSON)",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
     }
   },
   "$defs": {
     "sizeString": {
-      "title": "Human readable size (e.g., '2 GiB')",
+      "title": "Human readable size",
       "type": "string",
       "pattern": "^[0-9]+(\\.[0-9]+)?(\\s*([KkMmGgTtPpEeZzYy][iI]?)?[Bb])?$",
       "examples": ["2 GiB", "1.5 TB", "1TIB", "1073741824 b", "1073741824"]
@@ -639,13 +606,177 @@
     "sizeInteger": {
       "title": "Size in bytes",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "examples": [1024, 2048]
     },
     "sizeValue": {
       "anyOf": [
         { "$ref": "#/$defs/sizeString" },
         { "$ref": "#/$defs/sizeInteger" }
       ]
+    },
+    "filesystemValue": {
+      "anyOf": [
+        {
+          "title": "File system type",
+          "enum": [
+            "bcachefs", "btrfs", "exfat", "ext2", "ext3", "ext4", "f2fs", "jfs",
+            "nfs", "nilfs2", "ntfs", "reiserfs", "swap", "tmpfs", "vfat", "xfs"
+          ]
+        },
+        {
+          "title": "Btrfs file system",
+          "description": "Indicates properties of the Btrfs file system",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["btrfs"],
+          "properties": {
+            "btrfs": {
+              "title": "Specification of a Btrfs file system",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "snapshots": {
+                  "title": "Whether Btrfs snapshots should be configured",
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "boot": {
+      "title": "Boot options",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["configure"],
+      "properties": {
+        "configure": {
+          "title": "Whether to configure partitions for booting",
+          "type": "boolean"
+        },
+        "device": {
+          "title": "Device to use for booting",
+          "description": "The installation device is used by default for booting",
+          "type": "string",
+          "examples": ["/dev/vda"]
+        }
+      }
+    },
+    "search": {
+      "title": "Search options",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "title": "Device name",
+          "type": "string",
+          "examples": ["/dev/vda"]
+        }
+      }
+    },
+    "encrypt": {
+      "title": "Encryption options",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["password"],
+      "properties": {
+        "password": {
+          "title": "Passphrase to use when creating a new encryption device",
+          "type": "string"
+        },
+        "method": {
+          "title": "Method used to create the encryption device",
+          "enum": ["luks2", "tpm_fde"]
+        },
+        "pbkdFunction": {
+          "title": "Password-based key derivation function to use for LUKS2",
+          "enum": ["pbkdf2", "argon2i", "argon2id"]
+        }
+      }
+    },
+    "format": {
+      "title": "Format options",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["filesystem"],
+      "properties": {
+        "filesystem": {
+          "title": "File system to use for formatting the device",
+          "$ref": "#/$defs/filesystemValue"
+        },
+        "label": {
+          "title": "File system label",
+          "type": "string"
+        },
+        "mkfsOptions": {
+          "title": "Options for creating the file system",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "mount": {
+      "title": "Mount options",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "title": "Mount path",
+          "type": "string",
+          "examples": ["/dev/vda"]
+        },
+        "options": {
+          "title": "Options to add to the fourth field of fstab",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "partitions": {
+      "title": "Partitions to create, reuse or delete",
+      "type": "array",
+      "items": {
+        "title": "Partition options",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "search": {
+            "description": "The search is applied only to the partitions of the selected device",
+            "$ref": "#/$defs/search"
+          },
+          "create": {
+            "title": "Options to create the partition",
+            "description": "These options are ignored if the partition already exists",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "title": "Partition ID",
+                "enum": ["linux", "swap", "lvm", "raid", "esp", "prep", "biosBoot"]
+              },
+              "type": {
+                "title": "Partition type",
+                "enum": ["primary", "logical"]
+              }
+            }
+          },
+          "encrypt": {
+            "description": "The partition is encrypted only if it is going to be created",
+            "$ref": "#/$defs/encrypt"
+          },
+          "format": {
+            "$ref": "#/$defs/format"
+          },
+          "mount": {
+            "description": "The partition is mounted only if it is formatted",
+            "$ref": "#/$defs/mount"
+          }
+        }
+      }
     }
   }
 }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -758,10 +758,6 @@
                 "title": "Partition ID",
                 "enum": ["linux", "swap", "lvm", "raid", "esp", "prep", "biosBoot"]
               },
-              "type": {
-                "title": "Partition type",
-                "enum": ["primary", "logical"]
-              },
               "size": {
                 "title": "Partition size",
                 "$ref": "#/$defs/sizeValue"

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -514,23 +514,7 @@
                     }
                   },
                   "filesystem": {
-                    "title": "File system of the volume.",
-                    "anyOf": [
-                      {
-                        "$ref": "#/$defs/filesystemType"
-                      },
-                      {
-                        "title": "Btrfs file system.",
-                        "type": "object",
-                        "additionalProperties": false,
-                        "required": ["btrfs"],
-                        "properties": {
-                          "btrfs": {
-                            "$ref": "#/$defs/btrfsOptions"
-                          }
-                        }
-                      }
-                    ]
+                    "$ref": "#/$defs/filesystemType"
                   },
                   "size": {
                     "$ref": "#/$defs/size"
@@ -812,22 +796,34 @@
       ]
     },
     "filesystemType": {
-      "title": "File system type.",
-      "enum": [
-        "bcachefs", "btrfs", "exfat", "ext2", "ext3", "ext4", "f2fs", "jfs",
-        "nfs", "nilfs2", "ntfs", "reiserfs", "swap", "tmpfs", "vfat", "xfs"
-      ]
-    },
-    "btrfsOptions": {
-      "title": "Btrfs file system options.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "snapshots": {
-          "title": "Whether Btrfs snapshots should be configured.",
-          "type": "boolean"
+      "title": "File system type",
+      "anyOf": [
+        {
+          "enum": [
+            "bcachefs", "btrfs", "exfat", "ext2", "ext3", "ext4", "f2fs", "jfs",
+            "nfs", "nilfs2", "ntfs", "reiserfs", "swap", "tmpfs", "vfat", "xfs"
+          ]
+        },
+        {
+          "title": "Btrfs file system",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["btrfs"],
+          "properties": {
+            "btrfs": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "snapshots": {
+                  "title": "Btrfs snapshots",
+                  "description": "Whether Btrfs snapshots should be configured.",
+                  "type": "boolean"
+                }
+              }
+            }
+          }
         }
-      }
+      ]
     },
     "filesystem": {
       "title": "File system options.",
@@ -850,9 +846,6 @@
           "title": "Mount path.",
           "type": "string",
           "examples": ["/dev/vda"]
-        },
-        "btrfsOptions": {
-          "$ref": "#/$defs/btrfsOptions"
         },
         "mkfsOptions": {
           "title": "Options for creating the file system.",

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -864,6 +864,10 @@
           "type": "string",
           "examples": ["/dev/vda"]
         },
+        "mountBy": {
+          "title": "How to mount the device",
+          "enum": ["device", "id", "label", "path", "uuid"]
+        },
         "mkfsOptions": {
           "title": "mkfs options",
           "description": "Options for creating the file system.",

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -355,6 +355,8 @@
         },
         "guided": {
           "title": "Settings to execute a Guided Proposal.",
+          "deprecated": true,
+          "$comment": "Guided settings will be removed from the schema.",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -406,11 +408,11 @@
               "required": ["password"],
               "properties": {
                 "password": {
-                  "title": "Passphrase to use when creating a new encryption device.",
-                  "type": "string"
+                  "$ref": "#/$defs/encryptionPassword"
                 },
                 "method": {
-                  "$ref": "#/$defs/encryptionMethod"
+                  "title": "Method used to encrypt the devices.",
+                  "enum": ["luks2", "tpm_fde"]
                 },
                 "pbkdFunction": {
                   "$ref": "#/$defs/encryptionPbkdFunction"
@@ -705,45 +707,109 @@
         }
       }
     },
-    "encryptionMethod": {
-      "title": "Method used to create the encryption device.",
-      "enum": ["luks2", "tpm_fde"]
+    "encryptionPassword": {
+      "title": "Passphrase to use when creating a new encryption device.",
+      "type": "string"
+    },
+    "encryptionCipher": {
+      "title": "Cipher used for LUKS encryption.",
+      "description": "The value must be compatible with the --cipher argument of the command cryptsetup.",
+      "type": "string"
+    },
+    "encryptionKeySize": {
+      "title": "Key size, in bits, used for LUKS encryption.",
+      "description": "The value has to be a multiple of 8. The possible key sizes are limited by the used cipher.",
+      "type": "integer"
     },
     "encryptionPbkdFunction": {
       "title": "Password-based key derivation function to use for LUKS2.",
       "enum": ["pbkdf2", "argon2i", "argon2id"]
     },
-    "encryption": {
-      "title": "Encryption options.",
+    "encryptionLUKS1": {
+      "title": "LUKS1 encryption.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["key"],
+      "required": ["luks1"],
       "properties": {
-        "key": {
-          "title": "Passphrase to use when creating a new encryption device.",
-          "type": "string"
-        },
-        "method": {
-          "$ref": "#/$defs/encryptionMethod"
-        },
-        "pbkdFunction": {
-          "$ref": "#/$defs/encryptionPbkdFunction"
-        },
-        "label": {
-          "title": "LUKS label for the encrypted device.",
-          "type": "string"
-        },
-        "cipher": {
-          "title": "Cipher used for LUKS encryption.",
-          "description": "The value must be compatible with the --cipher argument of the command cryptsetup.",
-          "type": "string"
-        },
-        "key_size": {
-          "title": "Key size, in bits, used for LUKS encryption.",
-          "description": "The value has to be a multiple of 8. The possible key sizes are limited by the used cipher.",
-          "type": "integer"
+        "luks1": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["password"],
+          "properties": {
+            "password": {
+              "$ref": "#/$defs/encryptionPassword"
+            },
+            "cipher": {
+              "$ref": "#/$defs/encryptionCipher"
+            },
+            "keySize": {
+              "$ref": "#/$defs/encryptionKeySize"
+            }
+          }
         }
       }
+    },
+    "encryptionLUKS2": {
+      "title": "LUKS2 encryption.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["luks2"],
+      "properties": {
+        "luks2": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["password"],
+          "properties": {
+            "password": {
+              "$ref": "#/$defs/encryptionPassword"
+            },
+            "cipher": {
+              "$ref": "#/$defs/encryptionCipher"
+            },
+            "keySize": {
+              "$ref": "#/$defs/encryptionKeySize"
+            },
+            "pbkdFunction": {
+              "$ref": "#/$defs/encryptionPbkdFunction"
+            },
+            "label": {
+              "title": "LUKS label for the encrypted device.",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "encryptionPervasiveLUKS2": {
+      "title": "LUKS2 pervasive encryption.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pervasiveLuks2"],
+      "properties": {
+        "pervasiveLuks2": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["password"],
+          "properties": {
+            "password": {
+              "$ref": "#/$defs/encryptionPassword"
+            }
+          }
+        }
+      }
+    },
+    "encryptionSwap": {
+      "title": "Swap encryption.",
+      "enum": ["protected_swap", "secure_swap", "random_swap"]
+    },
+    "encryption": {
+      "title": "Encryption options.",
+      "anyOf": [
+        { "$ref": "#/$defs/encryptionLUKS1" },
+        { "$ref": "#/$defs/encryptionLUKS2" },
+        { "$ref": "#/$defs/encryptionPervasiveLUKS2" },
+        { "$ref": "#/$defs/encryptionSwap" }
+      ]
     },
     "filesystemType": {
       "title": "File system type.",

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 27 13:57:35 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Schema definition for basic storage settings
+  (gh#openSUSE/agama#1455).
+
+-------------------------------------------------------------------
 Mon Aug 26 11:19:27 UTC 2024 - Martin Vidner <mvidner@suse.com>
 
 - For CLI, use HTTP clients instead of D-Bus clients,
@@ -190,7 +196,7 @@ Fri Jun  7 05:58:48 UTC 2024 - Michal Filka <mfilka@suse.com>
   - self-signed certificate contains hostname
   - self-signed certificate is stored into default location
   - before creating new self-signed certificate a default location
-    (/etc/agama.d/ssl) is checked for a certificate 
+    (/etc/agama.d/ssl) is checked for a certificate
   - gh#openSUSE/agama#1228
 
 -------------------------------------------------------------------


### PR DESCRIPTION
Extend JSON schema to partially support the new *storage config* described in this document: https://github.com/openSUSE/agama/blob/master/doc/auto_storage.md.

This PR only extends the schema for the most basic settings (i.e., *boot*, *drives* and *partitions*). Settings for advanced searches, delete devices, creeate RAIDs, etc are not considered yet.

Notes:

* The *search* section added in this PR is based on the following proposal: https://gist.github.com/joseivanlopez/4f2381eb1f6c3aca562aadc2ad920a72?permalink_comment_id=5121860#gistcomment-5121860. This will be revisited later.
* The *guided* schema added by https://github.com/openSUSE/agama/pull/1263 is not going to be offered (e.g., *$ agama config load* will not understand it). The *storage config* will cover all the use cases and features provided by the *guided config*.
* The *guided config* will be used only by clients (e.g., web UI) to easily configure a subset of the use cases supported by the *storage config*.
