### PR TITLE
fix(web): add missing option to tsconfig file

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "./",
+    "outDir": "dist/",
     "isolatedModules": true,
     "target": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
There were a lot of `Cannot write file '<path>.js' because it would overwrite input file.` TypeScript complaints apparently because the lack of the [`outDir`](https://www.typescriptlang.org/tsconfig/#outDir) option in the _tsconfig.json_ file to avoid the `.js` files overwrite.

This PR sets the `outDir` to the same directory than webpack build, although another option would be to simply exclude `.js` having in mind that the goal is to migrate all of them to `.ts`. Anyway, it's a temporary problem already solved with the mentioned `outDir` option.


![image](https://github.com/user-attachments/assets/d4855cfb-0377-4557-bdc8-4bcc330524ab)
