### PR TITLE
fix(web): Added missing type data for "module.hot" calls

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -9,7 +9,7 @@
     "allowJs": true,
     "jsx": "react",
     "allowSyntheticDefaultImports": true,
-    "types": ["node", "jest", "@testing-library/jest-dom"],
+    "types": ["node", "jest", "@testing-library/jest-dom", "webpack-env"],
     "paths": {
       "~/*": ["src/*"],
       "~/client": ["src/client/index.js"],


### PR DESCRIPTION
## Problem

- RPM build [fails with this error](https://build.opensuse.org/package/live_build_log/systemsmanagement:Agama:Devel/agama-web-ui/openSUSE_Tumbleweed/x86_64):
  ```
  ERROR in /home/abuild/rpmbuild/BUILD/agama/src/context/installer.jsx
  ./src/context/installer.jsx 93:15-18
  [tsl] ERROR in /home/abuild/rpmbuild/BUILD/agama/src/context/installer.jsx(93,16)
      TS2339: Property 'hot' does not exist on type 'NodeModule'.
  ```
- It fails because the `module.hot` is not known

## Solution

- Explicitly load the types from the `@types/webpack-env` package
- Suggested solution found [here](https://stackoverflow.com/a/68539136)

## Testing

- Tested manually, the package now builds with `osc build` locally 

