### PR TITLE
Updated CI integration test

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -29,17 +29,20 @@ jobs:
         fetch-tags: true
 
     - name: Created shared YaST log directory
-      run: mkdir -p /tmp/log/YaST2
+      run: mkdir -p /tmp/log/YaST2 /tmp/log/puppeteer
 
     - name: Start container
-      run: podman run --privileged --detach --name agama --ipc=host -e CI -e GITHUB_ACTIONS -v /dev:/dev -v .:/checkout -v /tmp/log/YaST2:/var/log/YaST2 registry.opensuse.org/systemsmanagement/agama/staging/containers/opensuse/agama-testing:latest
+      run: podman run --privileged --detach --name agama --ipc=host -e CI -e GITHUB_ACTIONS -v /dev:/dev -v .:/checkout -v /tmp/log/puppeteer:/var/log/puppeteer -v /tmp/log/YaST2:/var/log/YaST2 registry.opensuse.org/systemsmanagement/agama/devel/containers/opensuse/agama-testing:latest
 
     - name: Environment
       run:  podman exec agama bash -c "env | sort"
 
-    - name: Set a testing Agama configuration
-      # delete all products except TW to skip the product selection at the beginning
-      run:  podman exec agama bash -c "ls /checkout/products.d/*.yaml | grep -v tumbleweed.yaml | xargs rm"
+    - name: Packages
+      run:  podman exec agama bash -c "rpm -qa | sort"
+
+    - name: Set the root password
+      # this allows to login into Agama
+      run:  podman exec agama bash -c "echo linux | passwd --stdin"
 
     - name: Build the frontend
       run:  podman exec agama bash -c "cd /checkout; ./setup-web.sh"
@@ -68,13 +71,16 @@ jobs:
     - name: Run the Agama smoke test
       run:  podman exec agama curl http://localhost
 
-    - name: Check Playwright version
-      run:  podman exec agama playwright --version
+    - name: Run the Puppeteer tests
+      # update the test file and the runner script from git
+      run:  podman exec agama bash -c
+            "cp /checkout/puppeteer/tests/test_root_password.js /usr/share/agama/integration-tests/tests &&
+            cp /checkout/puppeteer/agama-integration-tests /usr/bin/agama-integration-tests"
 
-    - name: Run the Playwright tests
-      # user authentication is not required when cockpit runs a local session
-      # run the tests in the Chromium browser
-      run:  podman exec agama bash -c "cd /checkout/playwright && SKIP_LOGIN=true playwright test --trace on --project chromium"
+    - name: Run the Puppeteer tests
+      # run the test
+      run:  podman exec agama bash -c "cd /var/log/puppeteer &&
+            agama-integration-tests /usr/share/agama/integration-tests/tests/test_root_password.js"
 
     - name: Again show the D-Bus services log
       # run even when any previous step fails
@@ -82,15 +88,14 @@ jobs:
       run:  podman exec agama journalctl
 
     - name: Upload the test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       # run even when any previous step fails
       if: always()
       with:
         name: test-results
         retention-days: 30
         path: |
-          playwright/test-results/**/*
-          /tmp/log/YaST2/y2log
+          /tmp/log
 
     - name: IRC notification
       # see https://github.com/marketplace/actions/irc-message-action

--- a/puppeteer/agama-integration-tests
+++ b/puppeteer/agama-integration-tests
@@ -1,16 +1,28 @@
-#! /usr/bin/sh
+#! /usr/bin/bash
+
+# A helper script for running the Puppeteer integration tests.
+#
+# Usage:
+#    agama-integration-tests [mochajs-options] <path-to-test>
 
 # exit on error, unset variables are an error
 set -eu
 
 MYDIR=$(realpath "$(dirname "$0")")
 
+# options passed to mocha.js:
+# --bail: stop at the first failure (otherwise the test would continue and very
+# likely fail at the next steps as well, this prevents from false alarms)
+# --slow: report tests as slow when they take more than 10 seconds, the default
+# is 75ms which is too small for Agama
+MOCHA_OPTIONS=(--bail --slow 10000)
+
 if [ -e "$MYDIR/../.git/" ]; then
-  PUPPETEER_SKIP_DOWNLOAD=true npm install --omit=optional
-  npx mocha --bail "$@"
+  npm install --omit=optional
+  npx mocha "${MOCHA_OPTIONS[@]}" "$@"
 else
   # set the default load path
   export NODE_PATH=/usr/share/agama/integration-tests/node_modules
   # run the CLI script directly, npm/npx might not be installed
-  /usr/bin/env node /usr/share/agama/integration-tests/node_modules/mocha/bin/mocha.js --bail "$@"
+  /usr/bin/env node /usr/share/agama/integration-tests/node_modules/mocha/bin/mocha.js "${MOCHA_OPTIONS[@]}" "$@"
 fi

--- a/puppeteer/tests/test_root_password.js
+++ b/puppeteer/tests/test_root_password.js
@@ -4,6 +4,12 @@ import path from "path";
 import puppeteer from "puppeteer-core";
 import { expect } from "chai";
 
+// This is an example file for running Agama integration tests using Puppeteer.
+//
+// If the test fails it saves the page screenshot and the HTML page dump to
+// ./log/ subdirectory.
+// For more details about customization see the README.md file.
+
 // helper function for converting String to Boolean
 function booleanEnv(name, default_value) {
   const env = process.env[name];


### PR DESCRIPTION
## Problem

- The old integration test did not work and has been disabled

## Solution

- Switch the test from Playwright to Puppeteer

## Testing

- The [test run](https://github.com/openSUSE/agama/actions/runs/10053959779/job/27787662876) is green now
- If the test fails the screenshot and the HTML page dump is included in the uploaded artifacts archive

