### PR TITLE
Update nokogiri dependency to version 1.16

### DIFF
--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       cheetah (~> 1.0.0)
       eventmachine (~> 1.2.7)
       fast_gettext (~> 2.3.0)
-      nokogiri (~> 1.15.4)
+      nokogiri (~> 1.16.6)
       rexml (~> 3.2.5)
       ruby-dbus (>= 0.23.1, < 1.0)
 
@@ -22,19 +22,18 @@ GEM
       cfa (~> 1.0)
     cheetah (1.0.0)
       abstract_method (~> 1.2)
-    diff-lcs (1.5.0)
-    docile (1.4.0)
+    diff-lcs (1.5.1)
+    docile (1.4.1)
     eventmachine (1.2.7)
     fast_gettext (2.3.0)
-    mini_portile2 (2.8.5)
-    nokogiri (1.15.5)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     packaging_rake_tasks (1.5.4)
       rake
-    racc (1.7.3)
+    racc (1.8.1)
     rake (13.0.6)
-    rexml (3.2.6)
+    rexml (3.2.9)
+      strscan
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -58,7 +57,8 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
-    yard (0.9.34)
+    strscan (3.1.0)
+    yard (0.9.36)
 
 PLATFORMS
   x86_64-linux
@@ -75,4 +75,4 @@ DEPENDENCIES
   yard (~> 0.9.0)
 
 BUNDLED WITH
-   2.4.22
+   2.5.11

--- a/service/agama-yast.gemspec
+++ b/service/agama-yast.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cheetah", "~> 1.0.0"
   spec.add_dependency "eventmachine", "~> 1.2.7"
   spec.add_dependency "fast_gettext", "~> 2.3.0"
-  spec.add_dependency "nokogiri", "~> 1.15.4"
+  spec.add_dependency "nokogiri", "~> 1.16.6"
   spec.add_dependency "rexml", "~> 3.2.5"
   spec.add_dependency "ruby-dbus", ">= 0.23.1", "< 1.0"
 end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 31 15:48:00 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Update nokogiri dependency to version 1.16
+  (gh#openSUSE/agama#1518)
+
+-------------------------------------------------------------------
 Mon Jul 22 15:26:48 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - AutoYaST convert script: use Agama questions to report errors


### PR DESCRIPTION
## Problem

The Live ISO does not build because of this problem:
```
nothing provides rubygem(ruby:3.3.0:nokogiri:1.15) >= 1.15.4 needed by ruby3.3-rubygem-agama-yast
```

## Solution

- The [nokogiri gem](https://build.opensuse.org/package/show/openSUSE:Factory/rubygem-nokogiri) has been updated to 1.16.6

## Testing

- Tested manually, I have updated the nokogiri gem manually in the Live ISO and Agama works fine with that