### PR TITLE
fix(live): One more PXE build fix

### DIFF
--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -158,7 +158,7 @@
         <archive name="root.tar.xz"/>
     </packages>
     <!-- additional packages for the openSUSE distributions -->
-    <packages type="image" profiles="openSUSE">
+    <packages type="image" profiles="openSUSE,openSUSE-PXE">
         <package name="agama-products-opensuse"/>
         <package name="grub2-branding-openSUSE" arch="aarch64,x86_64"/>
         <package name="openSUSE-repos-Tumbleweed"/>


### PR DESCRIPTION
## Problem

The PXE build now fails with this error:
```
[  125s] + rpm --import '/usr/lib/rpm/gnupg/keys/*.asc'
[  125s] error: /usr/lib/rpm/gnupg/keys/*.asc: import read failed(2).
```

## Solution

- Install the same packages as for default Live ISO
- The fix is similar to #1505 