### PR TITLE
openQA: Allow overriding of install repos #1474

### DIFF
--- a/doc/boot_arguments.md
+++ b/doc/boot_arguments.md
@@ -15,6 +15,22 @@ See [URL handling in the
 installer](https://github.com/yast/yast-installation/blob/master/doc/url.md) to find more details
 about the supported URLs.
 
+## Custom Installation URL Configuration
+
+You can override the default `installation_url` set in the product files [here](https://github.com/openSUSE/agama/tree/master/products.d) by passing the `agama.install_url` parameter as a boot option in the bootloader.
+This is particularly useful for any pre-production testing in openQA. 
+
+**Note:** Setting this variable will impact all products. 
+
+### Example Usage
+
+To specify a custom installation URLs, pass following as a parameter to kernel in the bootloader.
+You can specify multiple URLs by separating them with commas.
+
+```
+agama.install_url=https://myrepo,https://myrepo2
+```
+
 ## Changing configuration values
 
 Instead of loading a full configuration file, you might be interested in adjusting just a few

--- a/service/lib/agama/software/product_builder.rb
+++ b/service/lib/agama/software/product_builder.rb
@@ -19,24 +19,29 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "agama/cmdline_args"
 require "agama/software/product"
+require "logger"
 
 module Agama
   module Software
     # Builds products from the information of a config file.
     class ProductBuilder
       # @param config [Agama::Config]
-      def initialize(config)
+      def initialize(config, logger: Logger.new($stdout))
         @config = config
+        @logger = logger
       end
 
       # Builds the products.
       #
       # @return [Array<Agama::Product>]
       def build
+        cmdline_args = CmdlineArgs.read_from("/proc/cmdline")
+        @logger.info cmdline_args
         config.products.map do |id, attrs|
           data = product_data_from_config(id)
-          create_product(id, data, attrs)
+          create_product(id, data, attrs, cmdline_args)
         end
       end
 
@@ -45,21 +50,44 @@ module Agama
       # @return [Agama::Config]
       attr_reader :config
 
-      def create_product(id, data, attrs)
+      def create_product(id, data, attrs, cmdline_args)
+        product = initialize_product(id, data, attrs)
+        set_repositories(product, data, cmdline_args)
+        set_software(product, data)
+        set_translations(product, attrs)
+        product
+      end
+
+      def initialize_product(id, data, attrs)
         Agama::Software::Product.new(id).tap do |product|
           product.display_name = attrs["name"]
           product.description = attrs["description"]
           product.name = data[:name]
           product.version = data[:version]
-          product.repositories = data[:repositories]
-          product.labels = data[:labels]
-          product.mandatory_packages = data[:mandatory_packages]
-          product.optional_packages = data[:optional_packages]
-          product.mandatory_patterns = data[:mandatory_patterns]
-          product.optional_patterns = data[:optional_patterns]
-          product.user_patterns = data[:user_patterns]
-          product.translations = attrs["translations"] || {}
         end
+      end
+
+      def set_repositories(product, data, cmdline_args)
+        install_url = cmdline_args.data["install_url"]
+        if install_url
+          @logger.info "agama.install_url is set to #{install_url}"
+          product.repositories = install_url.split(",")
+        else
+          product.repositories = data[:repositories]
+        end
+      end
+
+      def set_software(product, data)
+        product.labels = data[:labels]
+        product.mandatory_packages = data[:mandatory_packages]
+        product.optional_packages = data[:optional_packages]
+        product.mandatory_patterns = data[:mandatory_patterns]
+        product.optional_patterns = data[:optional_patterns]
+        product.user_patterns = data[:user_patterns]
+      end
+
+      def set_translations(product, attrs)
+        product.translations = attrs["translations"] || {}
       end
 
       # Data from config, filtering by arch.

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 19 15:13:46 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Allow overriding of install repos which is needed by openQA
+- Override urls by using agama.install_url=https://.. boot param
+
+-------------------------------------------------------------------
 Mon Aug 12 11:44:15 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - Less strict nokogiri dependency as nokogiri follows semver, so do


### PR DESCRIPTION
* Override urls by using agama.install_url=https://url1,https://url2 boot param
* Add logger so we can print some repo related debug messages that can be captured by agama logs store

## Problem
We need to be able to test installation of preproduction data. See details in #1474 

## Example usage

Add agama.install_url as a boot argument to the linux kernel. Multiple urls can be seprated by commas.

![image](https://github.com/user-attachments/assets/2bed074a-156b-446d-8e2e-8ae5b727dc58)


```
# cat /proc/cmdline 
BOOT_IMAGE=/boot/vmlinuz-6.10.5-1-default root=UUID=4fd273b6-0453-4b36-8f58-a81e70bc9b9a splash=silent mitigations=auto quiet security=apparmor agama.install_url=https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64,https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/standard/x86_64/
```

This will now set https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64 as an installation_url to all products. This is extremely helpful for staging testing or any testing in openQA before publishing changes to the public repository.

Note: if you specify incorrect urls, you can at least the value it in the overview screen :-)
![image](https://github.com/user-attachments/assets/9bd1ac35-18f4-4021-a8d7-c384bdf00d84)

