### PR TITLE
fix(ci): avoid accidetally adding NPM TGZ source files to OBS

### DIFF
--- a/.github/workflows/obs-staging-shared.yml
+++ b/.github/workflows/obs-staging-shared.yml
@@ -95,7 +95,7 @@ jobs:
         # sometimes the "osc service" run does not cleanup properly all
         # downloaded NPM package tarballs and they are accidentally added to the
         # OBS package, so delete any TGZ files present
-        run: rm -f *.tgz
+        run: rm -vf *.tgz
         working-directory: ./${{ vars.OBS_PROJECT }}/${{ inputs.package_name }}
 
       - name: Check status

--- a/.github/workflows/obs-staging-shared.yml
+++ b/.github/workflows/obs-staging-shared.yml
@@ -91,6 +91,13 @@ jobs:
         run: osc service manualrun
         working-directory: ./${{ vars.OBS_PROJECT }}/${{ inputs.package_name }}
 
+      - name: Cleanup
+        # sometimes the "osc service" run does not cleanup properly all
+        # downloaded NPM package tarballs and they are accidentally added to the
+        # OBS package, so delete any TGZ files present
+        run: rm -f *.tgz
+        working-directory: ./${{ vars.OBS_PROJECT }}/${{ inputs.package_name }}
+
       - name: Check status
         run: osc addremove && osc diff && osc status
         working-directory: ./${{ vars.OBS_PROJECT }}/${{ inputs.package_name }}


### PR DESCRIPTION
## Problem

- Sometimes a TGZ file is accidentally added to the OBS package sources, [see an example](https://build.opensuse.org/package/show/systemsmanagement:Agama:Devel/agama-integration-tests?rev=4)
- I guess that the `osc service` for some reason does not delete all downloaded NPM packages and leaves them there
- Then they are submitted with the usual package sources


## Solution

- To avoid this problem always delete all `*.tgz` files before submitting the package to OBS