### PR TITLE
Live: Fixed building the PXE image

### DIFF
--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -184,7 +184,7 @@
         <package name="ca-certificates"/>
         <package name="ca-certificates-mozilla"/>
     </packages>
-    <packages type="bootstrap" profiles="openSUSE">
+    <packages type="bootstrap" profiles="openSUSE,openSUSE-PXE">
         <package name="openSUSE-release"/>
         <package name="openSUSE-release-ftp"/>
     </packages>


### PR DESCRIPTION
## Problem

- The PXE image does not build in OBS
 - There is a dependency problem:
```
unresolvable: have choice for product_flavor(openSUSE) needed by openSUSE-release:
openSUSE-release-appliance openSUSE-release-appliance-custom openSUSE-release-appliance-docker
openSUSE-release-appliance-hyperv openSUSE-release-appliance-kvm openSUSE-release-appliance-openstack
openSUSE-release-appliance-vagrant openSUSE-release-appliance-vmware openSUSE-release-appliance-wsl
openSUSE-release-dvd openSUSE-release-ftp openSUSE-release-livecd-gnome openSUSE-release-livecd-kde
openSUSE-release-livecd-x11 openSUSE-release-livecd-xfce openSUSE-release-usb-gnome openSUSE-release-usb-kde
openSUSE-release-usb-x11
```

## Solution

- Use the same release packages also for the PXE flavor

## Testing

- Tested manually, the local build was fine
