### PR TITLE
less strict nokogiri dependency

### DIFF
--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    agama-yast (9)
+    agama-yast (9.devel505)
       cfa (~> 1.0.2)
       cfa_grub2 (~> 2.0.0)
       cheetah (~> 1.0.0)
       eventmachine (~> 1.2.7)
       fast_gettext (~> 2.3.0)
-      nokogiri (~> 1.16.6)
+      nokogiri (~> 1.15)
       rexml (~> 3.2.5)
       ruby-dbus (>= 0.23.1, < 1.0)
 

--- a/service/agama-yast.gemspec
+++ b/service/agama-yast.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cheetah", "~> 1.0.0"
   spec.add_dependency "eventmachine", "~> 1.2.7"
   spec.add_dependency "fast_gettext", "~> 2.3.0"
-  spec.add_dependency "nokogiri", "~> 1.16.6"
+  spec.add_dependency "nokogiri", "~> 1.15"
   spec.add_dependency "rexml", "~> 3.2.5"
   spec.add_dependency "ruby-dbus", ">= 0.23.1", "< 1.0"
 end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 12 11:44:15 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Less strict nokogiri dependency as nokogiri follows semver, so do
+  not depend on patch level (gh#openSUSE/agama#1534).
+
+-------------------------------------------------------------------
 Thu Aug  1 13:57:51 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use exfatprogs instead of exfat-utils (gh#openSUSE/agama#1520).


### PR DESCRIPTION
## Problem

TW has nokogiri 1.16 and SLFO has 1.15. Due to our strict dependencies we cannot build against both.


## Solution

nokogiri follows semver, so it should be safe to depends only on minor version and not on patch level.
