### PR TITLE
fix(obs): Require at least 8GB RAM for building the Rust package in OBS

### DIFF
--- a/rust/package/_constraints
+++ b/rust/package/_constraints
@@ -1,7 +1,12 @@
 <constraints>
   <hardware>
+    <jobs>4</jobs>
     <disk>
       <size unit="G">20</size>
     </disk>
+    <physicalmemory>
+      <size unit="G">8</size>
+    </physicalmemory>
   </hardware>
+  <hostlabel exclude="true">SLOW_CPU</hostlabel>
 </constraints>


### PR DESCRIPTION


## Problem

- The build on PPC or S390 might fail in OBS because of insufficient RAM in the worker

## Solution

- Require at least 8GB RAM in the worker
- Additionally require at least 4 parallel jobs (the build on S390 takes ages with just 2 jobs...)

## Notes

- Inspired by this [example file](https://build.opensuse.org/projects/openSUSE:Factory/packages/wpewebkit/files/_constraints?expand=1)
- More details in the [OBS documentation](https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-build-constraints#constraint-syntax)
- Let's see how it helps, we might fine tune the config later again...
