### PR TITLE
feat(live): Display QR codes at the console for easier accessing Agama with smartphones

### DIFF
--- a/live/root/usr/bin/agama-issue-generator
+++ b/live/root/usr/bin/agama-issue-generator
@@ -139,6 +139,91 @@ generate_avahi_url() {
     done
 }
 
+# function for centering text
+# $1 - the text
+# $2 - requested width
+function center_text() {
+  LEN=${#1}
+  PADDING_LEN=$(($2 - LEN))
+  PADDING_LEN=$((PADDING_LEN / 2))
+  PADDING="$(printf '%*s' $PADDING_LEN)"
+  echo "$PADDING$1$PADDING"
+}
+
+# generate QR codes for the access URLs
+function create_qr_codes() {
+    ADDRESSES=("$@")
+    # width of the generated QR code
+    QR_WIDTH=30
+
+    # check if serial console is used, get the terminal size (width)
+    TERM_WIDTH=$(stty -F /dev/ttyS0 size 2> /dev/null | cut -d " " -f 2)
+
+    # otherwise check the first console size
+    if [ -z "$TERM_WIDTH" ]; then
+      TERM_WIDTH=$(stty -F /dev/tty1 size 2> /dev/null | cut -d " " -f 2)
+      echo "Linux console width $TERM_WIDTH"
+    else
+      echo "Serial console width $TERM_WIDTH"
+    fi
+
+    # display QR codes only if the terminal is bigger than the 80x24(25) default
+    if [ -n "$TERM_WIDTH" ] && [ "$TERM_WIDTH" -gt 80 ]; then
+      # compute how much QR codes can fit on the screen side-by-side
+      QR_NUM=$(( TERM_WIDTH / QR_WIDTH ))
+      # split the list into 2 parts, for the first part display the QR codes
+      QR_ADDRESSES=("${ADDRESSES[@]:0:$QR_NUM}")
+      SZ="${#ADDRESSES[@]}"
+      # for the rest display just the text URL
+      REST_ADDRESSES=("${ADDRESSES[@]:$QR_NUM:$SZ}")
+    else
+      QR_ADDRESSES=()
+      REST_ADDRESSES=("${ADDRESSES[@]}")
+    fi
+
+    if [ -n "${REST_ADDRESSES[*]}" ]; then
+      printf "    https://%s\n" "${REST_ADDRESSES[@]}" >> "$URL_ISSUES"
+    fi
+
+    if [ -z "${QR_ADDRESSES[*]}" ]; then
+      return 0
+    fi
+
+    # temporary file for generated QR code
+    QR_TEMP=$(mktemp)
+    # temporary file for merged QR codes (displayed side-by-side)
+    QR_RESULT=$(mktemp)
+    # copy of the merged QR codes (the merged file cannot be used as input and
+    # output at the same time)
+    QR_RESULT_COPY=$(mktemp)
+
+    # label with URLs displayed below the QR codes
+    LABEL=""
+
+    # generate the QR codes and merge them side-by-side
+    for ADDR in "${QR_ADDRESSES[@]}"; do
+      cp "$QR_RESULT" "$QR_RESULT_COPY"
+      URL="https://$ADDR"
+      echo "Rendering QR code for $URL"
+      # force (the -v option) using at least symbol version 2 (QR size 25x25),
+      # for short addresses (like https://1.1.1.1) it would be enough using
+      # version 1 (QR size 21x21), but longer addresses need version 2 and
+      # putting different sizes side-by-side breaks formatting, see `man
+      # qrencode` and https://www.qrcode.com/en/about/version.html
+      qrencode -t ANSIUTF8 -m 2 -v 2 -o "$QR_TEMP" "$URL"
+      # put the QR codes side-by-side
+      paste -d " " "$QR_RESULT_COPY" "$QR_TEMP" > "$QR_RESULT"
+      PADDED_URL=$(center_text "$URL" "$QR_WIDTH")
+      LABEL="$LABEL$PADDED_URL "
+    done
+
+    cat "$QR_RESULT" >> "$URL_ISSUES"
+    echo "$LABEL" >> "$URL_ISSUES"
+
+    # delete the temporary files
+    rm -f "$QR_TEMP" "$QR_RESULT_COPY" "$QR_RESULT"
+}
+
 # helper function, write the issue with the currently available URLs for
 # accessing Agama from outside
 build_addresses() {
@@ -158,11 +243,11 @@ build_addresses() {
   # remove duplicates
   readarray -t ADDRESSES < <(printf "%s\n" "${ADDRESSES[@]}" | sort -u)
 
+  # delete the old file
+  rm -f "$URL_ISSUES"
+
   if [ -n "${ADDRESSES[*]}" ]; then
-    printf "    https://%s\n" "${ADDRESSES[@]}" > "$URL_ISSUES"
-  else
-    # no messages, delete the URLs
-    rm -f "$URL_ISSUES"
+    create_qr_codes "${ADDRESSES[@]}"
   fi
 
   write_url_headers
@@ -185,6 +270,7 @@ generate_network_url() {
   type=signal" 2> /dev/null | while read -r line; do
     # some IP4 configuration has been changed, rebuild the URLs
     if echo "$line" | grep -q 'string "org.freedesktop.NetworkManager.IP4Config"'; then
+      echo "Network configuration changed"
       build_addresses
     fi
   done

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -155,6 +155,7 @@
         <package name="libtss2-tcti-device0"/>
         <package name="jq"/>
         <package name="yast2-schema"/>
+        <package name="qrencode"/>
         <archive name="root.tar.xz"/>
     </packages>
     <!-- additional packages for the openSUSE distributions -->


### PR DESCRIPTION
## Problem

- Make accessing Agama easier for smartphones by scanning an QR code
- And this is a pretty cool feature for advertising Agama!  :smiley: 

## Solution

- Use the `qrencode` tool for generating the QR codes as text (it uses special UTF-8 graphical symbols)
- Display the codes side-by-side with URL below them
- If there is not enough space the QR codes are displayed only for the subset of the URLs, the other URLs are displayed just as text  without QR code. That means the QR codes always displayed in a single line.
- When running on serial console or when on the VGA plain text console the QR codes are not displayed (the terminal width must be greater than 80 to display them)
- The codes are refreshed whenever the network configuration is changed (see the video at the end)
- Tested manually

## Notes

The root password is randomly generated so the system actually knows the password. I was thinking about rendering URLs with embedded password (something like `https://1.2.3.4?password=PASSWORD`) so then using a smartphone would be even easier.

But that has some security drawbacks. The terminal already contains the root password, but you would need to be close to the screen to get it. On the other hand QR codes are designed for robustness, the QR code might be blurred, some part can be missing but the scanner will still be able to get the full content. That means you do not need to be next to the screen, the risk of eavesdropping for QR is higher than for a plain text password.

We could discuss that with the security team...

## Screenshots

| Standard resolution, 1 network device  | |
| -- | -- |
| ![qr_1dev](https://github.com/user-attachments/assets/fc00f5d4-b2a0-4433-a885-314b559d5904) | |
| Standard resolution, 4 network devices  | Smaller resolution, 4 network devices, only 3 QR codes displayed |
| ![qr_4devs](https://github.com/user-attachments/assets/599d511a-c367-4db0-9554-58979d9e01b6) | ![qr_4devs_800](https://github.com/user-attachments/assets/52b41919-7e30-45f4-bf6a-32307a204062)  |
| Serial console (80x24), 4 network devices, no QR code displayed | VGA text mode (80x25), 4 network devices, no QR code displayed |
| ![qr_4devs_serial](https://github.com/user-attachments/assets/ff805458-5663-4c45-b123-239be4d6ae1d) | ![qr_4devs_text](https://github.com/user-attachments/assets/33c32632-25cb-415b-bb9c-699bbcb9f49c) |

Dynamically adding network connections (activating 3 more network interfaces)

[Agama-screen0.webm](https://github.com/user-attachments/assets/c17c9c3a-c74b-4fd3-ac6a-87bbc2298e0f)
