### PR TITLE
Add KDE to Leap 16.0, drop Xfce which is not ready

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep  3 10:24:30 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Add kde to Leap 16.0
+  initial set of ~800 related packages were just merged to Leap 16.0
+
+-------------------------------------------------------------------
 Fri Aug  2 09:12:25 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Adjust Linux Security Modules (LSM) configuration for SLES 16

--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Tue Sep  3 10:24:30 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
-- Add kde to Leap 16.0
-  initial set of ~800 related packages were just merged to Leap 16.0
+- Add kde to Leap 16.0, remove Xfce until it's fully submitted to 16.0
+  initial set of ~800 KIDE related packages were just merged to Leap 16.0
 
 -------------------------------------------------------------------
 Fri Aug  2 09:12:25 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -39,7 +39,6 @@ software:
   optional_patterns: null # no optional pattern shared
   user_patterns:
     - basic_desktop
-    - xfce
     - gnome
     - kde
     - yast2_basis

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -41,6 +41,7 @@ software:
     - basic_desktop
     - xfce
     - gnome
+    - kde
     - yast2_basis
     - yast2_desktop
     - yast2_server


### PR DESCRIPTION
KDE enablement for Leap 16.0 (on of prereqs for Alpha). Drop XFce which is not ready yet.