### PR TITLE
fix(rust): do not use camel case in event names

### DIFF
--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -102,7 +102,7 @@ pub enum Event {
         job: Job,
     },
     DASDFormatJobChanged {
-        #[serde(rename = "JobId")]
+        #[serde(rename = "jobId")]
         job_id: String,
         summary: HashMap<String, DASDFormatSummary>,
     },

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -17,7 +17,7 @@ use tokio::sync::broadcast::{Receiver, Sender};
 use super::common::Issue;
 
 #[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "camelCase", tag = "type")]
+#[serde(tag = "type")]
 pub enum Event {
     L10nConfigChanged(LocaleConfig),
     LocaleChanged {
@@ -102,6 +102,7 @@ pub enum Event {
         job: Job,
     },
     DASDFormatJobChanged {
+        #[serde(rename = "JobId")]
         job_id: String,
         summary: HashMap<String, DASDFormatSummary>,
     },

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Aug 28 12:37:34 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Expose the DASD D-Bus API through HTTP (gh#openSUSE/agama#1532).
+
+-------------------------------------------------------------------
 Tue Aug 27 13:57:35 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Schema definition for basic storage settings


### PR DESCRIPTION
* Revert a226fec6 as it affects the event names (`progress` vs `Progress`).
* Add the changelog for #1532.