### PR TITLE
Fix gpg import

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 12 12:38:45 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Do not fail if there is no opensuse keys on medium for PXE
+  (gh#openSUSE/agama#1535)
+
+-------------------------------------------------------------------
 Fri Aug  2 08:02:41 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Display QR codes at the console for easier connecting to Agama

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -27,8 +27,10 @@ rm /tmp/systemsmanagement_key.gpg
 # import the IBS key for the Devel:YaST:Agama:Head project
 rpm --import /tmp/Devel_YaST_Agama_Head_key.gpg
 rm /tmp/Devel_YaST_Agama_Head_key.gpg
-# import the openSUSE keys
-rpm --import /usr/lib/rpm/gnupg/keys/*.asc
+# import the openSUSE keys, but check if there is any
+if stat -t /usr/lib/rpm/gnupg/keys/*.asc 2>/dev/null 1>/dev/null; then
+  rpm --import /usr/lib/rpm/gnupg/keys/*.asc
+fi
 
 # activate services
 systemctl enable sshd.service


### PR DESCRIPTION
## Problem

In staging there is no opensuse keys for PXE build which causes build failure.

https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:adi:34/agama-installer:openSUSE-PXE/images/x86_64


## Solution

Import keys only if there is any available.


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

