### PR TITLE
feat(storage): initial version of config search

### DIFF
--- a/rust/agama-lib/share/examples/storage.json
+++ b/rust/agama-lib/share/examples/storage.json
@@ -6,13 +6,12 @@
     },
     "drives": [
       {
-        "search": {
-          "name": "/dev/vda"
-        },
+        "search": "/dev/vda",
         "ptableType": "gpt",
         "partitions": [
           {
-            "search": { "name": "/dev/vda2" },
+            "id": "linux",
+            "size": "10 GiB",
             "encryption": {
               "luks1": {
                 "password": "notsecret"
@@ -31,12 +30,16 @@
             }
           },
           {
-            "id": "linux",
-            "size": "10 GiB",
+            "search": {
+              "condition": {
+                "name": "/dev/vda2"
+              },
+              "ifNotFound": "skip"
+            },
             "encryption": {
               "luks2": {
                 "password": "notsecret",
-                "label": "data"
+                "label": "home"
               }
             },
             "filesystem": {
@@ -45,7 +48,7 @@
             }
           },
           {
-            "size": "2 GiB",
+            "search": {},
             "encryption": "random_swap",
             "filesystem": {
               "type": "swap",
@@ -56,7 +59,10 @@
       },
       {
         "search": {
-          "name": "/dev/vdb"
+          "condition": {
+            "name": "/dev/vda"
+          },
+          "ifNotFound": "error"
         },
         "filesystem": {
           "type": "ext4",

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -671,18 +671,44 @@
         }
       ]
     },
-    "search": {
-      "title": "Search options",
+    "searchName": {
+      "title": "Device name",
+      "type": "string",
+      "examples": ["/dev/vda", "/dev/disk/by-id/ata-WDC_WD3200AAKS-75L9"]
+    },
+    "searchByName": {
+      "title": "Search by name condition",
       "type": "object",
       "additionalProperties": false,
       "required": ["name"],
       "properties": {
         "name": {
-          "title": "Device name",
-          "type": "string",
-          "examples": ["/dev/vda"]
+          "$ref": "#/$defs/searchName"
         }
       }
+    },
+    "search": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/searchName"
+        },
+        {
+          "title": "Search options",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "condition": {
+              "$ref": "#/$defs/searchByName"
+            },
+            "ifNotFound": {
+              "title": "Not found action",
+              "description": "How to handle the section if the device is not found.",
+              "enum": ["skip", "error"],
+              "default": "error"
+            }
+          }
+        }
+      ]
     },
     "boot": {
       "title": "Boot options",

--- a/service/lib/agama/storage/config_conversions/block_device/from_json.rb
+++ b/service/lib/agama/storage/config_conversions/block_device/from_json.rb
@@ -45,11 +45,13 @@ module Agama
 
           # Performs the conversion from Hash according to the JSON schema.
           #
-          # @param config [#encrypt=, #format=, #mount=]
-          def convert(config)
-            config.encryption = convert_encrypt
-            config.filesystem = convert_filesystem
-            config
+          # @param default [Configs::Drive, Configs::Partition]
+          # @return [Configs::Drive, Configs::Partition]
+          def convert(default)
+            default.dup.tap do |config|
+              config.encryption = convert_encrypt
+              config.filesystem = convert_filesystem
+            end
           end
 
         private

--- a/service/lib/agama/storage/config_conversions/filesystem/from_json.rb
+++ b/service/lib/agama/storage/config_conversions/filesystem/from_json.rb
@@ -37,7 +37,7 @@ module Agama
           # Performs the conversion from Hash according to the JSON schema.
           #
           # @param default [Configs::Filesystem, nil]
-          # @return [Configs::Format]
+          # @return [Configs::Filesystem]
           def convert(default = nil)
             default_config = default.dup || Configs::Filesystem.new
 

--- a/service/lib/agama/storage/config_conversions/partitionable/from_json.rb
+++ b/service/lib/agama/storage/config_conversions/partitionable/from_json.rb
@@ -41,11 +41,13 @@ module Agama
 
           # Performs the conversion from Hash according to the JSON schema.
           #
-          # @param config [#ptable_type=, #partitions=]
-          def convert(config)
-            config.ptable_type = convert_ptable_type
-            config.partitions = convert_partitions
-            config
+          # @param default [Configs::Drive]
+          # @return [Configs::Drive]
+          def convert(default)
+            default.dup.tap do |config|
+              config.ptable_type = convert_ptable_type
+              config.partitions = convert_partitions
+            end
           end
 
         private

--- a/service/lib/agama/storage/config_conversions/search.rb
+++ b/service/lib/agama/storage/config_conversions/search.rb
@@ -19,20 +19,14 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "agama/storage/config_conversions/block_device"
-require "agama/storage/config_conversions/drive"
-require "agama/storage/config_conversions/encryption"
-require "agama/storage/config_conversions/filesystem"
-require "agama/storage/config_conversions/from_json"
-require "agama/storage/config_conversions/partition"
-require "agama/storage/config_conversions/partitionable"
-require "agama/storage/config_conversions/search"
-require "agama/storage/config_conversions/size"
+require "agama/storage/config_conversions/search/from_json"
 
 module Agama
   module Storage
-    # Conversions for the storage config.
     module ConfigConversions
+      # Conversions for search.
+      module Search
+      end
     end
   end
 end

--- a/service/lib/agama/storage/config_conversions/search/from_json.rb
+++ b/service/lib/agama/storage/config_conversions/search/from_json.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Agama
+  module Storage
+    module ConfigConversions
+      module Search
+        # Search conversion from JSON hash according to schema.
+        class FromJSON
+          # @param search_json [Hash, String]
+          def initialize(search_json)
+            @search_json = search_json
+          end
+
+          # Performs the conversion from Hash according to the JSON schema.
+          #
+          # @param default [Configs::Search, nil]
+          # @return [Configs::Search]
+          def convert(default = nil)
+            default_config = default.dup || Configs::Search.new
+
+            default_config.tap do |config|
+              name = convert_name
+              not_found = convert_not_found
+
+              config.name = name if name
+              config.if_not_found = not_found if not_found
+            end
+          end
+
+        private
+
+          # @return [Hash, String]
+          attr_reader :search_json
+
+          # @return [String, nil]
+          def convert_name
+            return search_json if search_json.is_a?(String)
+
+            search_json.dig(:condition, :name)
+          end
+
+          # @return [Symbol, nil]
+          def convert_not_found
+            return if search_json.is_a?(String)
+
+            value = search_json[:ifNotFound]
+            return unless value
+
+            value.to_sym
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/config_conversions/size/from_json.rb
+++ b/service/lib/agama/storage/config_conversions/size/from_json.rb
@@ -35,11 +35,12 @@ module Agama
 
           # Performs the conversion from Hash according to the JSON schema.
           #
+          # @param default [Configs::Size, nil]
           # @return [Configs::Size]
-          def convert
-            return default_size if size_json.is_a?(String) && size_json.casecmp?("default")
+          def convert(default = nil)
+            default_config = default.dup || Configs::Size.new
 
-            Configs::Size.new.tap do |config|
+            default_config.tap do |config|
               config.default = false
               config.min = convert_size(:min)
               config.max = convert_size(:max) || Y2Storage::DiskSize.unlimited
@@ -70,10 +71,6 @@ module Agama
             rescue TypeError
               # JSON schema validations should prevent this from happening
             end
-          end
-
-          def default_size
-            Configs::Size.new.tap { |c| c.default = true }
           end
         end
       end

--- a/service/lib/agama/storage/configs/drive.rb
+++ b/service/lib/agama/storage/configs/drive.rb
@@ -27,7 +27,7 @@ module Agama
       # Section of the configuration representing a device that is expected to exist in the target
       # system and that can be used as a regular disk.
       class Drive
-        # @return [Search, nil]
+        # @return [Search]
         attr_accessor :search
 
         # @return [Encryption, nil]
@@ -45,33 +45,17 @@ module Agama
         # Constructor
         def initialize
           @partitions = []
+          # All drives are expected to match a real device in the system, so let's ensure a search.
+          @search = Search.new
         end
 
-        # Resolves the search, so a devices of the given devicegraph is associated to the drive if
-        # possible
+        # Assigned device according to the search.
         #
-        # Since all drives are expected to match a real device in the system, this creates a default
-        # search if that was ommited.
-        #
-        # @param devicegraph [Y2Storage::Devicegraph] source of the search
-        # @param used_sids [Array<Integer>] SIDs of the devices that are already associated to
-        #   another drive, so they cannot be associated to this
-        def search_device(devicegraph, used_sids)
-          @search ||= default_search
-          devs = devicegraph.blk_devices.select { |d| d.is?(:disk_device, :stray_blk_device) }
-          search.find(devs, used_sids)
-        end
-
-        # @return [Search]
-        def default_search
-          Search.new
-        end
-
-        # Device resulting from a previous call to {#search_device}
+        # @see Y2Storage::Proposal::AgamaSearcher
         #
         # @return [Y2Storage::Device, nil]
         def found_device
-          search&.device
+          search.device
         end
 
         # Whether the drive definition contains partition definitions

--- a/service/lib/agama/storage/configs/partition.rb
+++ b/service/lib/agama/storage/configs/partition.rb
@@ -19,6 +19,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "agama/storage/configs/size"
+
 module Agama
   module Storage
     module Configs
@@ -30,7 +32,7 @@ module Agama
         # @return [Y2Storage::PartitionId, nil]
         attr_accessor :id
 
-        # @return [Size, nil] can be nil for reused partitions
+        # @return [Size]
         attr_accessor :size
 
         # @return [Encryption, nil]
@@ -39,19 +41,13 @@ module Agama
         # @return [Filesystem, nil]
         attr_accessor :filesystem
 
-        # Resolves the search if the partition specification contains any, associating a partition
-        # of the given device if possible
-        #
-        # @param partitionable [Y2Storage::Partitionable] scope for the search
-        # @param used_sids [Array<Integer>] SIDs of the devices that are already associated to
-        #   another partition definition, so they cannot be associated to this
-        def search_device(partitionable, used_sids)
-          return unless search
-
-          search.find(partitionable.partitions, used_sids)
+        def initialize
+          @size = Size.new
         end
 
-        # Device resulting from a previous call to {#search_device}
+        # Assigned device according to the search.
+        #
+        # @see Y2Storage::Proposal::AgamaSearcher
         #
         # @return [Y2Storage::Device, nil]
         def found_device

--- a/service/lib/agama/storage/configs/search.rb
+++ b/service/lib/agama/storage/configs/search.rb
@@ -29,20 +29,39 @@ module Agama
         # @return [Y2Storage::Device, nil]
         attr_reader :device
 
+        # Name of the device to find.
+        # @return [String, nil]
+        attr_accessor :name
+
         # What to do if the search does not match with the expected number of devices
-        # @return [Symbol] :create, :skip or :error
+        # @return [:create, :skip, :error]
         attr_accessor :if_not_found
 
         # Constructor
         def initialize
-          @if_not_found = :skip
+          @if_not_found = :error
         end
 
-        # Whether {#find} was already called
+        # Whether the search does not define any specific condition.
+        #
+        # @return [Boolean]
+        def any_device?
+          name.nil?
+        end
+
+        # Whether the search was already resolved.
         #
         # @return [Boolean]
         def resolved?
           !!@resolved
+        end
+
+        # Resolves the search with the given device.
+        #
+        # @param device [Y2Storage::Device, nil]
+        def resolve(device = nil)
+          @device = device
+          @resolved = true
         end
 
         # Whether the section containing the search should be skipped
@@ -50,16 +69,6 @@ module Agama
         # @return [Boolean]
         def skip_device?
           resolved? && device.nil? && if_not_found == :skip
-        end
-
-        # Resolve the search, associating the corresponding device to {#device}
-        #
-        # @param candidate_devs [Array<Y2Storage::Device>] candidate devices
-        # @param used_sids [Array<Integer>] SIDs of the devices that are already used elsewhere
-        def find(candidate_devs, used_sids)
-          devices = candidate_devs.reject { |d| used_sids.include?(d.sid) }
-          @resolved = true
-          @device = devices.min_by(&:name)
         end
       end
     end

--- a/service/lib/agama/storage/proposal_strategies/agama.rb
+++ b/service/lib/agama/storage/proposal_strategies/agama.rb
@@ -45,18 +45,23 @@ module Agama
 
         # @see Base#calculate
         def calculate
-          proposal = agama_proposal
-          proposal.propose
+          @proposal = agama_proposal
+          @proposal.propose
         ensure
-          storage_manager.proposal = proposal
+          storage_manager.proposal = @proposal
         end
 
         # @see Base#issues
         def issues
-          storage_manager.proposal.issues_list
+          return [] unless proposal
+
+          proposal.issues_list
         end
 
       private
+
+        # @return [Y2Storage::AgamaProposal, nil] Proposal used.
+        attr_reader :proposal
 
         # Instance of the Y2Storage proposal to be used to run the calculation.
         #

--- a/service/lib/y2storage/proposal/agama_device_planner.rb
+++ b/service/lib/y2storage/proposal/agama_device_planner.rb
@@ -59,6 +59,17 @@ module Y2Storage
     private
 
       # @param planned [Planned::Disk, Planned::Partition]
+      # @param settings [#found_device]
+      def configure_reuse(planned, settings)
+        device = settings.found_device
+        return unless device
+
+        planned.assign_reuse(device)
+        # TODO: Allow mounting without reformatting.
+        planned.reformat = true
+      end
+
+      # @param planned [Planned::Disk, Planned::Partition]
       # @param settings [#encryption, #filesystem]
       def configure_device(planned, settings)
         configure_encryption(planned, settings.encryption) if settings.encryption
@@ -189,6 +200,7 @@ module Y2Storage
       def planned_partition(settings)
         Planned::Partition.new(nil, nil).tap do |planned|
           planned.partition_id = settings.id
+          configure_reuse(planned, settings)
           configure_device(planned, settings)
           configure_size(planned, settings.size)
         end

--- a/service/lib/y2storage/proposal/agama_drive_planner.rb
+++ b/service/lib/y2storage/proposal/agama_drive_planner.rb
@@ -48,7 +48,7 @@ module Y2Storage
       # @return [Planned::Disk]
       def planned_full_drive(settings)
         Planned::Disk.new.tap do |planned|
-          configure_drive(planned, settings)
+          configure_reuse(planned, settings)
           configure_device(planned, settings)
         end
       end
@@ -57,15 +57,9 @@ module Y2Storage
       # @return [Planned::Disk]
       def planned_partitioned_drive(settings)
         Planned::Disk.new.tap do |planned|
-          configure_drive(planned, settings)
+          configure_reuse(planned, settings)
           configure_partitions(planned, settings)
         end
-      end
-
-      # @param planned [Planned::Disk]
-      # @param settings [Agama::Storage::Configs::Drive]
-      def configure_drive(planned, settings)
-        planned.assign_reuse(settings.found_device)
       end
     end
   end

--- a/service/lib/y2storage/proposal/agama_searcher.rb
+++ b/service/lib/y2storage/proposal/agama_searcher.rb
@@ -28,45 +28,105 @@ module Y2Storage
       include Yast::Logger
       include Yast::I18n
 
-      # Constructor
-      def initialize
+      # @param devicegraph [Devicegraph] used to find the corresponding devices that will get
+      #   associated to each search element.
+      def initialize(devicegraph)
         textdomain "agama"
+
+        @devicegraph = devicegraph
       end
 
       # Resolve all the 'search' elements within a given configuration
       #
-      # The second argument (the storage configuration) gets modified in several ways:
+      # The first argument (the storage configuration) gets modified in several ways:
       #
       #   - All its 'search' elements get resolved, associating devices from the devicegraph
       #     (first argument) if some is found.
       #   - Some device definitions can get removed if configured to be skipped in absence of a
       #     corresponding device
       #
-      # The third argument (the list of issues) gets modified by adding any found problem.
+      # The second argument (the list of issues) gets modified by adding any found problem.
       #
-      # @param devicegraph [Devicegraph] used to find the corresponding devices that will get
-      #   associated to each search element
-      # @param settings [Agama::Storage::Config] storage configuration containing device definitions
+      # @param config [Agama::Storage::Config] storage configuration containing device definitions
       #   like drives, volume groups, etc.
       # @param issues_list [Array<Agama::Issue>]
-      def search(devicegraph, settings, issues_list)
+      def search(config, issues_list)
         @sids = []
-        settings.drives.each do |drive|
-          drive.search_device(devicegraph, @sids)
-          process_element(drive, settings.drives, issues_list)
+        config.drives.each do |drive_config|
+          device = find_drive(drive_config.search)
+          drive_config.search.resolve(device)
 
-          next unless drive.found_device && drive.partitions?
+          process_element(drive_config, config.drives, issues_list)
 
-          drive.partitions.each do |part|
-            next unless part.search
+          next unless drive_config.found_device && drive_config.partitions?
 
-            part.search_device(drive.found_device, @sids)
-            process_element(part, drive.partitions, issues_list)
+          drive_config.partitions.each do |partition_config|
+            next unless partition_config.search
+
+            partition = find_partition(partition_config.search, drive_config.found_device)
+            partition_config.search.resolve(partition)
+            process_element(partition_config, drive_config.partitions, issues_list)
           end
         end
       end
 
     private
+
+      # @return [Devicegraph]
+      attr_reader :devicegraph
+
+      # @return [Array<Integer>] SIDs of the devices that are already associated to another search.
+      attr_reader :sids
+
+      # Finds a drive matching the given search config.
+      #
+      # @param search_config [Agama::Storage::Configs::Search]
+      # @return [Y2Storage::Device, nil]
+      def find_drive(search_config)
+        candidates = candidate_devices(search_config, default: devicegraph.blk_devices)
+        candidates.select! { |d| d.is?(:disk_device, :stray_blk_device) }
+        next_unassigned_device(candidates)
+      end
+
+      # Finds a partitions matching the given search config.
+      #
+      # @param search_config [Agama::Storage::Configs::Search]
+      # @return [Y2Storage::Device, nil]
+      def find_partition(search_config, device)
+        candidates = candidate_devices(search_config, default: device.partitions)
+        candidates.select! { |d| d.is?(:partition) }
+        next_unassigned_device(candidates)
+      end
+
+      # Candidate devices for the given search config.
+      #
+      # @param search_config [Agama::Storage::Configs::Search]
+      # @param default [Array<Y2Storage::Device>] Candidates if the search does not indicate
+      #   conditions.
+      # @return [Array<Y2Storage::Device>]
+      def candidate_devices(search_config, default: [])
+        return default if search_config.any_device?
+
+        [find_device(search_config)].compact
+      end
+
+      # Perfomrs a search in the devicegraph to find a device matching the given search config.
+      #
+      # @param search_config [Agama::Storage::Configs::Search]
+      # @return [Y2Storage::Device]
+      def find_device(search_config)
+        devicegraph.find_by_any_name(search_config.name)
+      end
+
+      # Next unassigned device from the given list.
+      #
+      # @param devices [Array<Y2Storage::Device>]
+      # @return [Y2Storage::Device, nil]
+      def next_unassigned_device(devices)
+        devices
+          .reject { |d| sids.include?(d.sid) }
+          .min_by(&:name)
+      end
 
       # @see #search
       def process_element(element, collection, issues_list)

--- a/service/lib/y2storage/proposal/agama_searcher.rb
+++ b/service/lib/y2storage/proposal/agama_searcher.rb
@@ -110,7 +110,7 @@ module Y2Storage
         [find_device(search_config)].compact
       end
 
-      # Perfomrs a search in the devicegraph to find a device matching the given search config.
+      # Performs a search in the devicegraph to find a device matching the given search config.
       #
       # @param search_config [Agama::Storage::Configs::Search]
       # @return [Y2Storage::Device]

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep  3 08:14:23 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Storage: add support for searching by device in the storage
+  config (gh#openSUSE/agama#1560).
+
+-------------------------------------------------------------------
 Tue Aug 27 15:16:17 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Storage: allow calling to #SetConfig D-Bus method using the new

--- a/service/test/fixtures/partitioned_disk.yaml
+++ b/service/test/fixtures/partitioned_disk.yaml
@@ -1,0 +1,23 @@
+---
+- disk:
+    name: "/dev/vda"
+    size: 50 GiB
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 2 MiB
+        name: "/dev/vda1"
+        id: bios_boot
+    - partition:
+        size: 20 GiB
+        name: "/dev/vda2"
+        id: linux
+        file_system: btrfs
+    - partition:
+        size: 10 GiB
+        name: "/dev/vda3"
+        id: linux
+        file_system: xfs
+- disk:
+    name: "/dev/vdb"
+    size: 50 GiB


### PR DESCRIPTION
Allow using a *search* section in the storage JSON config for drives and partitions, according to the [auto_storage](https://github.com/openSUSE/agama/blob/master/doc/auto_storage.md) document. For now, the *search* only supports:

* To search by device name (linux name or udev name).
* To fail or to skip the section if the device is not found.

Examples:

~~~json
{
  "search": "/dev/disk/by-id/ata-Micron_1100_SATA_512GB_1652155452D8"
}
~~~

~~~json
{
  "search": {
    "condition": { "name": "/dev/vdc1" },
    "ifNotFound": "skip"
  }
}
~~~
