### PR TITLE
Fix opensuse build key

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 19 17:54:55 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Add beside staging-build-keys also openSUSE-build-keys to not
+  require import of keys for official opensuse repos
+  (gh#openSUSE/agama#1538)
+
+-------------------------------------------------------------------
 Mon Aug 12 12:38:45 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not fail if there is no opensuse keys on medium for PXE

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -167,6 +167,7 @@
         <package name="ruby3.3-rubygem-agama-yast"/>
         <package name="ruby3.3-rubygem-byebug"/>
         <package name="staging-build-key"/>
+        <package name="openSUSE-build-key"/>
     </packages>
     <!-- additional packages for the SLE distributions -->
     <packages type="image" profiles="SLE">


### PR DESCRIPTION
## Problem

see https://github.com/openSUSE/agama/issues/1538


## Solution

Add beside staging keys also official openSUSE ones.


## Testing

- due to broken opensuse build not tested, only by manual comparison of working build and non-working one where the later one missing added package.

