### PR TITLE
Drop .package-lock.json

### DIFF
--- a/puppeteer/package/agama-integration-tests.spec
+++ b/puppeteer/package/agama-integration-tests.spec
@@ -61,6 +61,8 @@ cp -a %{_builddir}/agama/package.json %{buildroot}%{_datadir}/agama/integration-
 install -D -d -m 0755 %{buildroot}%{_bindir}
 cp -a %{_builddir}/agama/agama-integration-tests %{buildroot}%{_bindir}
 
+rm %{buildroot}%{_datadir}/agama/integration-tests/node_modules/.package-lock.json
+
 # symlink duplicate files
 %fdupes -s %{buildroot}/%{_datadir}/agama/integration-tests
 


### PR DESCRIPTION
Drop (leftover?) .package-lock.json for reproducible builds

## Problem

The .package-lock.json file containted a random TCP port number, which made build results vary.


- *Bugzilla link* [generic tracker bug](https://bugzilla.opensuse.org/show_bug.cgi?id=1062303)


## Solution

We drop the file. If that is not appropriate, we could replace the random number with a constant.


## Testing

- tested that it builds reproducibly.