### PR TITLE
Live ISO autosubmission needs obs-service-format_spec_file package

### DIFF
--- a/.github/workflows/obs-staging-live.yml
+++ b/.github/workflows/obs-staging-live.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install tools
         run: zypper --non-interactive install --no-recommends
-             findutils git make osc
+             findutils git make osc obs-service-format_spec_file
 
       - name: Git Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

- Fixes [broken autosubmission](https://github.com/openSUSE/agama/actions/runs/9992973765/job/27619282726#step:12:5)