### PR TITLE
Downgrade Puppeteer from 22.13.1 to 22.13.0

### DIFF
--- a/puppeteer/package-lock.json
+++ b/puppeteer/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "chai": "^5.1.1",
         "mocha": "^10.6.0",
-        "puppeteer": "^22.13.0"
+        "puppeteer": "22.13.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -109,18 +109,18 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.4.tgz",
-      "integrity": "sha512-BdG2qiI1dn89OTUUsx2GZSpUzW+DRffR1wlMJyKxVHYrhnKoELSDxDd+2XImUkuWPEKk76H5FcM/gPFrEK1Tfw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.3.tgz",
+      "integrity": "sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==",
       "dependencies": {
-        "debug": "^4.3.5",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.4.0",
-        "semver": "^7.6.2",
-        "tar-fs": "^3.0.6",
-        "unbzip2-stream": "^1.4.3",
-        "yargs": "^17.7.2"
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.4.0",
+        "semver": "7.6.0",
+        "tar-fs": "3.0.5",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.2"
       },
       "bin": {
         "browsers": "lib/cjs/main-cli.js"
@@ -141,6 +141,27 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/@puppeteer/browsers/node_modules/yargs": {
       "version": "17.7.2",
@@ -503,9 +524,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.1.tgz",
-      "integrity": "sha512-kSxJRj0VgtUKz6nmzc2JPfyfJGzwzt65u7PqhPHtgGQUZLF5oG+ST6l6e5ONfStUMAlhSutFCjaGKllXZa16jA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.0.tgz",
+      "integrity": "sha512-VnxVrpGojAjkiGFN2I+KtsDILFAjiGWVEDizOEnKzEDkT93eQT1cqTfUkqmOyLq33i1q4a1KDYbH+52CUe4Ufw==",
       "dependencies": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "10.0.0",
@@ -1413,15 +1434,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.13.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.13.1.tgz",
-      "integrity": "sha512-PwXLDQK5u83Fm5A7TGMq+9BR7iHDJ8a3h21PSsh/E6VfhxiKYkU7+tvGZNSCap6k3pCNDd9oNteVBEctcBalmQ==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.13.0.tgz",
+      "integrity": "sha512-nmICzeHTBtZiu+y4vs0fboe/NKIFwH5W8RZuxmEVAKNfBQg/8u5FEQAvPlWmyVpJoAVM5kXD5PEl3GlK3F9pPA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.2.4",
+        "@puppeteer/browsers": "2.2.3",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1299070",
-        "puppeteer-core": "22.13.1"
+        "puppeteer-core": "22.13.0"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -1431,12 +1452,12 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.13.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.13.1.tgz",
-      "integrity": "sha512-NmhnASYp51QPRCAf9n0OPxuPMmzkKd8+2sB9Q+BjwwCG25gz6iuNc3LQDWa+cH2tyivmJppLhNNFt6Q3HmoOpw==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.13.0.tgz",
+      "integrity": "sha512-ZkpRX8nm/S39BnpcCverMzIc6oGWBPOUeOeaWRLKHqiKVCZ1l28HxPTYLitJlDiB16xZATSKpjul+sl+ZEm0HQ==",
       "dependencies": {
-        "@puppeteer/browsers": "2.2.4",
-        "chromium-bidi": "0.6.1",
+        "@puppeteer/browsers": "2.2.3",
+        "chromium-bidi": "0.6.0",
         "debug": "^4.3.5",
         "devtools-protocol": "0.0.1299070",
         "ws": "^8.18.0"
@@ -1505,11 +1526,25 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -1635,9 +1670,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
+      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -1767,6 +1802,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -1914,18 +1954,18 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.4.tgz",
-      "integrity": "sha512-BdG2qiI1dn89OTUUsx2GZSpUzW+DRffR1wlMJyKxVHYrhnKoELSDxDd+2XImUkuWPEKk76H5FcM/gPFrEK1Tfw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.3.tgz",
+      "integrity": "sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==",
       "requires": {
-        "debug": "^4.3.5",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.4.0",
-        "semver": "^7.6.2",
-        "tar-fs": "^3.0.6",
-        "unbzip2-stream": "^1.4.3",
-        "yargs": "^17.7.2"
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.4.0",
+        "semver": "7.6.0",
+        "tar-fs": "3.0.5",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.2"
       },
       "dependencies": {
         "cliui": {
@@ -1937,6 +1977,19 @@
             "strip-ansi": "^6.0.1",
             "wrap-ansi": "^7.0.0"
           }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "yargs": {
           "version": "17.7.2",
@@ -2198,9 +2251,9 @@
       }
     },
     "chromium-bidi": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.1.tgz",
-      "integrity": "sha512-kSxJRj0VgtUKz6nmzc2JPfyfJGzwzt65u7PqhPHtgGQUZLF5oG+ST6l6e5ONfStUMAlhSutFCjaGKllXZa16jA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.0.tgz",
+      "integrity": "sha512-VnxVrpGojAjkiGFN2I+KtsDILFAjiGWVEDizOEnKzEDkT93eQT1cqTfUkqmOyLq33i1q4a1KDYbH+52CUe4Ufw==",
       "requires": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "10.0.0",
@@ -2834,23 +2887,23 @@
       }
     },
     "puppeteer": {
-      "version": "22.13.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.13.1.tgz",
-      "integrity": "sha512-PwXLDQK5u83Fm5A7TGMq+9BR7iHDJ8a3h21PSsh/E6VfhxiKYkU7+tvGZNSCap6k3pCNDd9oNteVBEctcBalmQ==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.13.0.tgz",
+      "integrity": "sha512-nmICzeHTBtZiu+y4vs0fboe/NKIFwH5W8RZuxmEVAKNfBQg/8u5FEQAvPlWmyVpJoAVM5kXD5PEl3GlK3F9pPA==",
       "requires": {
-        "@puppeteer/browsers": "2.2.4",
+        "@puppeteer/browsers": "2.2.3",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1299070",
-        "puppeteer-core": "22.13.1"
+        "puppeteer-core": "22.13.0"
       }
     },
     "puppeteer-core": {
-      "version": "22.13.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.13.1.tgz",
-      "integrity": "sha512-NmhnASYp51QPRCAf9n0OPxuPMmzkKd8+2sB9Q+BjwwCG25gz6iuNc3LQDWa+cH2tyivmJppLhNNFt6Q3HmoOpw==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.13.0.tgz",
+      "integrity": "sha512-ZkpRX8nm/S39BnpcCverMzIc6oGWBPOUeOeaWRLKHqiKVCZ1l28HxPTYLitJlDiB16xZATSKpjul+sl+ZEm0HQ==",
       "requires": {
-        "@puppeteer/browsers": "2.2.4",
-        "chromium-bidi": "0.6.1",
+        "@puppeteer/browsers": "2.2.3",
+        "chromium-bidi": "0.6.0",
         "debug": "^4.3.5",
         "devtools-protocol": "0.0.1299070",
         "ws": "^8.18.0"
@@ -2893,9 +2946,22 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
+      }
     },
     "serialize-javascript": {
       "version": "6.0.2",
@@ -2983,9 +3049,9 @@
       }
     },
     "tar-fs": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
+      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
       "requires": {
         "bare-fs": "^2.1.1",
         "bare-path": "^2.1.0",
@@ -3084,6 +3150,11 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/puppeteer/package.json
+++ b/puppeteer/package.json
@@ -3,6 +3,6 @@
   "dependencies": {
     "chai": "^5.1.1",
     "mocha": "^10.6.0",
-    "puppeteer": "^22.13.0"
+    "puppeteer": "22.13.0"
   }
 }

--- a/puppeteer/package/agama-integration-tests.changes
+++ b/puppeteer/package/agama-integration-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 19 10:18:37 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Downgrade Puppeteer from 22.13.1 to 22.13.0, the latest version
+  fails to start with the Firefox browser (gh#openSUSE/agama#1485)
+
+-------------------------------------------------------------------
 Tue Jul 16 13:25:52 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Initial version


### PR DESCRIPTION
## Problem

- The latest version 22.13.1 fails to start with the Firefox browser :-(
- With Chromium it works fine
- It crashes with this error when starting the test:
```
ProtocolError: Protocol error (session.new): invalid argument Expected [object String]
"unhandledPromptBehavior" to be a string, got [object Object] {"default":"ignore"}
RemoteError@chrome://remote/content/shared/RemoteError.sys.mjs:8:8
```

## Solution

- Downgrade to 22.13.0

## Details

- I have tracked that down to [this commit](https://github.com/puppeteer/puppeteer/commit/28d86688a825157a58f24f662dd3871896183777#diff-814c5c298beedb9132f44e37f06c2e3595ab67b2bd07f74741eb2860df0f7f34R75) which was added in 22.13.1
- The `^22.13.0` version actually means latest 22.x.x higher or equal to 22.13.0 which currently means 22.13.1
-  With `22.13.0` we explicitly pin to that specific version

## Testing

- Tested manually, with 22.13.0 the test starts fine

