### PR TITLE
chore(ruby): relax REXML dependency

### DIFF
--- a/service/agama-yast.gemspec
+++ b/service/agama-yast.gemspec
@@ -57,6 +57,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "eventmachine", "~> 1.2.7"
   spec.add_dependency "fast_gettext", "~> 2.3.0"
   spec.add_dependency "nokogiri", "~> 1.15"
-  spec.add_dependency "rexml", "~> 3.2.5"
+  spec.add_dependency "rexml", "~> 3.2"
   spec.add_dependency "ruby-dbus", ">= 0.23.1", "< 1.0"
 end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 10 10:03:04 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Relax REXML version (gh#openSUSE/agama#1595) to build with Ruby
+  3.3.
+
+-------------------------------------------------------------------
 Thu Sep  5 17:35:04 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Storage: add support for reusing file systems in the storage

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -2,12 +2,12 @@
 Fri Sep  6 16:38:06 UTC 2024 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
 
 - Do not try to install assets/ and products/ directories (everything
-  is inside agama/web_ui/ already)
+  is inside agama/web_ui/ already) (gh#openSUSE/agama#1588).
 
 -------------------------------------------------------------------
 Fri Sep  6 15:04:58 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
-- Ensure that product icons are packaged 
+- Ensure that product icons are packaged (gh#openSUSE/agama#1587).
 
 -------------------------------------------------------------------
 Fri Sep  6 08:06:41 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>


### PR DESCRIPTION
Relax REXML dependency to allow building in Ruby 3.3 (fixes #1595).