### PR TITLE
feat(rust): add an HTTP/JSON API to DASD operations

### DIFF
--- a/rust/agama-lib/src/jobs.rs
+++ b/rust/agama-lib/src/jobs.rs
@@ -1,0 +1,35 @@
+//! This module implements support for the so-called Jobs. It is a concept hat represents running
+//! an external command that may take some time, like formatting a DASD device. It is exposed via
+//! D-Bus and, at this time, only the storage service makes use of it.
+
+use std::collections::HashMap;
+
+use serde::Serialize;
+use zbus::zvariant::OwnedValue;
+
+use crate::{dbus::get_property, error::ServiceError};
+
+pub mod client;
+
+/// Represents a job.
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct Job {
+    /// Artificial job identifier.
+    pub id: String,
+    /// Whether the job is running.
+    pub running: bool,
+    /// Job exit code.
+    pub exit_code: u32,
+}
+
+impl TryFrom<&HashMap<String, OwnedValue>> for Job {
+    type Error = ServiceError;
+
+    fn try_from(value: &HashMap<String, OwnedValue>) -> Result<Self, Self::Error> {
+        Ok(Job {
+            running: get_property(value, "Running")?,
+            exit_code: get_property(value, "ExitCode")?,
+            ..Default::default()
+        })
+    }
+}

--- a/rust/agama-lib/src/jobs/client.rs
+++ b/rust/agama-lib/src/jobs/client.rs
@@ -1,0 +1,53 @@
+//! Implements a client to access Agama's Jobs API.
+
+use zbus::{fdo::ObjectManagerProxy, zvariant::OwnedObjectPath, Connection};
+
+use crate::error::ServiceError;
+
+use super::Job;
+
+#[derive(Clone)]
+pub struct JobsClient<'a> {
+    object_manager_proxy: ObjectManagerProxy<'a>,
+}
+
+impl<'a> JobsClient<'a> {
+    pub async fn new(
+        connection: Connection,
+        destination: &'static str,
+        path: &'static str,
+    ) -> Result<Self, ServiceError> {
+        let object_manager_proxy = ObjectManagerProxy::builder(&connection)
+            .destination(destination)?
+            .path(path)?
+            .build()
+            .await?;
+
+        Ok(Self {
+            object_manager_proxy,
+        })
+    }
+
+    pub async fn jobs(&self) -> Result<Vec<(OwnedObjectPath, Job)>, ServiceError> {
+        let managed_objects = self.object_manager_proxy.get_managed_objects().await?;
+
+        let mut jobs = vec![];
+        for (path, ifaces) in managed_objects {
+            let Some(properties) = ifaces.get("org.opensuse.Agama.Storage1.Job") else {
+                continue;
+            };
+
+            match Job::try_from(properties) {
+                Ok(mut job) => {
+                    job.id = path.to_string();
+                    jobs.push((path, job));
+                }
+                Err(error) => {
+                    log::warn!("Not a valid job: {}", error);
+                }
+            }
+        }
+
+        Ok(jobs)
+    }
+}

--- a/rust/agama-lib/src/lib.rs
+++ b/rust/agama-lib/src/lib.rs
@@ -27,6 +27,7 @@ pub mod auth;
 pub mod base_http_client;
 pub mod error;
 pub mod install_settings;
+pub mod jobs;
 pub mod localization;
 pub mod manager;
 pub mod network;

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -192,3 +192,29 @@ trait Locale {
     /// SetLocale method
     fn set_locale(&self, locale: &str) -> zbus::Result<()>;
 }
+
+#[dbus_proxy(
+    interface = "org.opensuse.Agama.Storage1.Job",
+    default_service = "org.opensuse.Agama.Storage1",
+    default_path = "/org/opensuse/Agama/Storage1/jobs"
+)]
+trait Job {
+    #[dbus_proxy(property)]
+    fn running(&self) -> zbus::Result<bool>;
+
+    #[dbus_proxy(property)]
+    fn exit_code(&self) -> zbus::Result<u32>;
+
+    #[dbus_proxy(signal)]
+    fn finished(&self, exit_code: u32) -> zbus::Result<()>;
+}
+
+#[dbus_proxy(
+    interface = "org.opensuse.Agama.Storage1.DASD.Format",
+    default_service = "org.opensuse.Agama.Storage1",
+    default_path = "/org/opensuse/Agama/Storage1/jobs/1"
+)]
+trait FormatJob {
+    #[dbus_proxy(property)]
+    fn summary(&self) -> zbus::Result<std::collections::HashMap<String, (u32, u32, bool)>>;
+}

--- a/rust/agama-lib/src/storage/client.rs
+++ b/rust/agama-lib/src/storage/client.rs
@@ -14,6 +14,7 @@ use zbus::fdo::ObjectManagerProxy;
 use zbus::names::{InterfaceName, OwnedInterfaceName};
 use zbus::zvariant::{OwnedObjectPath, OwnedValue};
 use zbus::Connection;
+pub mod dasd;
 pub mod iscsi;
 
 type DBusObject = (

--- a/rust/agama-lib/src/storage/client/dasd.rs
+++ b/rust/agama-lib/src/storage/client/dasd.rs
@@ -1,0 +1,100 @@
+//! Implements a client to access Agama's D-Bus API related to DASD management.
+
+use zbus::{
+    fdo::ObjectManagerProxy,
+    zvariant::{ObjectPath, OwnedObjectPath},
+    Connection,
+};
+
+use crate::{
+    error::ServiceError,
+    storage::{model::dasd::DASDDevice, proxies::DASDManagerProxy},
+};
+
+/// Client to connect to Agama's D-Bus API for DASD management.
+#[derive(Clone)]
+pub struct DASDClient<'a> {
+    manager_proxy: DASDManagerProxy<'a>,
+    object_manager_proxy: ObjectManagerProxy<'a>,
+}
+
+impl<'a> DASDClient<'a> {
+    pub async fn new(connection: Connection) -> Result<DASDClient<'a>, ServiceError> {
+        let manager_proxy = DASDManagerProxy::new(&connection).await?;
+        let object_manager_proxy = ObjectManagerProxy::builder(&connection)
+            .destination("org.opensuse.Agama.Storage1")?
+            .path("/org/opensuse/Agama/Storage1")?
+            .build()
+            .await?;
+        Ok(Self {
+            manager_proxy,
+            object_manager_proxy,
+        })
+    }
+
+    pub async fn probe(&self) -> Result<(), ServiceError> {
+        Ok(self.manager_proxy.probe().await?)
+    }
+
+    pub async fn devices(&self) -> Result<Vec<(OwnedObjectPath, DASDDevice)>, ServiceError> {
+        let managed_objects = self.object_manager_proxy.get_managed_objects().await?;
+
+        let mut devices: Vec<(OwnedObjectPath, DASDDevice)> = vec![];
+        for (path, ifaces) in managed_objects {
+            if let Some(properties) = ifaces.get("org.opensuse.Agama.Storage1.DASD.Device") {
+                match DASDDevice::try_from(properties) {
+                    Ok(device) => {
+                        devices.push((path, device));
+                    }
+                    Err(error) => {
+                        log::warn!("Not a valid DASD device: {}", error);
+                    }
+                }
+            }
+        }
+        Ok(devices)
+    }
+
+    pub async fn format(&self, ids: &[&str]) -> Result<(), ServiceError> {
+        let selected = self.find_devices(ids).await?;
+        let references = selected.iter().collect::<Vec<&ObjectPath<'_>>>();
+        self.manager_proxy.format(&references).await?;
+        Ok(())
+    }
+
+    pub async fn enable(&self, ids: &[&str]) -> Result<(), ServiceError> {
+        let selected = self.find_devices(ids).await?;
+        let references = selected.iter().collect::<Vec<&ObjectPath<'_>>>();
+        self.manager_proxy.enable(&references).await?;
+        Ok(())
+    }
+
+    pub async fn disable(&self, ids: &[&str]) -> Result<(), ServiceError> {
+        let selected = self.find_devices(ids).await?;
+        let references = selected.iter().collect::<Vec<&ObjectPath<'_>>>();
+        self.manager_proxy.disable(&references).await?;
+        Ok(())
+    }
+
+    pub async fn set_diag(&self, ids: &[&str], diag: bool) -> Result<(), ServiceError> {
+        let selected = self.find_devices(ids).await?;
+        let references = selected.iter().collect::<Vec<&ObjectPath<'_>>>();
+        self.manager_proxy.set_diag(&references, diag).await?;
+        Ok(())
+    }
+
+    async fn find_devices(&self, ids: &[&str]) -> Result<Vec<ObjectPath<'_>>, ServiceError> {
+        let devices = self.devices().await?;
+        let selected: Vec<ObjectPath> = devices
+            .into_iter()
+            .filter_map(|(path, device)| {
+                if ids.contains(&device.id.as_str()) {
+                    Some(path.into_inner())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Ok(selected)
+    }
+}

--- a/rust/agama-lib/src/storage/model.rs
+++ b/rust/agama-lib/src/storage/model.rs
@@ -5,6 +5,8 @@ use zbus::zvariant::{OwnedValue, Value};
 
 use crate::dbus::{get_optional_property, get_property};
 
+pub mod dasd;
+
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct DeviceSid(u32);
 

--- a/rust/agama-lib/src/storage/model/dasd.rs
+++ b/rust/agama-lib/src/storage/model/dasd.rs
@@ -1,0 +1,39 @@
+//! Implements a data model for DASD devices management.
+use std::collections::HashMap;
+
+use serde::Serialize;
+use zbus::zvariant::OwnedValue;
+
+use crate::{dbus::get_property, error::ServiceError};
+
+/// Represents a DASD device (specific to s390x systems).
+#[derive(Clone, Debug, Serialize, Default, utoipa::ToSchema)]
+pub struct DASDDevice {
+    pub id: String,
+    pub enabled: bool,
+    pub device_name: String,
+    pub formatted: bool,
+    pub diag: bool,
+    pub status: String,
+    pub device_type: String,
+    pub access_type: String,
+    pub partition_info: String,
+}
+
+impl TryFrom<&HashMap<String, OwnedValue>> for DASDDevice {
+    type Error = ServiceError;
+
+    fn try_from(value: &HashMap<String, OwnedValue>) -> Result<Self, Self::Error> {
+        Ok(DASDDevice {
+            id: get_property(value, "Id")?,
+            enabled: get_property(value, "Enabled")?,
+            device_name: get_property(value, "DeviceName")?,
+            formatted: get_property(value, "Formatted")?,
+            diag: get_property(value, "Diag")?,
+            status: get_property(value, "Status")?,
+            device_type: get_property(value, "Type")?,
+            access_type: get_property(value, "AccessType")?,
+            partition_info: get_property(value, "PartitionInfo")?,
+        })
+    }
+}

--- a/rust/agama-lib/src/storage/proxies.rs
+++ b/rust/agama-lib/src/storage/proxies.rs
@@ -156,3 +156,75 @@ trait Node {
     #[dbus_proxy(property)]
     fn target(&self) -> zbus::Result<String>;
 }
+
+#[dbus_proxy(
+    interface = "org.opensuse.Agama.Storage1.DASD.Manager",
+    default_service = "org.opensuse.Agama.Storage1",
+    default_path = "/org/opensuse/Agama/Storage1"
+)]
+trait DASDManager {
+    /// Disable method
+    fn disable(&self, devices: &[&zbus::zvariant::ObjectPath<'_>]) -> zbus::Result<u32>;
+
+    /// Enable method
+    fn enable(&self, devices: &[&zbus::zvariant::ObjectPath<'_>]) -> zbus::Result<u32>;
+
+    /// Format method
+    fn format(
+        &self,
+        devices: &[&zbus::zvariant::ObjectPath<'_>],
+    ) -> zbus::Result<(u32, zbus::zvariant::OwnedObjectPath)>;
+
+    /// Probe method
+    fn probe(&self) -> zbus::Result<()>;
+
+    /// SetDiag method
+    fn set_diag(
+        &self,
+        devices: &[&zbus::zvariant::ObjectPath<'_>],
+        diag: bool,
+    ) -> zbus::Result<u32>;
+}
+
+#[dbus_proxy(
+    interface = "org.opensuse.Agama.Storage1.DASD.Device",
+    default_service = "org.opensuse.Agama.Storage1",
+    assume_defaults = true
+)]
+trait DASDDevice {
+    /// AccessType property
+    #[dbus_proxy(property)]
+    fn access_type(&self) -> zbus::Result<String>;
+
+    /// DeviceName property
+    #[dbus_proxy(property)]
+    fn device_name(&self) -> zbus::Result<String>;
+
+    /// Diag property
+    #[dbus_proxy(property)]
+    fn diag(&self) -> zbus::Result<bool>;
+
+    /// Enabled property
+    #[dbus_proxy(property)]
+    fn enabled(&self) -> zbus::Result<bool>;
+
+    /// Formatted property
+    #[dbus_proxy(property)]
+    fn formatted(&self) -> zbus::Result<bool>;
+
+    /// Id property
+    #[dbus_proxy(property)]
+    fn id(&self) -> zbus::Result<String>;
+
+    /// PartitionInfo property
+    #[dbus_proxy(property)]
+    fn partition_info(&self) -> zbus::Result<String>;
+
+    /// Status property
+    #[dbus_proxy(property)]
+    fn status(&self) -> zbus::Result<String>;
+
+    /// Type property
+    #[dbus_proxy(property)]
+    fn type_(&self) -> zbus::Result<String>;
+}

--- a/rust/agama-server/src/storage/web/dasd.rs
+++ b/rust/agama-server/src/storage/web/dasd.rs
@@ -1,0 +1,176 @@
+//! This module implements the web API for the handling of DASD storage service.
+//!
+//! The module offers two public functions:
+//!
+//! * `dasd_service` which returns the Axum service.
+//! * `dasd_stream` which offers an stream that emits the DASD-related events coming from D-Bus.
+
+use agama_lib::{
+    error::ServiceError,
+    storage::{client::dasd::DASDClient, model::dasd::DASDDevice},
+};
+use axum::{
+    extract::State,
+    routing::{get, post, put},
+    Json, Router,
+};
+use serde::Deserialize;
+
+use crate::{error::Error, web::common::EventStreams};
+
+use self::stream::DASDDeviceStream;
+
+mod stream;
+
+/// Returns the stream of DASD-related events.
+///
+/// The stream combines the following events:
+///
+/// * Changes on the DASD devices collection.
+///
+/// * `dbus`: D-Bus connection to use.
+pub async fn dasd_stream(dbus: &zbus::Connection) -> Result<EventStreams, Error> {
+    let stream: EventStreams = vec![("dasd_devices", Box::pin(DASDDeviceStream::new(dbus).await?))];
+    Ok(stream)
+}
+
+#[derive(Clone)]
+struct DASDState<'a> {
+    client: DASDClient<'a>,
+}
+
+pub async fn dasd_service<T>(dbus: &zbus::Connection) -> Result<Router<T>, ServiceError> {
+    let client = DASDClient::new(dbus.clone()).await?;
+    let state = DASDState { client };
+    let router = Router::new()
+        .route("/devices", get(devices))
+        .route("/probe", post(probe))
+        .route("/format", post(format))
+        .route("/enable", post(enable))
+        .route("/disable", post(disable))
+        .route("/diag", put(set_diag))
+        .with_state(state);
+    Ok(router)
+}
+
+/// Returns the list of known DASD devices.
+#[utoipa::path(
+    get,
+    path="/devices",
+    context_path="/api/storage/dasd",
+    responses(
+        (status = OK, description = "List of DASD devices", body = Vec<DASDDevice>)
+    )
+)]
+async fn devices(State(state): State<DASDState<'_>>) -> Result<Json<Vec<DASDDevice>>, Error> {
+    let devices = state
+        .client
+        .devices()
+        .await?
+        .into_iter()
+        .map(|(_path, device)| device)
+        .collect();
+    Ok(Json(devices))
+}
+
+/// Find DASD devices in the system.
+#[utoipa::path(
+    post,
+    path="/probe",
+    context_path="/api/storage/dasd",
+    responses(
+        (status = OK, description = "The probing process ran successfully")
+    )
+)]
+async fn probe(State(state): State<DASDState<'_>>) -> Result<Json<()>, Error> {
+    Ok(Json(state.client.probe().await?))
+}
+
+/// Formats a set of devices.
+#[utoipa::path(
+    post,
+    path="/format",
+    context_path="/api/storage/dasd",
+    responses(
+        (status = OK, description = "The formatting process started.")
+    )
+)]
+async fn format(
+    State(state): State<DASDState<'_>>,
+    Json(devices): Json<DevicesList>,
+) -> Result<Json<()>, Error> {
+    state.client.format(&devices.as_references()).await?;
+    Ok(Json(()))
+}
+
+/// Enables a set of devices.
+#[utoipa::path(
+    post,
+    path="/enable",
+    context_path="/api/storage/dasd",
+    responses(
+        (status = OK, description = "The formatting process started.")
+    )
+)]
+async fn enable(
+    State(state): State<DASDState<'_>>,
+    Json(devices): Json<DevicesList>,
+) -> Result<Json<()>, Error> {
+    state.client.enable(&devices.as_references()).await?;
+    Ok(Json(()))
+}
+
+/// Disables a set of devices.
+#[utoipa::path(
+    post,
+    path="/disable",
+    context_path="/api/storage/dasd",
+    responses(
+        (status = OK, description = "The formatting process started.")
+    )
+)]
+async fn disable(
+    State(state): State<DASDState<'_>>,
+    Json(devices): Json<DevicesList>,
+) -> Result<Json<()>, Error> {
+    state.client.disable(&devices.as_references()).await?;
+    Ok(Json(()))
+}
+
+/// Sets the diag property for a set of devices.
+#[utoipa::path(
+     put,
+     path="/diag",
+     context_path="/api/storage/dasd",
+     responses(
+         (status = OK, description = "The formatting process started.")
+     )
+ )]
+async fn set_diag(
+    State(state): State<DASDState<'_>>,
+    Json(params): Json<SetDiagParams>,
+) -> Result<Json<()>, Error> {
+    state
+        .client
+        .set_diag(&params.devices.as_references(), params.diag)
+        .await?;
+    Ok(Json(()))
+}
+
+#[derive(Deserialize)]
+struct SetDiagParams {
+    #[serde(flatten)]
+    pub devices: DevicesList,
+    pub diag: bool,
+}
+
+#[derive(Deserialize)]
+struct DevicesList {
+    devices: Vec<String>,
+}
+
+impl DevicesList {
+    pub fn as_references(&self) -> Vec<&str> {
+        self.devices.iter().map(AsRef::as_ref).collect()
+    }
+}

--- a/rust/agama-server/src/storage/web/dasd.rs
+++ b/rust/agama-server/src/storage/web/dasd.rs
@@ -18,7 +18,7 @@ use serde::Deserialize;
 
 use crate::{error::Error, web::common::EventStreams};
 
-use self::stream::DASDDeviceStream;
+use self::stream::{DASDDeviceStream, DASDFormatJobStream};
 
 mod stream;
 
@@ -30,7 +30,13 @@ mod stream;
 ///
 /// * `dbus`: D-Bus connection to use.
 pub async fn dasd_stream(dbus: &zbus::Connection) -> Result<EventStreams, Error> {
-    let stream: EventStreams = vec![("dasd_devices", Box::pin(DASDDeviceStream::new(dbus).await?))];
+    let stream: EventStreams = vec![
+        ("dasd_devices", Box::pin(DASDDeviceStream::new(dbus).await?)),
+        (
+            "format_jobs",
+            Box::pin(DASDFormatJobStream::new(dbus).await?),
+        ),
+    ];
     Ok(stream)
 }
 

--- a/rust/agama-server/src/storage/web/dasd/stream.rs
+++ b/rust/agama-server/src/storage/web/dasd/stream.rs
@@ -1,0 +1,160 @@
+// FIXME: the code is pretty similar to iscsi::stream. Refactor the stream to reduce the repetition.
+
+use std::{collections::HashMap, task::Poll};
+
+use agama_lib::{
+    dbus::get_optional_property,
+    error::ServiceError,
+    property_from_dbus,
+    storage::{client::dasd::DASDClient, model::dasd::DASDDevice},
+};
+use futures_util::{ready, Stream};
+use pin_project::pin_project;
+use thiserror::Error;
+use tokio::sync::mpsc::unbounded_channel;
+use tokio_stream::{wrappers::UnboundedReceiverStream, StreamExt};
+use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue};
+
+use crate::{
+    dbus::{DBusObjectChange, DBusObjectChangesStream, ObjectsCache},
+    web::Event,
+};
+
+#[derive(Debug, Error)]
+enum DASDDeviceStreamError {
+    #[error("Service error: {0}")]
+    Service(#[from] ServiceError),
+    #[error("Unknown DASD device: {0}")]
+    UnknownDevice(OwnedObjectPath),
+}
+
+/// This stream listens for changes in the collection of DASD devices and emits
+/// the updated objects.
+///
+/// It relies on the [DBusObjectChangesStream] stream and uses a cache to avoid holding a bunch of
+/// proxy objects.
+#[pin_project]
+pub struct DASDDeviceStream {
+    dbus: zbus::Connection,
+    cache: ObjectsCache<DASDDevice>,
+    #[pin]
+    inner: UnboundedReceiverStream<DBusObjectChange>,
+}
+
+impl DASDDeviceStream {
+    /// Creates a new stream
+    ///
+    /// * `dbus`: D-Bus connection to listen on.
+    pub async fn new(dbus: &zbus::Connection) -> Result<Self, ServiceError> {
+        const MANAGER_PATH: &str = "/org/opensuse/Agama/Storage1";
+        const NAMESPACE: &str = "/org/opensuse/Agama/Storage1/dasds";
+
+        let (tx, rx) = unbounded_channel();
+        let mut stream = DBusObjectChangesStream::new(
+            dbus,
+            &ObjectPath::from_str_unchecked(MANAGER_PATH),
+            &ObjectPath::from_str_unchecked(NAMESPACE),
+            "org.opensuse.Agama.Storage1.DASD.Device",
+        )
+        .await?;
+
+        tokio::spawn(async move {
+            while let Some(change) = stream.next().await {
+                let _ = tx.send(change);
+            }
+        });
+        let rx = UnboundedReceiverStream::new(rx);
+
+        let mut cache: ObjectsCache<DASDDevice> = Default::default();
+        let client = DASDClient::new(dbus.clone()).await?;
+        for (path, device) in client.devices().await? {
+            cache.add(path.into(), device);
+        }
+
+        Ok(Self {
+            dbus: dbus.clone(),
+            cache,
+            inner: rx,
+        })
+    }
+
+    fn update_device<'a>(
+        cache: &'a mut ObjectsCache<DASDDevice>,
+        path: &OwnedObjectPath,
+        values: &HashMap<String, OwnedValue>,
+    ) -> Result<&'a DASDDevice, ServiceError> {
+        let device = cache.find_or_create(path);
+        property_from_dbus!(device, id, "Id", values, str);
+        property_from_dbus!(device, enabled, "Enabled", values, bool);
+        property_from_dbus!(device, device_name, "DeviceName", values, str);
+        property_from_dbus!(device, formatted, "Formatted", values, bool);
+        property_from_dbus!(device, diag, "Diag", values, bool);
+        property_from_dbus!(device, status, "Status", values, str);
+        property_from_dbus!(device, device_type, "Type", values, str);
+        property_from_dbus!(device, access_type, "AccessType", values, str);
+        property_from_dbus!(device, partition_info, "PartitionInfo", values, str);
+        Ok(device)
+    }
+
+    fn remove_device(
+        cache: &mut ObjectsCache<DASDDevice>,
+        path: &OwnedObjectPath,
+    ) -> Result<DASDDevice, DASDDeviceStreamError> {
+        cache
+            .remove(path)
+            .ok_or_else(|| DASDDeviceStreamError::UnknownDevice(path.clone()))
+    }
+
+    fn handle_change(
+        cache: &mut ObjectsCache<DASDDevice>,
+        change: &DBusObjectChange,
+    ) -> Result<Event, DASDDeviceStreamError> {
+        match change {
+            DBusObjectChange::Added(path, values) => {
+                let device = Self::update_device(cache, path, values)?;
+                Ok(Event::DASDDeviceAdded {
+                    device: device.clone(),
+                })
+            }
+            DBusObjectChange::Changed(path, updated) => {
+                let device = Self::update_device(cache, path, updated)?;
+                Ok(Event::DASDDeviceChanged {
+                    device: device.clone(),
+                })
+            }
+            DBusObjectChange::Removed(path) => {
+                let device = Self::remove_device(cache, path)?;
+                Ok(Event::DASDDeviceRemoved { device })
+            }
+        }
+    }
+}
+
+impl Stream for DASDDeviceStream {
+    type Item = Event;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let mut pinned = self.project();
+
+        Poll::Ready(loop {
+            let change = ready!(pinned.inner.as_mut().poll_next(cx));
+            let next_value = match change {
+                Some(change) => {
+                    if let Ok(event) = Self::handle_change(pinned.cache, &change) {
+                        Some(event)
+                    } else {
+                        log::warn!("Could not process change {:?}", &change);
+                        None
+                    }
+                }
+                None => break None,
+            };
+            if next_value.is_some() {
+                break next_value;
+            }
+        })
+    }
+}

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -13,7 +13,7 @@ use crate::{
     software::web::{software_service, software_streams},
     storage::web::{storage_service, storage_streams},
     users::web::{users_service, users_streams},
-    web::common::{issues_stream, progress_stream, service_status_stream},
+    web::common::{issues_stream, jobs_stream, progress_stream, service_status_stream},
 };
 use axum::Router;
 
@@ -138,6 +138,16 @@ async fn run_events_monitor(dbus: zbus::Connection, events: EventsSender) -> Res
             dbus.clone(),
             "org.opensuse.Agama.Storage1",
             "/org/opensuse/Agama/Storage1",
+        )
+        .await?,
+    );
+    stream.insert(
+        "storage-jobs",
+        jobs_stream(
+            dbus.clone(),
+            "org.opensuse.Agama.Storage1",
+            "/org/opensuse/Agama/Storage1",
+            "/org/opensuse/Agama/Storage1/jobs",
         )
         .await?,
     );

--- a/rust/agama-server/src/web/common.rs
+++ b/rust/agama-server/src/web/common.rs
@@ -15,6 +15,9 @@ use zbus::PropertyStream;
 
 use crate::error::Error;
 
+mod jobs;
+pub use jobs::{jobs_router, jobs_stream};
+
 use super::Event;
 
 pub type EventStreams = Vec<(&'static str, Pin<Box<dyn Stream<Item = Event> + Send>>)>;

--- a/rust/agama-server/src/web/common.rs
+++ b/rust/agama-server/src/web/common.rs
@@ -16,7 +16,7 @@ use zbus::PropertyStream;
 use crate::error::Error;
 
 mod jobs;
-pub use jobs::{jobs_router, jobs_stream};
+pub use jobs::{jobs_service, jobs_stream};
 
 use super::Event;
 

--- a/rust/agama-server/src/web/common/jobs.rs
+++ b/rust/agama-server/src/web/common/jobs.rs
@@ -1,0 +1,187 @@
+use std::{collections::HashMap, task::Poll};
+
+use agama_lib::{
+    dbus::get_optional_property,
+    error::ServiceError,
+    jobs::{client::JobsClient, Job},
+    property_from_dbus,
+};
+use axum::{extract::State, routing::get, Json, Router};
+use futures_util::{ready, Stream};
+use pin_project::pin_project;
+use tokio::sync::mpsc::unbounded_channel;
+use tokio_stream::{wrappers::UnboundedReceiverStream, StreamExt};
+use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue};
+
+use crate::{
+    dbus::{DBusObjectChange, DBusObjectChangesStream, ObjectsCache},
+    error::Error,
+    web::Event,
+};
+
+use super::EventStreams;
+
+/// Builds a router for the jobs objects.
+pub async fn jobs_router<T>(
+    dbus: &zbus::Connection,
+    destination: &'static str,
+    path: &'static str,
+) -> Result<Router<T>, ServiceError> {
+    let client = JobsClient::new(dbus.clone(), destination, path).await?;
+    let state = JobsState { client };
+    Ok(Router::new().route("/jobs", get(jobs)).with_state(state))
+}
+
+#[derive(Clone)]
+struct JobsState<'a> {
+    client: JobsClient<'a>,
+}
+
+async fn jobs(State(state): State<JobsState<'_>>) -> Result<Json<Vec<Job>>, Error> {
+    let jobs = state
+        .client
+        .jobs()
+        .await?
+        .into_iter()
+        .map(|(_path, job)| job)
+        .collect();
+    Ok(Json(jobs))
+}
+
+/// Returns the stream of jobs-related events.
+///
+/// The stream combines the following events:
+///
+/// * Changes on the DASD devices collection.
+///
+/// * `dbus`: D-Bus connection to use.
+pub async fn jobs_stream(
+    dbus: &zbus::Connection,
+    manager: &'static str,
+    namespace: &'static str,
+) -> Result<EventStreams, Error> {
+    let jobs_stream = JobsStream::new(dbus, manager, namespace).await?;
+    let stream: EventStreams = vec![("jobs", Box::pin(jobs_stream))];
+    Ok(stream)
+}
+
+#[pin_project]
+pub struct JobsStream {
+    dbus: zbus::Connection,
+    cache: ObjectsCache<Job>,
+    #[pin]
+    inner: UnboundedReceiverStream<DBusObjectChange>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum JobsStreamError {
+    #[error("Service error: {0}")]
+    Service(#[from] ServiceError),
+    #[error("Unknown job: {0}")]
+    UnknownJob(OwnedObjectPath),
+}
+
+impl JobsStream {
+    pub async fn new(
+        dbus: &zbus::Connection,
+        manager: &'static str,
+        namespace: &'static str,
+    ) -> Result<Self, ServiceError> {
+        let (tx, rx) = unbounded_channel();
+        let mut stream = DBusObjectChangesStream::new(
+            dbus,
+            &ObjectPath::from_static_str(manager)?,
+            &ObjectPath::from_static_str(namespace)?,
+            "org.opensuse.Agama.Storage1.Job",
+        )
+        .await?;
+
+        tokio::spawn(async move {
+            while let Some(change) = stream.next().await {
+                let _ = tx.send(change);
+            }
+        });
+        let rx = UnboundedReceiverStream::new(rx);
+
+        let mut cache: ObjectsCache<Job> = Default::default();
+        let client = JobsClient::new(dbus.clone(), manager, namespace).await?;
+        for (path, job) in client.jobs().await? {
+            cache.add(path.into(), job);
+        }
+
+        Ok(Self {
+            dbus: dbus.clone(),
+            cache,
+            inner: rx,
+        })
+    }
+
+    fn update_job<'a>(
+        cache: &'a mut ObjectsCache<Job>,
+        path: &OwnedObjectPath,
+        values: &HashMap<String, OwnedValue>,
+    ) -> Result<&'a Job, ServiceError> {
+        let job = cache.find_or_create(path);
+        property_from_dbus!(job, running, "Running", values, bool);
+        property_from_dbus!(job, exit_code, "ExitCode", values, u32);
+        Ok(job)
+    }
+
+    fn remove_job(
+        cache: &mut ObjectsCache<Job>,
+        path: &OwnedObjectPath,
+    ) -> Result<Job, JobsStreamError> {
+        cache
+            .remove(path)
+            .ok_or_else(|| JobsStreamError::UnknownJob(path.clone()))
+    }
+
+    fn handle_change(
+        cache: &mut ObjectsCache<Job>,
+        change: &DBusObjectChange,
+    ) -> Result<Event, JobsStreamError> {
+        match change {
+            DBusObjectChange::Added(path, values) => {
+                let job = Self::update_job(cache, path, values)?;
+                Ok(Event::JobAdded { job: job.clone() })
+            }
+            DBusObjectChange::Changed(path, updated) => {
+                let job = Self::update_job(cache, path, updated)?;
+                Ok(Event::JobChanged { job: job.clone() })
+            }
+            DBusObjectChange::Removed(path) => {
+                let job = Self::remove_job(cache, path)?;
+                Ok(Event::JobRemoved { job })
+            }
+        }
+    }
+}
+
+impl Stream for JobsStream {
+    type Item = Event;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let mut pinned = self.project();
+
+        Poll::Ready(loop {
+            let change = ready!(pinned.inner.as_mut().poll_next(cx));
+            let next_value = match change {
+                Some(change) => {
+                    if let Ok(event) = Self::handle_change(pinned.cache, &change) {
+                        Some(event)
+                    } else {
+                        log::warn!("Could not process change {:?}", &change);
+                        None
+                    }
+                }
+                None => break None,
+            };
+            if next_value.is_some() {
+                break next_value;
+            }
+        })
+    }
+}

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -1,8 +1,8 @@
 use crate::network::model::NetworkChange;
 use agama_lib::{
     localization::model::LocaleConfig, manager::InstallationPhase,
-    product::RegistrationRequirement, progress::Progress, software::SelectedBy, storage::ISCSINode,
-    users::FirstUser,
+    product::RegistrationRequirement, progress::Progress, software::SelectedBy,
+    storage::model::dasd::DASDDevice, storage::ISCSINode, users::FirstUser,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -76,6 +76,15 @@ pub enum Event {
     ISCSIInitiatorChanged {
         name: Option<String>,
         ibft: Option<bool>,
+    },
+    DASDDeviceAdded {
+        device: DASDDevice,
+    },
+    DASDDeviceChanged {
+        device: DASDDevice,
+    },
+    DASDDeviceRemoved {
+        device: DASDDevice,
     },
 }
 

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -1,6 +1,6 @@
 use crate::network::model::NetworkChange;
 use agama_lib::{
-    localization::model::LocaleConfig, manager::InstallationPhase,
+    jobs::Job, localization::model::LocaleConfig, manager::InstallationPhase,
     product::RegistrationRequirement, progress::Progress, software::SelectedBy,
     storage::model::dasd::DASDDevice, storage::ISCSINode, users::FirstUser,
 };
@@ -85,6 +85,15 @@ pub enum Event {
     },
     DASDDeviceRemoved {
         device: DASDDevice,
+    },
+    JobAdded {
+        job: Job,
+    },
+    JobChanged {
+        job: Job,
+    },
+    JobRemoved {
+        job: Job,
     },
 }
 

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -95,6 +95,12 @@ pub enum Event {
     JobRemoved {
         job: Job,
     },
+    DASDFormatJobChanged {
+        job_id: String,
+        total: u32,
+        step: u32,
+        done: bool,
+    },
 }
 
 pub type EventsSender = Sender<Event>;


### PR DESCRIPTION
Trello: https://trello.com/c/2LC8JEZR/3743-8-agama-adapt-dasd-configuration-to-current-architecture

This PR is the first step to bring back support for DASD devices on s390x architectures. It includes:

* Extending the HTTP API to expose DASD devices and formatting jobs.
* Adding DASD-related events (adding, updating and changing DASD devices and format progress).

After some discussion, we decided to retain the original intention of the D-Bus API at HTTP level.

> [!WARNING]
> The code has barely been tested, and it may be incomplete or contain bugs. But it should be a good enough starting point.

## Examples

This section contains a few examples you can use to explore the API. For the ones using `curl`, it is required to have a `headers.txt` file containing the credentials (similar to the following example, but replacing `TOKEN` with your actual token):

```
Content-Type: application/json
Authorization: Bearer TOKEN
```

<details>
<summary>DASD operations</summary>

Remember that the `-k` disables the SSL certificate checking.

### Probing for DASD devices

```bash
curl -k -H @headers.txt -X POST https://$AGAMA_SERVER/api/storage/dasd/probe
```

### Listing DASD devices

```bash
$ curl -k --silent -H @headers.txt -X GET https://$AGAMA_SERVER/api/storage/dasd/devices | jq
[
  {
    "id": "0.0.0160",
    "enabled": true,
    "device_name": "dasda",
    "formatted": true,
    "diag": false,
    "status": "active",
    "device_type": "ECKD",
    "access_type": "rw",
    "partition_info": ""
  }
]
```

### Enabling DASD devices

> [!NOTE]
> We might consider using `PATCH` or even `POST` for enabling, disabling, setting diag and formatting the device.

```bash
$ curl -k -H @headers.txt -X POST https://$AGAMA_SERVER/api/storage/dasd/enable \
  -d '{"devices": ["0.0.0160"]}'
```

### Disabling devices

```bash
$ curl -k -H @headers.txt -X POST https://$AGAMA_SERVER/api/storage/dasd/disable \
  -d '{"devices": ["0.0.0160"]}'
```

### Setting the DIAG attribute

```bash
$ curl -k -H @headers.txt -X PUT https://$AGAMA_SERVER/api/storage/dasd/diag \
  -d '{"devices": ["0.0.0160"], "diag": true}'
```

### Formatting devices

```bash
$ curl -k -H @headers.txt -X PUT https://$AGAMA_SERVER/api/storage/dasd/diag \
  -d '{"devices": ["0.0.0160"], "diag": true}'
```
</details>

<details>
<summary>Jobs operation</summary>

### Listing jobs

```bash
$ curl -k -H @headers.txt -X GET https://$AGAMA_SERVER/api/storage/jobs | jq
[
  {
    "id": "/org/opensuse/Agama/Storage1/jobs/3",
    "running": false,
    "exit_code": 0
  },
  {
    "id": "/org/opensuse/Agama/Storage1/jobs/2",
    "running": false,
    "exit_code": 0
  }
]
```

</details>

<details>
<summary>Events</summary>

The PR adds the following events:

* `DASDDeviceAdded`, `DASDDeviceChaned` and `DASDDeviceRemoved`.
* `JobAdded`, `JobChanged` and `JobRemoved`.
* `DASDFormatProgress`.

> [!WARNING]
> The `Finished` signal of the `org.opensuse.Agama.Storage1.Job` is not handled.

Let's see a few examples:

## Formatting progress

```json
{"type":"DASDFormatJobChanged","job_id":"/org/opensuse/Agama/Storage1/jobs/9","total":30050,"step":30050,"done":true}
```

### DASD device changes

```
{"type":"DASDDeviceChanged","device":{"id":"0.0.0160","enabled":true,"device_name":"dasda","formatted":true,"diag":false,"status":"active","device_type":"ECKD","access_type":"rw","partition_info":""}
```

</details>

## A notes about signals

We have discussed whether we are abusing standard D-Bus signals a bit. For instance, we rely a lot on `PropertiesChanged`, `InterfacesAdded`, `InterfacesRemoved`, etc., even for meaningful and important system events. Then, the client code needs to figure out what those signals actually mean. Also, unless you use a proxy (and that's not always possible), you cannot rely on the type checking that the introspection offers.

Of course, that's out of the scope of this pull request.

## Code repetition

As you might notice, there is quite some repetitive code. At this point, I just wanted to have some working code. We can reduce the repetition later. Take into account that improving our signals would help reduce the amount of code on the client side.