### PR TITLE
feat(storage): config support to reuse file systems

### DIFF
--- a/rust/agama-lib/share/examples/storage.json
+++ b/rust/agama-lib/share/examples/storage.json
@@ -24,7 +24,6 @@
               }
             },
             "filesystem": {
-              "reuse": false,
               "type": {
                 "btrfs": {
                   "snapshots": true
@@ -87,6 +86,7 @@
           "ifNotFound": "skip"
         },
         "filesystem": {
+          "reuseIfPossible": true,
           "type": "ext4",
           "path": "/var/log"
         }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -870,9 +870,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "reuse": {
+        "reuseIfPossible": {
           "title": "Reuse file system",
-          "description": "Whether to reuse the existing file system (if any).",
+          "description": "Try to reuse the existing file system. In some cases the file system could not be reused, for example, if the device is re-encrypted.",
           "type": "boolean",
           "default": false
         },
@@ -886,7 +886,7 @@
         "path": {
           "title": "Mount path",
           "type": "string",
-          "examples": ["/dev/vda"]
+          "examples": ["/var/log"]
         },
         "mountBy": {
           "title": "How to mount the device",

--- a/service/lib/agama/storage/config_conversions/filesystem/from_json.rb
+++ b/service/lib/agama/storage/config_conversions/filesystem/from_json.rb
@@ -41,18 +41,20 @@ module Agama
           def convert(default = nil)
             default_config = default.dup || Configs::Filesystem.new
 
-            default_config.tap do |config|
-              mount_by = convert_mount_by
-              type = convert_type(config.type)
-              label = filesystem_json[:label]
-              mkfs_options = filesystem_json[:mkfsOptions]
+            values = {
+              reuse:         filesystem_json[:reuseIfPossible],
+              label:         filesystem_json[:label],
+              path:          filesystem_json[:path],
+              mount_options: filesystem_json[:mountOptions],
+              mkfs_options:  filesystem_json[:mkfsOptions],
+              mount_by:      convert_mount_by,
+              type:          convert_type(default_config.type)
+            }
 
-              config.path = filesystem_json[:path]
-              config.mount_options = filesystem_json[:mountOptions] || []
-              config.mount_by = mount_by if mount_by
-              config.type = type if type
-              config.label = label if label
-              config.mkfs_options = mkfs_options if mkfs_options
+            default_config.tap do |config|
+              values.each do |property, value|
+                config.public_send("#{property}=", value) unless value.nil?
+              end
             end
           end
 

--- a/service/lib/agama/storage/configs/filesystem.rb
+++ b/service/lib/agama/storage/configs/filesystem.rb
@@ -29,6 +29,10 @@ module Agama
         # @return [Pathname] Object that represents the root path.
         ROOT_PATH = Pathname.new("/").freeze
 
+        # @return [Boolean]
+        attr_accessor :reuse
+        alias_method :reuse?, :reuse
+
         # @return [String, nil]
         attr_accessor :path
 
@@ -48,6 +52,7 @@ module Agama
         attr_accessor :mount_by
 
         def initialize
+          @reuse = false
           @mount_options = []
           @mkfs_options = []
         end

--- a/service/lib/y2storage/proposal/agama_device_planner.rb
+++ b/service/lib/y2storage/proposal/agama_device_planner.rb
@@ -59,14 +59,25 @@ module Y2Storage
     private
 
       # @param planned [Planned::Disk, Planned::Partition]
-      # @param settings [#found_device]
-      def configure_reuse(planned, settings)
-        device = settings.found_device
+      # @param config [Agama::Storage::Configs::Drive, Agama::Storage::Configs::Partition]
+      def configure_reuse(planned, config)
+        device = config.found_device
         return unless device
 
         planned.assign_reuse(device)
-        # TODO: Allow mounting without reformatting.
-        planned.reformat = true
+        planned.reformat = reformat?(device, config)
+      end
+
+      # Whether to reformat the device.
+      #
+      # @param device [Y2Storage::BlkDevice]
+      # @param config [Agama::Storage::Configs::Drive, Agama::Storage::Configs::Partition]
+      # @return [Boolean]
+      def reformat?(device, config)
+        return true if device.filesystem.nil?
+
+        # TODO: reformat if the encryption has to be created.
+        !config.filesystem&.reuse?
       end
 
       # @param planned [Planned::Disk, Planned::Partition]

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep  5 17:35:04 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Storage: add support for reusing file systems in the storage
+  config (gh#openSUSE/agama#1575).
+
+-------------------------------------------------------------------
 Thu Sep  5 16:25:00 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Show product logo in product selector (gh#openSUSE/agama#1415).

--- a/service/test/agama/storage/config_conversions/from_json_test.rb
+++ b/service/test/agama/storage/config_conversions/from_json_test.rb
@@ -211,18 +211,20 @@ describe Agama::Storage::ConfigConversions::FromJSON do
 
       let(:filesystem) do
         {
-          path:         "/",
-          type:         "xfs",
-          label:        "root",
-          mkfsOptions:  ["version=2"],
-          mountOptions: ["rw"],
-          mountBy:      "label"
+          reuseIfPossible: true,
+          path:            "/",
+          type:            "xfs",
+          label:           "root",
+          mkfsOptions:     ["version=2"],
+          mountOptions:    ["rw"],
+          mountBy:         "label"
         }
       end
 
       it "uses the specified attributes" do
         config = subject.convert
         filesystem = config.drives.first.filesystem
+        expect(filesystem.reuse?).to eq true
         expect(filesystem.path).to eq "/"
         expect(filesystem.type.fs_type).to eq Y2Storage::Filesystems::Type::XFS
         expect(filesystem.label).to eq "root"
@@ -237,6 +239,7 @@ describe Agama::Storage::ConfigConversions::FromJSON do
         it "uses the default type and btrfs attributes for that path" do
           config = subject.convert
           filesystem = config.drives.first.filesystem
+          expect(filesystem.reuse?).to eq false
           expect(filesystem.type.fs_type).to eq Y2Storage::Filesystems::Type::BTRFS
           expect(filesystem.type.btrfs.snapshots).to eq true
           expect(filesystem.type.btrfs.default_subvolume).to eq "@"

--- a/service/test/fixtures/disks.yaml
+++ b/service/test/fixtures/disks.yaml
@@ -21,3 +21,8 @@
 - disk:
     name: "/dev/vdb"
     size: 50 GiB
+
+- disk:
+    name: "/dev/vdc"
+    size: 50 GiB
+    file_system: "ext4"


### PR DESCRIPTION
Allow using *reuseIfPossible* for a *filesystem* section in the storage JSON config. The [auto_storage](https://github.com/openSUSE/agama/blob/master/doc/auto_storage.md) document proposes to have a *reuse* property, but *reuseIfPossible* was used instead, see https://github.com/openSUSE/agama/pull/1575#pullrequestreview-2282229940:

If *reuseIfPossible* is true, then Agama will try to reuse the file system, if any. In that case, some other properties from the *filesystem* section would be ignored.

Example:

~~~json
{
  "search": "/dev/vda1",
  "filesystem": {
    "reuseIfPossible": true,
    "path": "/logs",
    "type": "xfs",
    "mkfsOptions": ["rw"]
  }
}
~~~

The properties *type* and *mkfsOptions* would be considered by Agama only if the file system is not finally reused.
