### PR TITLE
fix(service): add dbus-1-daemon as a dependency

### DIFF
--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -26,6 +26,7 @@
     Provides:       agama-yast
     BuildRequires:  dbus-1-common
     Requires:       dbus-1-common
+    Requires:       dbus-1-daemon
     Requires:       suseconnect-ruby-bindings
     # YaST dependencies
     Requires:       autoyast2-installation

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Aug 27 11:38:01 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add a dependency on the D-Bus daemon (bsc#1229807).
+
+-------------------------------------------------------------------
 Mon Aug 26 10:01:27 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not depend on f2fs-tools and nilfs-utils


### PR DESCRIPTION
`dbus-daemon` is no longer included in the ISO or the containers. This is most probably related to the introduction of `dbus-broker` which caused some dependencies to change. We might need to do some further investigation, but this is a hotfix to have the ISO working again.