### PR TITLE
fix(web): package: do not try to install non-existant directories

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep  6 16:38:06 UTC 2024 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
+
+- Do not try to install assets/ and products/ directories (everything
+  is inside agama/web_ui/ already)
+
+-------------------------------------------------------------------
 Fri Sep  6 15:04:58 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Ensure that product icons are packaged 

--- a/web/package/agama-web-ui.spec
+++ b/web/package/agama-web-ui.spec
@@ -54,7 +54,5 @@ install -D -m 0644 --target-directory=%{buildroot}%{_datadir}/agama/web_ui/asset
 %license LICENSE
 %dir %{_datadir}/agama
 %{_datadir}/agama/web_ui
-%{_datadir}/agama/assets
-%{_datadir}/agama/products
 
 %changelog


### PR DESCRIPTION
The logos/ directory is already inside web_ui/.


## Problem

Latest agama-web-ui [is not building](https://build.opensuse.org/package/live_build_log/systemsmanagement:Agama:Devel/agama-web-ui/openSUSE_Tumbleweed/x86_64) after #1587 .


## Solution

Since the logos are already installed in `web_ui/logos`, we can drop the two (non-existent)? directories
listed in the %files section:

```
%{_datadir}/agama/assets
%{_datadir}/agama/products
```


## Testing

- *Tested manually*


