### PR TITLE
Autosubmit to OBS also the agama-integration-tests package

### DIFF
--- a/.github/workflows/obs-staging-integration-tests.yml
+++ b/.github/workflows/obs-staging-integration-tests.yml
@@ -1,0 +1,22 @@
+name: Submit agama-integration-tests
+
+on:
+  # runs on pushes targeting the default branch
+  push:
+    branches:
+      - master
+    paths:
+      # run only when a source file is changed
+      - puppeteer/**
+
+  # allow running manually
+  workflow_dispatch:
+
+jobs:
+  update_staging:
+    uses: ./.github/workflows/obs-staging-shared.yml
+    # pass all secrets
+    secrets: inherit
+    with:
+      package_name: agama-integration-tests
+      service_file: puppeteer/package/_service


### PR DESCRIPTION
- This adds automation for submitting the `agama-integration-tests` package to the Devel OBS project.
- Based on [obs-staging-playwright.yml](https://github.com/openSUSE/agama/blob/master/.github/workflows/obs-staging-playwright.yml)