### PR TITLE
Ensure that product icons are packaged

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Sep  6 15:04:58 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Ensure that product icons are packaged 
+
+-------------------------------------------------------------------
 Fri Sep  6 08:06:41 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Adopt TanStack Query and Axios for state management and

--- a/web/package/agama-web-ui.spec
+++ b/web/package/agama-web-ui.spec
@@ -47,11 +47,14 @@ NODE_ENV="production" npm run build
 %install
 install -D -m 0644 --target-directory=%{buildroot}%{_datadir}/agama/web_ui %{_builddir}/agama/dist/*.{gz,html,js,map,svg}
 install -D -m 0644 --target-directory=%{buildroot}%{_datadir}/agama/web_ui/fonts %{_builddir}/agama/dist/fonts/*.woff?
+install -D -m 0644 --target-directory=%{buildroot}%{_datadir}/agama/web_ui/assets/logos %{_builddir}/agama/src/assets/products/*.svg
 
 %files
 %doc README.md
 %license LICENSE
 %dir %{_datadir}/agama
 %{_datadir}/agama/web_ui
+%{_datadir}/agama/assets
+%{_datadir}/agama/products
 
 %changelog


### PR DESCRIPTION
Hello folks

Here's a fix that ensures installation of missing product icons but I'm not really happy about two things.

It seems that we're somehow trying to webpack this (I don't really have experience with this) I know that we're doing some npm installation in spec so I'm not sure if we should fix the webpack instead.

```
{_builddir}/agama/src/assets/products/*.svg
web/webpack.config.js:  { from: "./src/assets/products/*.svg", to: "assets/logos/[name][ext]" }

```

Why do we have it in src/assets/products/*.svg and install it into assets/logos/*.svg ?
Let's just use same path in both cases. 

Cheers

![image](https://github.com/user-attachments/assets/4440f5ec-7479-43df-9eed-f69631bf9e65)

