### PR TITLE
fix(web): drop dead code at product client

### DIFF
--- a/web/src/client/software.js
+++ b/web/src/client/software.js
@@ -96,56 +96,6 @@ class ProductClient {
   }
 
   /**
-   * Returns the list of available products.
-   *
-   * @return {Promise<Array<Product>>}
-   */
-  async getAll() {
-    const response = await this.client.get("/software/products");
-    if (!response.ok) {
-      console.log("Failed to get software products: ", response);
-    }
-    return response.json();
-  }
-
-  /**
-   * Returns the identifier of the selected product.
-   *
-   * @return {Promise<string>} Selected identifier.
-   */
-  async getSelected() {
-    const response = await this.client.get("/software/config");
-    if (!response.ok) {
-      console.log("Failed to get software config: ", response);
-    }
-    const config = await response.json();
-    return config.product;
-  }
-
-  /**
-   * Selects a product for installation.
-   *
-   * @param {string} id - Product ID.
-   */
-  async select(id) {
-    await this.client.put("/software/config", { product: id });
-  }
-
-  /**
-   * Registers a callback to run when the select product changes.
-   *
-   * @param {(id: string) => void} handler - Callback function.
-   * @return {import ("./http").RemoveFn} Function to remove the callback.
-   */
-  onChange(handler) {
-    return this.client.onEvent("ProductChanged", ({ id }) => {
-      if (id) {
-        handler(id);
-      }
-    });
-  }
-
-  /**
    * Returns the registration of the selected product.
    *
    * @return {Promise<import('~/types/registration').Registration>}

--- a/web/src/client/software.test.js
+++ b/web/src/client/software.test.js
@@ -74,29 +74,6 @@ const microos = {
 };
 
 describe("ProductClient", () => {
-  describe("#getAll", () => {
-    it("returns the list of available products", async () => {
-      const http = new HTTPClient(new URL("http://localhost"));
-      const client = new ProductClient(http);
-      mockJsonFn.mockResolvedValue([tumbleweed, microos]);
-      const products = await client.getAll();
-      expect(products).toEqual([
-        { id: "Tumbleweed", name: "openSUSE Tumbleweed", description: "Tumbleweed is..." },
-        { id: "MicroOS", name: "openSUSE MicroOS", description: "MicroOS is..." },
-      ]);
-    });
-  });
-
-  describe("#getSelected", () => {
-    it("returns the selected product", async () => {
-      const http = new HTTPClient(new URL("http://localhost"));
-      const client = new ProductClient(http);
-      mockJsonFn.mockResolvedValue({ product: "microos" });
-      const selected = await client.getSelected();
-      expect(selected).toEqual("microos");
-    });
-  });
-
   describe("#getRegistration", () => {
     describe("if the product is not registered yet", () => {
       it("returns the expected registration result", async () => {


### PR DESCRIPTION
Drop dead code that was replaced by its equivalent using TanStack Query. See https://github.com/openSUSE/agama/pull/1454.