### PR TITLE
fix(web): make useProductChanges work as expected

### DIFF
--- a/web/src/queries/software.ts
+++ b/web/src/queries/software.ts
@@ -188,7 +188,7 @@ const useProductChanges = () => {
     if (!client) return;
 
     return client.ws().onEvent((event) => {
-      if (event.type === "") {
+      if (event.type === "ProductChanged") {
         queryClient.invalidateQueries({ queryKey: ["software/config"] });
       }
     });


### PR DESCRIPTION
By mistake, https://github.com/openSUSE/agama/pull/1483 introduced a tiny bug in the `useProductChanges` query hook by checking the `event.type` against an empty string instead of the exepected `ProductChanged` event.

https://github.com/openSUSE/agama/pull/1483/files#diff-e671c06f4a1cefe3bef4af838681c780f2ba41356d44f72f5ce97be1b6eead66R172-R185

This PR fixes it for properly performs the software config query invalidation.