### PR TITLE
fix(web): drop software client leftovers

### DIFF
--- a/web/src/client/software.js
+++ b/web/src/client/software.js
@@ -76,43 +76,6 @@ class SoftwareBaseClient {
   constructor(client) {
     this.client = client;
   }
-
-  /**
-   * Asks the service to reload the repositories metadata
-   *
-   * @return {Promise<Response>}
-   */
-  probe() {
-    return this.client.post("/software/probe", {});
-  }
-
-  /**
-   * @return {Promise<SoftwareConfig>}
-   */
-  config() {
-    return this.client.get("/software/config");
-  }
-
-  /**
-   * @param {Object.<string, boolean>} patterns - An object where the keys are the pattern names
-   *   and the values whether to install them or not.
-   * @return {Promise<Response>}
-   */
-  selectPatterns(patterns) {
-    return this.client.put("/software/config", { patterns });
-  }
-
-  /**
-   * Registers a callback to run when the select product changes.
-   *
-   * @param {(changes: object) => void} handler - Callback function.
-   * @return {import ("./http").RemoveFn} Function to remove the callback.
-   */
-  onSelectedPatternsChanged(handler) {
-    return this.client.onEvent("SoftwareProposalChanged", ({ patterns }) => {
-      handler(patterns);
-    });
-  }
 }
 
 /**

--- a/web/src/client/software.js
+++ b/web/src/client/software.js
@@ -26,21 +26,6 @@ import { WithProgress, WithStatus } from "./mixins";
 const SOFTWARE_SERVICE = "org.opensuse.Agama.Software1";
 
 /**
- * Enum for the reasons to select a pattern
- *
- * @readonly
- * @enum { number }
- */
-const SelectedBy = Object.freeze({
-  /** Selected by the user */
-  USER: 0,
-  /** Automatically selected as a dependency of another package */
-  AUTO: 1,
-  /** No selected */
-  NONE: 2,
-});
-
-/**
  * @typedef {object} Product
  * @property {string} id - Product ID (e.g., "Leap")
  * @property {string} name - Product name (e.g., "openSUSE Leap 15.4")
@@ -280,4 +265,4 @@ class ProductClient {
   }
 }
 
-export { ProductClient, SelectedBy, SoftwareClient };
+export { ProductClient, SoftwareClient };


### PR DESCRIPTION
https://github.com/openSUSE/agama/pull/1483 didn't drop dead software client methods that were replaced by queries. Let's do it now.