### PR TITLE
Implement 802.1x (EAP) in network settings

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -231,6 +231,90 @@
                     }
                   }
                 }
+              },
+              "ieee-8021x": {
+                "type": "object",
+                "title": "IEEE 802.1x (EAP) settings",
+                "properties": {
+                  "eap": {
+                    "type": "array",
+                    "items": {
+                      "title": "List of EAP methods used",
+                      "type": "string",
+                      "enum": [
+                        "leap",
+                        "md5",
+                        "tls",
+                        "peap",
+                        "ttls",
+                        "pwd",
+                        "fast"
+                      ]
+                    }
+                  },
+                  "phase2_auth": {
+                    "title": "Phase 2 inner auth method",
+                    "type": "string",
+                    "enum": [
+                      "pap",
+                      "chap",
+                      "mschap",
+                      "mschapv2",
+                      "gtc",
+                      "otp",
+                      "md5",
+                      "tls"
+                    ]
+                  },
+                  "identity": {
+                    "title": "Identity string, often for example the user's login name",
+                    "type": "string"
+                  },
+                  "password": {
+                    "title": "Password string used for EAP authentication",
+                    "type": "string"
+                  },
+                  "ca_cert": {
+                    "title": "Path to CA certificate",
+                    "type": "string"
+                  },
+                  "ca_cert_password": {
+                    "title": "Password string for CA certificate if it is encrypted",
+                    "type": "string"
+                  },
+                  "client_cert": {
+                    "title": "Path to client certificate",
+                    "type": "string"
+                  },
+                  "client_cert_password": {
+                    "title": "Password string for client certificate if it is encrypted",
+                    "type": "string"
+                  },
+                  "private_key": {
+                    "title": "Path to private key",
+                    "type": "string"
+                  },
+                  "private_key_password": {
+                    "title": "Password string for private key if it is encrypted",
+                    "type": "string"
+                  },
+                  "anonymous_identity": {
+                    "title": "Anonymous identity string for EAP authentication methods",
+                    "type": "string"
+                  },
+                  "peap_version": {
+                    "title": "Which PEAP version is used when PEAP is set as the EAP method in the 'eap' property",
+                    "type": "string",
+                    "enum": [
+                      "0",
+                      "1"
+                    ]
+                  },
+                  "peap_label": {
+                    "title": "Force the use of the new PEAP label during key derivation",
+                    "type": "boolean"
+                  }
+                }
               }
             }
           }

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -63,6 +63,50 @@ impl Default for BondSettings {
     }
 }
 
+/// IEEE 802.1x (EAP) settings
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IEEE8021XSettings {
+    /// List of EAP methods used
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub eap: Vec<String>,
+    /// Phase 2 inner auth method
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase2_auth: Option<String>,
+    /// Identity string, often for example the user's login name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identity: Option<String>,
+    /// Password string used for EAP authentication
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    /// Path to CA certificate
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ca_cert: Option<String>,
+    /// Password string for CA certificate if it is encrypted
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ca_cert_password: Option<String>,
+    /// Path to client certificate
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_cert: Option<String>,
+    /// Password string for client certificate if it is encrypted
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_cert_password: Option<String>,
+    /// Path to private key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private_key: Option<String>,
+    /// Password string for private key if it is encrypted
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private_key_password: Option<String>,
+    /// Anonymous identity string for EAP authentication methods
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anonymous_identity: Option<String>,
+    /// Which PEAP version is used when PEAP is set as the EAP method in the 'eap' property
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peap_version: Option<String>,
+    /// Force the use of the new PEAP label during key derivation
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub peap_label: bool,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NetworkDevice {
     pub id: String,
@@ -106,6 +150,8 @@ pub struct NetworkConnection {
     pub status: Option<Status>,
     #[serde(skip_serializing_if = "is_zero", default)]
     pub mtu: u32,
+    #[serde(rename = "ieee-8021x", skip_serializing_if = "Option::is_none")]
+    pub ieee_8021x: Option<IEEE8021XSettings>,
 }
 
 fn is_zero(u: &u32) -> bool {

--- a/rust/agama-server/src/network/error.rs
+++ b/rust/agama-server/src/network/error.rs
@@ -36,6 +36,10 @@ pub enum NetworkStateError {
     InvalidWEPAuthAlg(String),
     #[error("Invalid WEP key type: '{0}'")]
     InvalidWEPKeyType(u32),
+    #[error("Invalid EAP method: '{0}'")]
+    InvalidEAPMethod(String),
+    #[error("Invalid phase2 authentication method: '{0}'")]
+    InvalidPhase2AuthMethod(String),
 }
 
 impl From<NetworkStateError> for zbus::fdo::Error {

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Sep 10 15:00:33 UTC 2024 - Jorik Cronenberg <jorik.cronenberg@suse.com>
+
+- Implement 802.1x (EAP) in network settings (gh#openSUSE/agama#1597).
+
+-------------------------------------------------------------------
 Mon Sep  9 09:09:54 UTC 2024 - Martin Vidner <mvidner@suse.com>
 
 - For CLI, use HTTP clients instead of D-Bus clients,


### PR DESCRIPTION
## Problem

No option to configure 802.1x (EAP) for network connections.

## Solution

Add ability to configure 802.1x in agama.
Note: For the certificates etc. NM supports 3 different formats. I decided to only implement the file format as that is IMO the most useful and should suffice.

## Testing

- *Added a new unit test*
- *Tested manually*
```bash
sudo agama auth login && AGAMA_TOKEN=`sudo agama auth show`
curl -X POST http://localhost/api/network/connections \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $AGAMA_TOKEN" \
    -d '{ "id": "ethernet-test", "method4": "auto", "method6": "auto", "ignore_auto_dns": false, "status": "down", "ieee-8021x": { "eap": [ "peap" ], "phase2_auth": "mschapv2", "identity": "test_user", "password": "test_pw", "client_cert": "/etc/NetworkManager/system-connections/cert.pem", "private_key": "/etc/NetworkManager/system-connections/key.pem", "private_key_password": "test_pw", "peap_version": "1", "peap_label": true } }'
curl -X POST http://localhost/api/network/system/apply \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $AGAMA_TOKEN"
nmcli con show ethernet-test
# See 802-1x.* settings set.
```