### PR TITLE
fix(live): Install Firefox on all archs, install  MozillaFirefox-branding-SLE

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep  4 07:08:30 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Install Firefox on all architectures, install
+  MozillaFirefox-branding-SLE in the SLE image
+  (gh#openSUSE/agama#1574)
+
+-------------------------------------------------------------------
 Tue Sep  3 14:50:58 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Firefox: disable the initial configuration workflow

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -133,8 +133,7 @@
         <package name="libblogger2" arch="s390x" />
         <package name="xauth"/>
         <package name="patterns-yast-yast2_basis"/>
-        <package name="MozillaFirefox" arch="aarch64,x86_64"/>
-        <package name="MozillaFirefox-branding-openSUSE" arch="aarch64,x86_64"/>
+        <package name="MozillaFirefox"/>
         <package name="libpwquality-tools"/>
         <package name="NetworkManager"/>
         <package name="agama"/>
@@ -168,6 +167,7 @@
         <package name="ruby3.3-rubygem-byebug"/>
         <package name="staging-build-key"/>
         <package name="openSUSE-build-key"/>
+        <package name="MozillaFirefox-branding-openSUSE"/>
     </packages>
     <!-- additional packages for the SLE distributions -->
     <packages type="image" profiles="SLE">
@@ -177,6 +177,7 @@
         <package name="ruby3.2-rubygem-agama-yast"/>
         <package name="ruby3.2-rubygem-byebug"/>
         <package name="suse-build-key"/>
+        <package name="MozillaFirefox-branding-SLE"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>


### PR DESCRIPTION
## Problem

- Firefox is not installed on all architectures, it is need to run the integration tests


## Solution

- Include it on all architectures
- Add the SLE branding to the SLE image

## Testing

- Testing image built in my IBS branch [home:lslezak:branches:Devel:YaST:Agama:Head](https://build.suse.de/package/show/home:lslezak:branches:Devel:YaST:Agama:Head/agama-installer), the image builds fine on all architectures
- Manually tested the built x86_64 image

