### PR TITLE
Use tty2 instead of tty7

### DIFF
--- a/live/root/etc/systemd/system/x11-autologin.service
+++ b/live/root/etc/systemd/system/x11-autologin.service
@@ -8,16 +8,16 @@ WorkingDirectory=~
 
 PAMName=login
 Environment=XDG_SESSION_TYPE=x11
-TTYPath=/dev/tty7
+TTYPath=/dev/tty2
 StandardInput=tty
 UnsetEnvironment=TERM
 
-UtmpIdentifier=tty7
+UtmpIdentifier=tty2
 UtmpMode=user
 
 StandardOutput=journal
-ExecStartPre=/usr/bin/chvt 7
-ExecStart=/usr/bin/startx -- vt7 -keeptty -verbose 3 -logfile /dev/null
+ExecStartPre=/usr/bin/chvt 2
+ExecStart=/usr/bin/startx -- vt2 -keeptty -verbose 3 -logfile /dev/null
 Restart=no
 
 [Install]

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Sun Sep  8 06:28:35 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Use tty2 instead of tty7 (gh#openSUSE/agama#1582)
+  This matches openQA tty expectations for >SLES12
+
+-------------------------------------------------------------------
 Wed Sep  4 07:08:30 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Install Firefox on all architectures, install


### PR DESCRIPTION
- This matches openQA tty expectations for >SLES12
-  Solves #1582 
-  Obsoletes following workaround https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20126