### PR TITLE
fix(live): Firefox: disable the initial configuration workflow

### DIFF
--- a/live/root/root/.mozilla/firefox/profile/user.js.template
+++ b/live/root/root/.mozilla/firefox/profile/user.js.template
@@ -5,6 +5,9 @@ user_pref("signon.management.page.breach-alerts.enabled", false);
 user_pref("signon.rememberSignons", false);
 user_pref("signon.generation.enabled", false);
 
+// disable the initial configuration workflow
+user_pref("browser.aboutwelcome.enabled", false);
+
 // start always in the custom homepage
 user_pref("browser.startup.page", 1);
 // custom homepage: the value is expected to be replaced with the login URL by the startup script

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep  3 14:50:58 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Firefox: disable the initial configuration workflow
+  (gh#openSUSE/agama#1573)
+
+-------------------------------------------------------------------
 Fri Aug 30 13:05:53 UTC 2024 - Thomas Blume <Thomas.Blume@suse.com>
 
 - remove memcheck workaround in images.sh (bsc#1228621)


### PR DESCRIPTION
## Problem

In SLFO the Firefox shows the welcome screen at the first start instead of the Agama page.

![Agama-Firefox-SLE](https://github.com/user-attachments/assets/df2abd2f-4683-4066-99cc-e90b0212c758)


## Solution

- Disable the initial welcome screen in the default Firefox profile

## Testing

- With this option the welcome screen is skipped