### PR TITLE
fix(live): firefox: set browser.startup.homepage_override.mstone to ignore

### DIFF
--- a/live/root/root/.mozilla/firefox/profile/user.js.template
+++ b/live/root/root/.mozilla/firefox/profile/user.js.template
@@ -8,6 +8,9 @@ user_pref("signon.generation.enabled", false);
 // disable the initial configuration workflow
 user_pref("browser.aboutwelcome.enabled", false);
 
+// disable homepage override on updates
+user_pref("browser.startup.homepage_override.mstone", "ignore");
+
 // start always in the custom homepage
 user_pref("browser.startup.page", 1);
 // custom homepage: the value is expected to be replaced with the login URL by the startup script

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep  9 15:55:16 UTC 2024 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
+
+- Firefox: set browser.startup.homepage_override.mstone to ignore
+  (gh#openSUSE/agama#1593) 
+
+-------------------------------------------------------------------
 Sun Sep  8 06:28:35 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Use tty2 instead of tty7 (gh#openSUSE/agama#1582)


### PR DESCRIPTION
Observed on Firefox ESR 128.1 in SLFO (with MozillaFirefox-branding-SLE). Without this option, Agama live would boot to the Firefox "new tab" window.

Only after closing and reopening Firefox multiple times it would then open the correct homepage as specified in the user.js settings.

Setting browser.startup.homepage_override.mstone to ignore helps in these cases.

MozillaZine reference: https://kb.mozillazine.org/Browser.startup.homepage_override.mstone


## Screenshots

![Screenshot from 2024-09-09 17-40-00](https://github.com/user-attachments/assets/486fc0d0-bfd7-42d4-aebf-f0b94b32dca6)

