### PR TITLE
Install dbus-1-daemon explicitly since Tumbleweed now uses dbus-broker (#1561)

### DIFF
--- a/setup-services.sh
+++ b/setup-services.sh
@@ -51,6 +51,7 @@ $SUDO $ZYPPER install \
 # TODO extract list from gem2rpm.yml
 $SUDO $ZYPPER install \
   dbus-1-common \
+  dbus-1-daemon \
   suseconnect-ruby-bindings \
   autoyast2-installation \
   yast2 \


### PR DESCRIPTION

## Problem

- Filed as issue #1561
[Tumbleweed snapshot 20240825 announcement][tw0825] quotes dbus-1.changes:

> - No longer start or offer starting dbus as a system service
>   dbus-broker will be the only supported system dbus. Although
>   the existing daemon will stay as some things (gdm) require
>   dbus-run-session

[tw0825]: https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/GUIJNW45DGP25M7RS4EPAKTEP7IXEHWU/

dbus-broker is not a drop-in replacement:
for example it does not share the config file, so eventual migration to use it is not trivial

## Solution

- Fix `/setup-services.sh`, used by `/setup.sh` and `testing_in_container.sh`
- No `.changes` entry as this fixes no package (yet. TODO)


## Testing

- *Tested manually*: `testing_in_container.sh` passes


## Screenshots

No
