### PR TITLE
Fixed failing integration test in CI

### DIFF
--- a/setup-services.sh
+++ b/setup-services.sh
@@ -116,7 +116,13 @@ fi
       sed -e '/gemspec/a gem "ruby-dbus", path: "/checkout-ruby-dbus"' -i Gemfile
   fi
 
-  bundle config set --local path 'vendor/bundle'
+  if [ -n "$CI" ]; then
+    # in CI reuse the pre-installed system gems from RPMs
+    bundle config set --local disable_shared_gems 0
+  else
+    bundle config set --local path 'vendor/bundle'
+  fi
+
   bundle install
 )
 


### PR DESCRIPTION
## Problem

- The [integration test fails](https://github.com/openSUSE/agama/actions/runs/10630606402/job/29469809489#step:9:411)
- The augeas Ruby gem 0.5.0 from rubygems.org is not compatible with Ruby 3.3

## Solution

- Configure the bundler to reuse the preinstalled RPM packages. The rubygem-augeas is already patched in OBS.
- The [test passes](https://github.com/lslezak/agama/actions/runs/10631867513/job/29473633071#step:9:329) when running from my fork