### PR TITLE
Fix typo in changes

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -7,7 +7,7 @@ Thu Sep  5 16:25:00 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 Tue Sep  3 10:24:30 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Add kde to Leap 16.0, remove Xfce until it's fully submitted to 16.0
-  initial set of ~800 KIDE related packages were just merged to Leap 16.0
+  initial set of ~800 KDE related packages were just merged to Leap 16.0
 
 -------------------------------------------------------------------
 Fri Aug  2 09:12:25 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>


### PR DESCRIPTION
Fix of typo in KDE in changelog. This typo was a reason to reject https://build.opensuse.org/request/show/1198965 