### PR TITLE
doc(dbus): add documentation for the DASD-related interfaces

### DIFF
--- a/doc/dbus/bus/org.opensuse.Agama.Storage1.DASD.Device.bus.xml
+++ b/doc/dbus/bus/org.opensuse.Agama.Storage1.DASD.Device.bus.xml
@@ -1,0 +1,41 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/Agama/Storage1/dasds/1">
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="v"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="val" direction="in" type="v"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="a{sv}"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg name="interface" type="s"/>
+      <arg name="changed_properties" type="a{sv}"/>
+      <arg name="invalidated_properties" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.opensuse.Agama.Storage1.DASD.Device">
+    <property type="s" name="Id" access="read"/>
+    <property type="b" name="Enabled" access="read"/>
+    <property type="s" name="DeviceName" access="read"/>
+    <property type="b" name="Formatted" access="read"/>
+    <property type="b" name="Diag" access="read"/>
+    <property type="s" name="Status" access="read"/>
+    <property type="s" name="Type" access="read"/>
+    <property type="s" name="AccessType" access="read"/>
+    <property type="s" name="PartitionInfo" access="read"/>
+  </interface>
+</node>

--- a/doc/dbus/bus/org.opensuse.Agama.Storage1.DASD.Manager.bus.xml
+++ b/doc/dbus/bus/org.opensuse.Agama.Storage1.DASD.Manager.bus.xml
@@ -1,0 +1,121 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/Agama/Storage1">
+  <node name="Proposal" />
+  <node name="dasds" />
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="v"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="val" direction="in" type="v"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="a{sv}"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg name="interface" type="s"/>
+      <arg name="changed_properties" type="a{sv}"/>
+      <arg name="invalidated_properties" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.ObjectManager">
+    <method name="GetManagedObjects">
+      <arg name="res" direction="out" type="a{oa{sa{sv}}}"/>
+    </method>
+    <signal name="InterfacesAdded">
+      <arg name="object" type="o"/>
+      <arg name="interfaces_and_properties" type="a{sa{sv}}"/>
+    </signal>
+    <signal name="InterfacesRemoved">
+      <arg name="object" type="o"/>
+      <arg name="interfaces" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.opensuse.Agama1.Issues">
+    <property type="a(ssuu)" name="All" access="read"/>
+  </interface>
+  <interface name="org.opensuse.Agama1.Progress">
+    <property type="u" name="TotalSteps" access="read"/>
+    <property type="(us)" name="CurrentStep" access="read"/>
+    <property type="b" name="Finished" access="read"/>
+  </interface>
+  <interface name="org.opensuse.Agama1.ServiceStatus">
+    <property type="aa{sv}" name="All" access="read"/>
+    <property type="u" name="Current" access="read"/>
+  </interface>
+  <interface name="org.opensuse.Agama.Storage1">
+    <method name="Probe">
+    </method>
+    <method name="Install">
+    </method>
+    <method name="Finish">
+    </method>
+    <property type="b" name="DeprecatedSystem" access="read"/>
+  </interface>
+  <interface name="org.opensuse.Agama.Storage1.Proposal.Calculator">
+    <method name="DefaultVolume">
+      <arg name="mount_path" direction="in" type="s"/>
+      <arg name="volume" direction="out" type="a{sv}"/>
+    </method>
+    <method name="Calculate">
+      <arg name="settings" direction="in" type="a{sv}"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <property type="ao" name="AvailableDevices" access="read"/>
+    <property type="as" name="ProductMountPoints" access="read"/>
+    <property type="as" name="EncryptionMethods" access="read"/>
+    <property type="o" name="Result" access="read"/>
+  </interface>
+  <interface name="org.opensuse.Agama.Storage1.ISCSI.Initiator">
+    <method name="Discover">
+      <arg name="address" direction="in" type="s"/>
+      <arg name="port" direction="in" type="u"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <method name="Delete">
+      <arg name="node" direction="in" type="o"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <property type="s" name="InitiatorName" access="readwrite"/>
+    <property type="b" name="IBFT" access="read"/>
+  </interface>
+  <interface name="org.opensuse.Agama.Storage1.DASD.Manager">
+    <method name="Probe">
+    </method>
+    <method name="Enable">
+      <arg name="devices" direction="in" type="ao"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <method name="Disable">
+      <arg name="devices" direction="in" type="ao"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <method name="SetDiag">
+      <arg name="devices" direction="in" type="ao"/>
+      <arg name="diag" direction="in" type="b"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <method name="Format">
+      <arg name="devices" direction="in" type="ao"/>
+      <arg name="result" direction="out" type="u"/>
+      <arg name="job" direction="out" type="o"/>
+    </method>
+  </interface>
+  <interface name="org.opensuse.Agama.Storage1.ZFCP.Manager">
+    <method name="Probe">
+    </method>
+    <property type="b" name="AllowLUNScan" access="read"/>
+  </interface>
+</node>

--- a/doc/dbus/org.opensuse.Agama.Storage1.DASD.Device.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Storage1.DASD.Device.doc.xml
@@ -1,0 +1,58 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/Agama/Storage1/dasds/1">
+  <interface name="org.opensuse.Agama.Storage1.DASD.Device">
+    <!--
+        Id:
+        Device channel ID.
+    -->
+    <property type="s" name="Id" access="read"/>
+
+    <!--
+        Enabled:
+        Whether the device is enabled.
+    -->
+    <property type="b" name="Enabled" access="read"/>
+
+    <!--
+        DeviceName:
+        The associated device name. It is empty if the device is not enabled.
+    -->
+    <property type="s" name="DeviceName" access="read"/>
+
+    <!--
+        Formatted:
+        Whether the device is formatted.
+    -->
+    <property type="b" name="Formatted" access="read"/>
+
+    <!--
+        Diag:
+        Whether the DIAG access method is enabled.
+    -->
+    <property type="b" name="Diag" access="read"/>
+
+    <!--
+        Status:
+        The device status. It is empty if unknown.
+    -->
+    <property type="s" name="Status" access="read"/>
+
+    <!--
+        Type:
+        The DASD type ("ECKD" or "FBA"). It is empty if unknown.
+    -->
+    <property type="s" name="Type" access="read"/>
+
+    <!--
+        AccessType:
+        Device access type ("rw" or "ro"). It is empty if unknown.
+    -->
+    <property type="s" name="AccessType" access="read"/>
+    <!--
+        PartitionInfo:
+        Description of the partitions. It is empty if unknown.
+    -->
+    <property type="s" name="PartitionInfo" access="read"/>
+  </interface>
+</node>

--- a/doc/dbus/org.opensuse.Agama.Storage1.DASD.Manager.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Storage1.DASD.Manager.doc.xml
@@ -1,0 +1,54 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/Agama/Storage1">
+  <node name="Proposal" />
+  <node name="dasds" />
+  <interface name="org.opensuse.Agama.Storage1.DASD.Manager">
+    <!--
+        Probe:
+        Finds DASDs in the system and populates the D-Bus objects tree
+        accordingly.
+    -->
+    <method name="Probe">
+    </method>
+
+    <!--
+        Enable:
+        Enables the given list of DASDs.
+    -->
+    <method name="Enable">
+      <arg name="devices" direction="in" type="ao"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+
+    <!--
+        Disable:
+        Disables the given list of DASDs.
+    -->
+    <method name="Disable">
+      <arg name="devices" direction="in" type="ao"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+
+    <!--
+        SetDiag:
+        Sets the use_diag attribute for the given DASDs.
+    -->
+    <method name="SetDiag">
+      <arg name="devices" direction="in" type="ao"/>
+      <arg name="diag" direction="in" type="b"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+
+    <!--
+        Format:
+        Starts the formatting of the given DASDs. To keep track
+        of the progress check the jobs interface.
+    -->
+    <method name="Format">
+      <arg name="devices" direction="in" type="ao"/>
+      <arg name="result" direction="out" type="u"/>
+      <arg name="job" direction="out" type="o"/>
+    </method>
+  </interface>
+</node>


### PR DESCRIPTION
We rely on D-Bus introspection for code and documentation generation. While working in the adaption of the DASD-related code to the HTTP/API, we found out that DASD introspection (and documentation) files were missing.

This pull request adds the missing files.
