### PR TITLE
refactor(web): use `axios` instead of `fetch`

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "@patternfly/react-core": "^5.1.1",
         "@patternfly/react-table": "^5.1.1",
         "@tanstack/react-query": "^5.49.2",
+        "axios": "^1.7.3",
         "fast-sort": "^3.4.0",
         "ipaddr.js": "^2.1.0",
         "react": "^18.2.0",
@@ -5929,8 +5930,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/attr-accept": {
       "version": "2.2.2",
@@ -5953,6 +5953,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -6810,7 +6821,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -8087,7 +8097,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -10143,7 +10152,6 @@
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -10200,7 +10208,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -14517,7 +14524,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14526,7 +14532,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -16061,6 +16066,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/web/package.json
+++ b/web/package.json
@@ -110,6 +110,7 @@
     "@patternfly/react-core": "^5.1.1",
     "@patternfly/react-table": "^5.1.1",
     "@tanstack/react-query": "^5.49.2",
+    "axios": "^1.7.3",
     "fast-sort": "^3.4.0",
     "ipaddr.js": "^2.1.0",
     "react": "^18.2.0",

--- a/web/src/api/http.ts
+++ b/web/src/api/http.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import axios from "axios";
+
+const http = axios.create({
+  responseType: "json",
+});
+
+/**
+ * Retrieves the object from given URL
+ *
+ * @param url - HTTP URL
+ * @return data from the response body
+ */
+const get = (url: string) => http.get(url).then(({ data }) => data);
+
+/**
+ * Performs a PATCH request with the given URL and data
+ *
+ * @param url - endpoint URL
+ * @param data - Request payload
+ */
+const patch = (url: string, data: object) => http.patch(url, data);
+
+/**
+ * Performs a PUT request with the given URL and data
+ *
+ * @param url - endpoint URL
+ * @param data - request payload
+ */
+const put = (url: string, data: object) => http.put(url, data);
+
+/**
+ * Performs a POST request with the given URL and data
+ *
+ * @param url - endpoint URL
+ * @param data - request payload
+ */
+const post = (url: string, data: object) => http.post(url, data);
+
+/**
+ * Performs a DELETE request on the given URL
+ *
+ * @param url - endpoint URL
+ * @param data - request payload
+ */
+const del = (url: string) => http.delete(url);
+
+export { get, patch, post, put, del };

--- a/web/src/api/issues.ts
+++ b/web/src/api/issues.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { get } from "~/api/http";
+import { IssuesScope } from "~/types/issues";
+
+const URLS = {
+  product: "software/issues/product",
+  software: "software/issues/software",
+  users: "users/issues",
+  storage: "storage/issues",
+};
+
+/**
+ * Return the issues of the given scope.
+ */
+const fetchIssues = (scope: IssuesScope) => get(`/api/${URLS[scope]}`);
+
+export { fetchIssues };

--- a/web/src/api/issues.ts
+++ b/web/src/api/issues.ts
@@ -20,7 +20,7 @@
  */
 
 import { get } from "~/api/http";
-import { IssuesScope } from "~/types/issues";
+import { Issue, IssuesScope } from "~/types/issues";
 
 const URLS = {
   product: "software/issues/product",
@@ -32,6 +32,6 @@ const URLS = {
 /**
  * Return the issues of the given scope.
  */
-const fetchIssues = (scope: IssuesScope) => get(`/api/${URLS[scope]}`);
+const fetchIssues = (scope: IssuesScope): Promise<Issue[]> => get(`/api/${URLS[scope]}`);
 
 export { fetchIssues };

--- a/web/src/api/l10n.ts
+++ b/web/src/api/l10n.ts
@@ -26,7 +26,7 @@ import { timezoneUTCOffset } from "~/utils";
 /**
  * Returns the l10n configuration
  */
-const fetchConfig = () => get("/api/l10n/config");
+const fetchConfig = (): Promise<LocaleConfig> => get("/api/l10n/config");
 
 /**
  * Returns the list of known locales for installation

--- a/web/src/api/l10n.ts
+++ b/web/src/api/l10n.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { get, patch } from "~/api/http";
+import { Keymap, Locale, LocaleConfig, Timezone } from "~/types/l10n";
+import { timezoneUTCOffset } from "~/utils";
+
+/**
+ * Returns the l10n configuration
+ */
+const fetchConfig = () => get("/api/l10n/config");
+
+/**
+ * Returns the list of known locales for installation
+ */
+const fetchLocales = async (): Promise<Locale[]> => {
+  const json = await get("/api/l10n/locales");
+  return json.map(({ id, language, territory }): Locale => {
+    return { id, name: language, territory };
+  });
+};
+
+/**
+ * Returns the list of known timezones
+ */
+const fetchTimezones = async (): Promise<Timezone[]> => {
+  const json = await get("/api/l10n/timezones");
+  return json.map(({ code, parts, country }): Timezone => {
+    const offset = timezoneUTCOffset(code);
+    return { id: code, parts, country, utcOffset: offset };
+  });
+};
+
+/**
+ * Returns the list of known keymaps
+ */
+const fetchKeymaps = async (): Promise<Keymap[]> => {
+  const json = await get("/api/l10n/keymaps");
+  const keymaps: Keymap[] = json.map(({ id, description }): Keymap => {
+    return { id, name: description };
+  });
+  return keymaps.sort((a, b) => (a.name < b.name ? -1 : 1));
+};
+
+/**
+ * Updates the l10n configuration for the system to install
+ *
+ * @param config - Localization configuration
+ */
+const updateConfig = (config: LocaleConfig) => patch("/api/l10n/config", config);
+
+export { fetchConfig, fetchKeymaps, fetchLocales, fetchTimezones, updateConfig };

--- a/web/src/api/progress.ts
+++ b/web/src/api/progress.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { get } from "~/api/http";
+import { APIProgress, Progress } from "~/types/progress";
+
+/**
+ * Returns the progress information for a given service
+ *
+ * At this point, the services that implement the progress API are
+ * "manager", "software" and "storage".
+ *
+ * @param service - Service to retrieve the progress from (e.g., "manager")
+ */
+const fetchProgress = async (service: string): Promise<Progress> => {
+  const progress: APIProgress = await get(`/api/${service}/progress`);
+  return Progress.fromApi(progress);
+};
+
+export { fetchProgress };

--- a/web/src/api/questions.ts
+++ b/web/src/api/questions.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { get, put } from "~/api/http";
+import { Answer, Question, QuestionType } from "~/types/questions";
+
+type APIQuestion = {
+  generic?: Question;
+  withPassword?: Pick<Question, "password">;
+};
+
+/**
+ * Internal method to build proper question objects
+ *
+ * TODO: improve/simplify it once the backend API is improved.
+ */
+function buildQuestion(httpQuestion: APIQuestion) {
+  const question: Question = { ...httpQuestion.generic };
+
+  if (httpQuestion.generic) {
+    question.type = QuestionType.generic;
+    question.answer = httpQuestion.generic.answer;
+  }
+
+  if (httpQuestion.withPassword) {
+    question.type = QuestionType.withPassword;
+    question.password = httpQuestion.withPassword.password;
+  }
+
+  return question;
+}
+
+/**
+ * Returns the list of questions
+ */
+const fetchQuestions = async (): Promise<Question[]> => {
+  const apiQuestions: APIQuestion[] = await get("/api/questions");
+  return apiQuestions.map(buildQuestion);
+};
+
+/**
+ * Update a questions' answer
+ *
+ * The answer is part of the Question object.
+ */
+const updateAnswer = async (question: Question): Promise<void> => {
+  const answer: Answer = { generic: { answer: question.answer } };
+
+  if (question.type === QuestionType.withPassword) {
+    answer.withPassword = { password: question.password };
+  }
+
+  await put(`/api/questions/${question.id}/answer`, answer);
+};
+
+export { fetchQuestions, updateAnswer };

--- a/web/src/api/software.ts
+++ b/web/src/api/software.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { Pattern, Product, SoftwareConfig, SoftwareProposal } from "~/types/software";
+import { get, put } from "~/api/http";
+
+/**
+ * Returns the software configuration
+ */
+const fetchConfig = (): Promise<SoftwareConfig> => get("/api/software/config");
+
+/**
+ * Returns the software proposal
+ */
+const fetchProposal = (): Promise<SoftwareProposal> => get("/api/software/proposal");
+
+/**
+ * Returns the list of known products
+ */
+const fetchProducts = (): Promise<Product[]> => get("/api/software/products");
+
+/**
+ * Returns the list of patterns for the selected product
+ */
+const fetchPatterns = (): Promise<Pattern[]> => get("/api/software/patterns");
+
+/**
+ * Updates the software configuration
+ *
+ * @param config - New software configuration
+ */
+const updateConfig = (config: SoftwareConfig) => put("/api/software/config", config);
+
+export { fetchConfig, fetchPatterns, fetchProposal, fetchProducts, updateConfig };

--- a/web/src/api/status.ts
+++ b/web/src/api/status.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { get } from "~/api/http";
+import { InstallerStatus } from "~/types/status";
+
+/**
+ * Returns the installer status information
+ */
+const fetchInstallerStatus = async (): Promise<InstallerStatus> => {
+  const { phase, isBusy, useIguana, canInstall } = await get("/api/manager/installer");
+  return { phase, isBusy, useIguana, canInstall };
+};
+
+export { fetchInstallerStatus };

--- a/web/src/api/users.ts
+++ b/web/src/api/users.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { del, get, patch, put } from "~/api/http";
+import { FirstUser, RootUser, RootUserChanges } from "~/types/users";
+
+/**
+ * Returns the first user's definition
+ */
+const fetchFirstUser = (): Promise<FirstUser> => get("/api/users/first");
+
+/**
+ * Updates the first user's definition
+ *
+ * @param user - Full first user's definition
+ */
+const updateFirstUser = (user: FirstUser) => put("/api/users/first", user);
+
+/**
+ * Removes the first user definition
+ */
+const removeFirstUser = () => del("/api/users/first");
+
+/**
+ * Returns the root user configuration
+ */
+const fetchRoot = (): Promise<RootUser> => get("/api/users/root");
+
+/**
+ * Updates the root user configuration
+ *
+ * @param changes - Changes to apply to the root user configuration
+ */
+const updateRoot = (changes: Partial<RootUserChanges>) => patch("/api/users/root", changes);
+
+export { fetchFirstUser, updateFirstUser, removeFirstUser, fetchRoot, updateRoot };

--- a/web/src/components/core/ProgressReport.jsx
+++ b/web/src/components/core/ProgressReport.jsx
@@ -35,13 +35,7 @@ import {
 
 import { _ } from "~/i18n";
 import { Center } from "~/components/layout";
-import {
-  progressQuery,
-  useProgress,
-  useProgressChanges,
-  useResetProgress,
-} from "~/queries/progress";
-import { useQuery } from "@tanstack/react-query";
+import { useProgress, useProgressChanges, useResetProgress } from "~/queries/progress";
 
 const Progress = ({ steps, step, firstStep, detail }) => {
   const stepProperties = (stepNumber) => {

--- a/web/src/queries/issues.ts
+++ b/web/src/queries/issues.ts
@@ -28,16 +28,8 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { useInstallerClient } from "~/context/installer";
-import { Issue, IssuesList } from "~/types/issues";
-
-type IssuesScope = "product" | "software" | "storage" | "users";
-
-const URLS = {
-  product: "software/issues/product",
-  software: "software/issues/software",
-  users: "users/issues",
-  storage: "storage/issues",
-};
+import { Issue, IssuesList, IssuesScope } from "~/types/issues";
+import { fetchIssues } from "~/api/issues";
 
 const scopesFromPath = {
   "/org/opensuse/Agama/Software1": "software",
@@ -49,15 +41,15 @@ const scopesFromPath = {
 const issuesQuery = (scope: IssuesScope) => {
   return {
     queryKey: ["issues", scope],
-    queryFn: () => fetch(`/api/${URLS[scope]}`).then((res) => res.json()),
+    queryFn: () => fetchIssues(scope),
   };
 };
 
 /**
  * Returns the issues for the given scope.
  *
- * @param {IssuesScope} scope - Scope to get the issues from.
- * @return {Issue[]}
+ * @param scope - Scope to get the issues from.
+ * @return issues for the given scope.
  */
 const useIssues = (scope: IssuesScope) => {
   const { data } = useSuspenseQuery(issuesQuery(scope));
@@ -74,12 +66,6 @@ const useAllIssues = () => {
 
   const [{ data: product }, { data: software }, { data: storage }, { data: users }] =
     useSuspenseQueries({ queries });
-  const list = {
-    product: product as Issue[],
-    software: software as Issue[],
-    storage: storage as Issue[],
-    users: users as Issue[],
-  };
   return new IssuesList(product, software, storage, users);
 };
 

--- a/web/src/queries/progress.ts
+++ b/web/src/queries/progress.ts
@@ -23,6 +23,7 @@ import React from "react";
 import { useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { useInstallerClient } from "~/context/installer";
 import { Progress } from "~/types/progress";
+import { fetchProgress } from "~/api/progress";
 
 const servicesMap = {
   "org.opensuse.Agama.Manager1": "manager",
@@ -41,10 +42,7 @@ const servicesMap = {
 const progressQuery = (service: string) => {
   return {
     queryKey: ["progress", service],
-    queryFn: () =>
-      fetch(`/api/${service}/progress`)
-        .then((res) => res.json())
-        .then((body) => Progress.fromApi(body)),
+    queryFn: () => fetchProgress(service),
   };
 };
 

--- a/web/src/queries/software.ts
+++ b/web/src/queries/software.ts
@@ -36,13 +36,20 @@ import {
   SoftwareConfig,
   SoftwareProposal,
 } from "~/types/software";
+import {
+  fetchConfig,
+  fetchPatterns,
+  fetchProducts,
+  fetchProposal,
+  updateConfig,
+} from "~/api/software";
 
 /**
  * Query to retrieve software configuration
  */
 const configQuery = () => ({
   queryKey: ["software/config"],
-  queryFn: () => fetch("/api/software/config").then((res) => res.json()),
+  queryFn: fetchConfig,
 });
 
 /**
@@ -50,7 +57,7 @@ const configQuery = () => ({
  */
 const proposalQuery = () => ({
   queryKey: ["software/proposal"],
-  queryFn: () => fetch("/api/software/proposal").then((res) => res.json()),
+  queryFn: fetchProposal,
 });
 
 /**
@@ -58,7 +65,7 @@ const proposalQuery = () => ({
  */
 const productsQuery = () => ({
   queryKey: ["software/products"],
-  queryFn: () => fetch("/api/software/products").then((res) => res.json()),
+  queryFn: fetchProducts,
   staleTime: Infinity,
 });
 
@@ -67,11 +74,7 @@ const productsQuery = () => ({
  */
 const selectedProductQuery = () => ({
   queryKey: ["software/product"],
-  queryFn: async () => {
-    const response = await fetch("/api/software/config");
-    const { product } = await response.json();
-    return product;
-  },
+  queryFn: () => fetchConfig().then(({ product }) => product),
 });
 
 /**
@@ -79,7 +82,7 @@ const selectedProductQuery = () => ({
  */
 const patternsQuery = () => ({
   queryKey: ["software/patterns"],
-  queryFn: () => fetch("/api/software/patterns").then((res) => res.json()),
+  queryFn: fetchPatterns,
 });
 
 /**
@@ -93,16 +96,8 @@ const useConfigMutation = () => {
   const client = useInstallerClient();
 
   const query = {
-    mutationFn: (newConfig: SoftwareConfig) =>
-      fetch("/api/software/config", {
-        // FIXME: use "PATCH" instead
-        method: "PUT",
-        body: JSON.stringify(newConfig),
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }),
-    onSuccess: (_, config: SoftwareConfig) => {
+    mutationFn: updateConfig,
+    onSuccess: (_: any, config: SoftwareConfig) => {
       queryClient.invalidateQueries({ queryKey: ["software/config"] });
       queryClient.invalidateQueries({ queryKey: ["software/proposal"] });
       if (config.product) {
@@ -126,7 +121,7 @@ const useProduct = (
     { data: products, isPending: isProductsPending },
   ] = func({
     queries: [selectedProductQuery(), productsQuery()],
-  });
+  }) as [{ data: string; isPending: boolean }, { data: Product[]; isPending: boolean }];
 
   if (isSelectedPending || isProductsPending) {
     return {};

--- a/web/src/queries/status.ts
+++ b/web/src/queries/status.ts
@@ -73,7 +73,7 @@ const useInstallerStatusChanges = () => {
 
       if (type === "ServiceStatusChanged" && event.service === MANAGER_SERVICE) {
         const { status } = event;
-        queryClient.setQueryData(["status"], { ...data, busy: status === 1 });
+        queryClient.setQueryData(["status"], { ...data, isBusy: status === 1 });
       }
 
       if (type === "IssuesChanged") {

--- a/web/src/queries/status.ts
+++ b/web/src/queries/status.ts
@@ -21,6 +21,7 @@
 
 import { useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import React from "react";
+import { fetchInstallerStatus } from "~/api/status";
 import { useInstallerClient } from "~/context/installer";
 import { InstallerStatus } from "~/types/status";
 
@@ -31,13 +32,7 @@ const MANAGER_SERVICE = "org.opensuse.Agama.Manager1";
  */
 const statusQuery = () => ({
   queryKey: ["status"],
-  queryFn: (): Promise<InstallerStatus> =>
-    fetch(`/api/manager/installer`)
-      .then((res) => res.json())
-      .then((body) => {
-        const { phase, isBusy, useIguana, canInstall } = body;
-        return { phase, isBusy, useIguana, canInstall };
-      }),
+  queryFn: fetchInstallerStatus,
 });
 
 /**

--- a/web/src/queries/users.ts
+++ b/web/src/queries/users.ts
@@ -20,17 +20,24 @@
  */
 
 import React from "react";
-import { QueryClient, useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { useInstallerClient } from "~/context/installer";
 import { _ } from "~/i18n";
-import { FirstUser, RootUser, RootUserChanges } from "~/types/users";
+import { RootUser, RootUserChanges } from "~/types/users";
+import {
+  fetchFirstUser,
+  fetchRoot,
+  removeFirstUser,
+  updateFirstUser,
+  updateRoot,
+} from "~/api/users";
 
 /**
  * Returns a query for retrieving the first user configuration
  */
 const firstUserQuery = () => ({
   queryKey: ["users", "firstUser"],
-  queryFn: () => fetch("/api/users/first").then((res) => res.json()),
+  queryFn: fetchFirstUser,
 });
 
 /**
@@ -47,20 +54,7 @@ const useFirstUser = () => {
 const useFirstUserMutation = () => {
   const queryClient = useQueryClient();
   const query = {
-    mutationFn: (user: FirstUser) =>
-      fetch("/api/users/first", {
-        method: "PUT",
-        body: JSON.stringify({ ...user, data: {} }),
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }).then((response) => {
-        if (response.ok) {
-          return response.json();
-        } else {
-          throw new Error(_("Please, try again"));
-        }
-      }),
+    mutationFn: updateFirstUser,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["users", "firstUser"] }),
   };
   return useMutation(query);
@@ -69,13 +63,7 @@ const useFirstUserMutation = () => {
 const useRemoveFirstUserMutation = () => {
   const queryClient = useQueryClient();
   const query = {
-    mutationFn: () =>
-      fetch("/api/users/first", {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }),
+    mutationFn: removeFirstUser,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["users", "firstUser"] });
     },
@@ -113,7 +101,7 @@ const useFirstUserChanges = () => {
  */
 const rootUserQuery = () => ({
   queryKey: ["users", "root"],
-  queryFn: () => fetch("/api/users/root").then((res) => res.json()),
+  queryFn: fetchRoot,
 });
 
 const useRootUser = () => {
@@ -127,14 +115,7 @@ const useRootUser = () => {
 const useRootUserMutation = () => {
   const queryClient = useQueryClient();
   const query = {
-    mutationFn: (changes: Partial<RootUserChanges>) =>
-      fetch("/api/users/root", {
-        method: "PATCH",
-        body: JSON.stringify({ ...changes, passwordEncrypted: false }),
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }),
+    mutationFn: updateRoot,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["users", "root"] }),
   };
   return useMutation(query);

--- a/web/src/types/issues.ts
+++ b/web/src/types/issues.ts
@@ -20,6 +20,11 @@
  */
 
 /**
+ * Known scopes for issues.
+ */
+type IssuesScope = "product" | "software" | "storage" | "users";
+
+/**
  * Source of the issue
  *
  * Which is the origin of the issue (the system, the configuration or unknown).
@@ -80,4 +85,4 @@ class IssuesList {
 }
 
 export { IssueSource, IssuesList, IssueSeverity };
-export type { Issue };
+export type { Issue, IssuesScope };

--- a/web/src/types/l10n.ts
+++ b/web/src/types/l10n.ts
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
 type Keymap = {
   /**
    * Keyboard id (e.g., "us").
@@ -42,3 +63,29 @@ type Timezone = {
    */
   utcOffset: number;
 };
+
+type LocaleConfig = {
+  /**
+   * List of locales to install (e.g., ["en_US.UTF-8"]).
+   */
+  locales?: string[];
+  /**
+   * Selected keymap for installation (e.g., "en").
+   */
+  keymap?: string;
+  /**
+   * Selected timezone for installation (e.g., "Atlantic/Canary").
+   */
+  timezone?: string;
+
+  /**
+   * Locale to be used in the UI.
+   */
+  ui_locale?: string;
+  /**
+   * Locale to be used in the UI.
+   */
+  ui_keymap?: string;
+};
+
+export type { Keymap, Locale, Timezone, LocaleConfig };

--- a/web/src/types/progress.ts
+++ b/web/src/types/progress.ts
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-type ProgressApi = {
+type APIProgress = {
   currentStep: number;
   maxSteps: number;
   currentTitle: string;
@@ -43,7 +43,7 @@ class Progress {
     this.steps = steps;
   }
 
-  static fromApi(progress: ProgressApi) {
+  static fromApi(progress: APIProgress) {
     const {
       currentStep: current,
       maxSteps: total,
@@ -56,3 +56,4 @@ class Progress {
 }
 
 export { Progress };
+export type { APIProgress };


### PR DESCRIPTION
* Use [axios](https://axios-http.com/) instead of `fetch` as it implements a promise-based API which is better for our use case.
* Move the logic related to interacting with the API to an `API` module.
* Handle the `ServiceStatusChanged` signal properly.

## To do

- [x] software
- [x] l10n
- [x] users
- [x] issues
- [x] progress
- [x] status