### PR TITLE
feat(live): Increase the available disk space in the Live system

### DIFF
--- a/live/root/etc/systemd/system/live-free-space.service
+++ b/live/root/etc/systemd/system/live-free-space.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Delete a temporary file to have more disk space
+
+[Service]
+ExecStart=rm -f /var/lib/live_free_space
+Type=oneshot
+
+[Install]
+WantedBy=default.target

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 25 13:18:38 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Increase the available disk space in the Live system to allow
+  installing additional development or debugging tools
+
+-------------------------------------------------------------------
 Fri Jul 19 09:43:06 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add a new profile for SLE-based distributions

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -3,6 +3,7 @@ Thu Jul 25 13:18:38 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Increase the available disk space in the Live system to allow
   installing additional development or debugging tools
+  (gh#openSUSE/agama#1501)
 
 -------------------------------------------------------------------
 Fri Jul 19 09:43:06 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -45,6 +45,7 @@ systemctl enable agama-welcome-issue.service
 systemctl enable agama-avahi-issue.service
 systemctl enable agama-ssh-issue.service
 systemctl enable agama-self-update.service
+systemctl enable live-free-space.service
 systemctl enable live-password-cmdline.service
 systemctl enable live-password-dialog.service
 systemctl enable live-password-iso.service
@@ -86,6 +87,16 @@ fi
 
 # replace the @@LIVE_MEDIUM_LABEL@@ with the real Live partition label name from KIWI
 sed -i -e "s/@@LIVE_MEDIUM_LABEL@@/$label/g" /usr/bin/live-password
+
+# Increase the Live ISO image size to have some extra free space for installing
+# additional debugging or development packages.
+#
+# Unfortunately Kiwi does not allow to configure the image size for the "iso"
+# build target (it can do  that for "oem"). As a workaround here we create a big
+# sparse file which in reality takes just little space in the image but Kiwi
+# uses its virtual size for estimating the needed filesystem size.
+# The file is later deleted at boot by the live-free-space service.
+dd bs=1 count=1 seek=2G if=/dev/zero of=/var/lib/live_free_space
 
 ################################################################################
 # Reducing the used space


### PR DESCRIPTION
## Problem

- If you want to install additional packages or you want to copy a manually built Rust binary then you might have trouble with not enough free disk space in the Live ISO
- This test shows that the available space in the default image is about 0.5GB:
```
# df -h /
Filesystem           Size  Used Avail Use% Mounted on
/dev/mapper/live-rw  2.4G  1.8G  398M  83% /
# dd bs=1M if=/dev/zero of=/take_space
dd: error writing '/take_space': No space left on device
522+0 records in
521+0 records out
546709504 bytes (547 MB, 521 MiB) copied, 0.750277 s, 729 MB/s
```

## Solution

- Unfortunately it seems Kiwi does not support manually changing the default value
- As a workaround create a huge sparse file which in reality takes tiny fraction of it's size
- Kiwi evaluates the apparent (virtual) file sizes when computing the size of the image so it makes the image bigger
- During testing I found out that after deleting the sparse file you can actually get even some more free space
- So I created a new systemd service which deletes the created file at boot

## Testing

- The build ISO image has a similar size as before, the sparse file does not increase the ISO size 
- Tested manually, with the fix there is about 3.4GB free space now:
```
# df -h /
Filesystem           Size  Used Avail Use% Mounted on
/dev/mapper/live-rw  5.3G  1.9G  3.2G  37% /
# dd bs=1M if=/dev/zero of=/take_space
dd: error writing '/take_space': No space left on device
3522+0 records in
3521+0 records out
3692621824 bytes (3.7 GB, 3.4 GiB) copied, 3.87284 s, 953 MB/s
```

## Notes

- The writes to the system are kept in RAM, that means to fully use the new 3.4GB disk space the machine needs more than 4GB RAM!



