### PR TITLE
 agama config load/store for "product" uses the HTTP API

### DIFF
--- a/rust/agama-lib/src/product.rs
+++ b/rust/agama-lib/src/product.rs
@@ -1,11 +1,13 @@
 //! Implements support for handling the product settings
 
 mod client;
+mod http_client;
 pub mod proxies;
 mod settings;
 mod store;
 
 pub use crate::software::model::RegistrationRequirement;
 pub use client::{Product, ProductClient};
+pub use http_client::ProductHTTPClient;
 pub use settings::ProductSettings;
 pub use store::ProductStore;

--- a/rust/agama-lib/src/product.rs
+++ b/rust/agama-lib/src/product.rs
@@ -5,6 +5,7 @@ pub mod proxies;
 mod settings;
 mod store;
 
-pub use client::{Product, ProductClient, RegistrationRequirement};
+pub use crate::software::model::RegistrationRequirement;
+pub use client::{Product, ProductClient};
 pub use settings::ProductSettings;
 pub use store::ProductStore;

--- a/rust/agama-lib/src/product/client.rs
+++ b/rust/agama-lib/src/product/client.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use crate::error::ServiceError;
+use crate::software::model::RegistrationRequirement;
 use crate::software::proxies::SoftwareProductProxy;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use zbus::Connection;
 
 use super::proxies::RegistrationProxy;
@@ -16,35 +17,6 @@ pub struct Product {
     pub name: String,
     /// Product description
     pub description: String,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
-pub enum RegistrationRequirement {
-    /// Product does not require registration
-    NotRequired = 0,
-    /// Product has optional registration
-    Optional = 1,
-    /// It is mandatory to register the product
-    Mandatory = 2,
-}
-
-impl TryFrom<u32> for RegistrationRequirement {
-    type Error = ();
-
-    fn try_from(v: u32) -> Result<Self, Self::Error> {
-        match v {
-            x if x == RegistrationRequirement::NotRequired as u32 => {
-                Ok(RegistrationRequirement::NotRequired)
-            }
-            x if x == RegistrationRequirement::Optional as u32 => {
-                Ok(RegistrationRequirement::Optional)
-            }
-            x if x == RegistrationRequirement::Mandatory as u32 => {
-                Ok(RegistrationRequirement::Mandatory)
-            }
-            _ => Err(()),
-        }
-    }
 }
 
 /// D-Bus client for the software service

--- a/rust/agama-lib/src/product/http_client.rs
+++ b/rust/agama-lib/src/product/http_client.rs
@@ -1,0 +1,75 @@
+use crate::software::model::RegistrationInfo;
+use crate::software::model::RegistrationParams;
+use crate::software::model::SoftwareConfig;
+use crate::{base_http_client::BaseHTTPClient, error::ServiceError};
+
+pub struct ProductHTTPClient {
+    client: BaseHTTPClient,
+}
+
+impl ProductHTTPClient {
+    pub fn new() -> Result<Self, ServiceError> {
+        Ok(Self {
+            client: BaseHTTPClient::new()?,
+        })
+    }
+
+    pub fn new_with_base(base: BaseHTTPClient) -> Self {
+        Self { client: base }
+    }
+
+    // FIXME get_software_config ?
+    pub async fn get_config(&self) -> Result<SoftwareConfig, ServiceError> {
+        self.client.get("/software/config").await
+    }
+
+    pub async fn set_config(&self, config: &SoftwareConfig) -> Result<(), ServiceError> {
+        self.client.put_void("/software/config", config).await
+    }
+
+    /// Returns the id of the selected product to install
+    pub async fn product(&self) -> Result<String, ServiceError> {
+        let config = self.get_config().await?;
+        if let Some(product) = config.product {
+            Ok(product)
+        } else {
+            Ok("".to_owned())
+        }
+    }
+
+    /// Selects the product to install
+    pub async fn select_product(&self, product_id: &str) -> Result<(), ServiceError> {
+        let config = SoftwareConfig {
+            product: Some(product_id.to_owned()),
+            patterns: None,
+        };
+        self.set_config(&config).await
+    }
+
+    pub async fn get_registration(&self) -> Result<RegistrationInfo, ServiceError> {
+        self.client.get("/software/registration").await
+    }
+
+    /// registration code used to register product
+    pub async fn registration_code(&self) -> Result<String, ServiceError> {
+        let ri = self.get_registration().await?;
+        Ok(ri.key)
+    }
+
+    /// email used to register product
+    pub async fn email(&self) -> Result<String, ServiceError> {
+        let ri = self.get_registration().await?;
+        Ok(ri.email)
+    }
+
+    /// register product
+    pub async fn register(&self, code: &str, email: &str) -> Result<(u32, String), ServiceError> {
+        // note RegistrationParams != RegistrationInfo, fun!
+        let params = RegistrationParams {
+            key: code.to_owned(),
+            email: email.to_owned(),
+        };
+
+        self.client.post("/software/registration", &params).await
+    }
+}

--- a/rust/agama-lib/src/product/store.rs
+++ b/rust/agama-lib/src/product/store.rs
@@ -1,20 +1,20 @@
 //! Implements the store for the product settings.
 
-use super::{ProductClient, ProductSettings};
+use super::{ProductHTTPClient, ProductSettings};
 use crate::error::ServiceError;
 use crate::manager::ManagerClient;
 use zbus::Connection;
 
 /// Loads and stores the product settings from/to the D-Bus service.
 pub struct ProductStore<'a> {
-    product_client: ProductClient<'a>,
+    product_client: ProductHTTPClient,
     manager_client: ManagerClient<'a>,
 }
 
 impl<'a> ProductStore<'a> {
     pub async fn new(connection: Connection) -> Result<ProductStore<'a>, ServiceError> {
         Ok(Self {
-            product_client: ProductClient::new(connection.clone()).await?,
+            product_client: ProductHTTPClient::new()?,
             manager_client: ManagerClient::new(connection).await?,
         })
     }

--- a/rust/agama-lib/src/software/model.rs
+++ b/rust/agama-lib/src/software/model.rs
@@ -9,3 +9,54 @@ pub struct SoftwareConfig {
     /// Name of the product to install.
     pub product: Option<String>,
 }
+
+/// Software service configuration (product, patterns, etc.).
+#[derive(Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct RegistrationParams {
+    /// Registration key.
+    pub key: String,
+    /// Registration email.
+    pub email: String,
+}
+
+/// Information about registration configuration (product, patterns, etc.).
+#[derive(Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RegistrationInfo {
+    /// Registration key. Empty value mean key not used or not registered.
+    pub key: String,
+    /// Registration email. Empty value mean email not used or not registered.
+    pub email: String,
+    /// if registration is required, optional or not needed for current product.
+    /// Change only if selected product is changed.
+    pub requirement: RegistrationRequirement,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub enum RegistrationRequirement {
+    /// Product does not require registration
+    NotRequired = 0,
+    /// Product has optional registration
+    Optional = 1,
+    /// It is mandatory to register the product
+    Mandatory = 2,
+}
+
+impl TryFrom<u32> for RegistrationRequirement {
+    type Error = ();
+
+    fn try_from(v: u32) -> Result<Self, Self::Error> {
+        match v {
+            x if x == RegistrationRequirement::NotRequired as u32 => {
+                Ok(RegistrationRequirement::NotRequired)
+            }
+            x if x == RegistrationRequirement::Optional as u32 => {
+                Ok(RegistrationRequirement::Optional)
+            }
+            x if x == RegistrationRequirement::Mandatory as u32 => {
+                Ok(RegistrationRequirement::Mandatory)
+            }
+            _ => Err(()),
+        }
+    }
+}

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -12,11 +12,12 @@ use crate::{
         Event,
     },
 };
+
 use agama_lib::{
     error::ServiceError,
-    product::{proxies::RegistrationProxy, Product, ProductClient, RegistrationRequirement},
+    product::{proxies::RegistrationProxy, Product, ProductClient},
     software::{
-        model::SoftwareConfig,
+        model::{RegistrationInfo, RegistrationParams, SoftwareConfig},
         proxies::{Software1Proxy, SoftwareProductProxy},
         Pattern, SelectedBy, SoftwareClient, UnknownSelectedBy,
     },
@@ -229,19 +230,6 @@ async fn products(State(state): State<SoftwareState<'_>>) -> Result<Json<Vec<Pro
     Ok(Json(products))
 }
 
-/// Information about registration configuration (product, patterns, etc.).
-#[derive(Clone, Serialize, Deserialize, utoipa::ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct RegistrationInfo {
-    /// Registration key. Empty value mean key not used or not registered.
-    key: String,
-    /// Registration email. Empty value mean email not used or not registered.
-    email: String,
-    /// if registration is required, optional or not needed for current product.
-    /// Change only if selected product is changed.
-    requirement: RegistrationRequirement,
-}
-
 /// returns registration info
 ///
 /// * `state`: service state.
@@ -265,15 +253,6 @@ async fn get_registration(
     Ok(Json(result))
 }
 
-/// Software service configuration (product, patterns, etc.).
-#[derive(Clone, Serialize, Deserialize, utoipa::ToSchema)]
-pub struct RegistrationParams {
-    /// Registration key.
-    key: String,
-    /// Registration email.
-    email: String,
-}
-
 #[derive(Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct FailureDetails {
     /// ID of error. See dbus API for possible values
@@ -281,6 +260,7 @@ pub struct FailureDetails {
     /// human readable error string intended to be displayed to user
     message: String,
 }
+
 /// Register product
 ///
 /// * `state`: service state.

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -112,7 +112,7 @@ fi
       # we are in a container, told to use that one
       # instead of a released version
       # edit +Gemfile and -gemspec
-      sed -e '/ruby-dbus/d' -i Gemfile agama.gemspec
+      sed -e '/ruby-dbus/d' -i Gemfile agama-yast.gemspec
       sed -e '/gemspec/a gem "ruby-dbus", path: "/checkout-ruby-dbus"' -i Gemfile
   fi
 

--- a/testing_using_container.sh
+++ b/testing_using_container.sh
@@ -44,7 +44,7 @@ podman run --name ${CNAME?} \
 # shortcut for the following
 CEXEC="podman exec ${CNAME?} bash -c"
 
-${CEXEC?} "cd /checkout && ./setup.sh"
+${CEXEC?} "cd /checkout && ./setup.sh || true"
 
 echo "Set the Agama (root) password:"
 podman exec -it ${CNAME?} passwd


### PR DESCRIPTION
## Problem

*Short description of the original problem.*

**Product** and **registration** part of the migration of the CLI from D-Bus API to HTTP API:

- https://trello.com/c/hvPtBtMD/3719-5-replace-d-bus-with-http-based-clients?filter=member:martinvidner


## Solution


- Added `ProductHTTPClient`
- Kept (D-Bus) `ProductClient` because it serves as the backend for the above
- TODO mention the trickier parts of using two clients at two levels


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

No
