### PR TITLE
AgamaProposal: handle resize of partitions

### DIFF
--- a/service/lib/y2storage/agama_proposal.rb
+++ b/service/lib/y2storage/agama_proposal.rb
@@ -161,7 +161,6 @@ module Y2Storage
     # @param devicegraph [Devicegraph] the graph gets modified
     def clean_graph(devicegraph)
       remove_empty_partition_tables(devicegraph)
-      protect_sids
       # {Proposal::SpaceMaker#prepare_devicegraph} returns a copy of the given devicegraph.
       space_maker.prepare_devicegraph(devicegraph, partitions_for_clean)
     end
@@ -234,18 +233,12 @@ module Y2Storage
       planned_devices.partitions
     end
 
-    # Configures SpaceMaker#protected_sids according to the given list of planned devices
-    def protect_sids
-      space_maker.protected_sids = planned_devices.all.select(&:reuse?).map(&:reuse_sid)
-    end
-
     # Creates the planned devices on a given devicegraph
     #
     # @param devicegraph [Devicegraph] the graph gets modified
     def create_devices(devicegraph)
       devices_creator = Proposal::AgamaDevicesCreator.new(devicegraph, issues_list)
       names = config.drives.map(&:found_device).compact.map(&:name)
-      protect_sids
       result = devices_creator.populated_devicegraph(planned_devices, names, space_maker)
     end
 

--- a/service/lib/y2storage/proposal/agama_device_planner.rb
+++ b/service/lib/y2storage/proposal/agama_device_planner.rb
@@ -61,6 +61,7 @@ module Y2Storage
 
         planned.assign_reuse(device)
         planned.reformat = reformat?(device, config)
+        planned.resize = grow?(device, config) if planned.respond_to?(:resize=)
       end
 
       # Whether to reformat the device.
@@ -73,6 +74,17 @@ module Y2Storage
 
         # TODO: reformat if the encryption has to be created.
         !config.filesystem&.reuse?
+      end
+
+      # Whether the device is a candidate to be resized (grown)
+      #
+      # @param device [Y2Storage::BlkDevice]
+      # @param config [Agama::Storage::Configs::Partition]
+      # @return [Boolean]
+      def grow?(device, config)
+        return false unless config.size
+
+        config.size.max.unlimited? || config.size.max > device.size
       end
 
       # @param planned [Planned::Disk, Planned::Partition]

--- a/service/lib/y2storage/proposal/agama_space_maker.rb
+++ b/service/lib/y2storage/proposal/agama_space_maker.rb
@@ -66,12 +66,12 @@ module Y2Storage
       # Space actions for devices that must be deleted.
       #
       # @param config [Agama::Storage::Config]
-      # @return [Hash]
+      # @return [Array<Y2Storage::SpaceActions::Delete>]
       def force_delete_actions(config)
         partition_configs = partitions(config).select(&:delete?)
         partition_names = device_names(partition_configs)
 
-        partition_names.each_with_object({}) { |p, a| a[p] = :force_delete }
+        partition_names.map { |p| Y2Storage::SpaceActions::Delete.new(p, mandatory: true) }
       end
 
       # Space actions for devices that might be deleted.
@@ -79,12 +79,12 @@ module Y2Storage
       # @note #delete? takes precedence over #delete_if_needed?.
       #
       # @param config [Agama::Storage::Config]
-      # @return [Hash]
+      # @return [Array<Y2Storage::SpaceActions::Delete>]
       def delete_actions(config)
         partition_configs = partitions(config).select(&:delete_if_needed?).reject(&:delete?)
         partition_names = device_names(partition_configs)
 
-        partition_names.each_with_object({}) { |p, a| a[p] = :delete }
+        partition_names.map { |p| Y2Storage::SpaceActions::Delete.new(p) }
       end
 
       # All partition configs from the given config.

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -39,7 +39,7 @@
     Requires:       yast2-iscsi-client >= 4.5.7
     Requires:       yast2-network
     Requires:       yast2-proxy
-    Requires:       yast2-storage-ng >= 5.0.17
+    Requires:       yast2-storage-ng >= 5.0.18
     Requires:       yast2-users
     %ifarch s390 s390x
     Requires:       yast2-s390 >= 4.6.4

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep 20 13:09:47 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Storage: preliminary support for resizing partitions based on
+  limits specified at the config (gh#openSUSE/agama#1599).
+
+-------------------------------------------------------------------
 Fri Sep 20 11:40:53 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 10

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -608,8 +608,13 @@ describe Agama::DBus::Storage::Manager do
           d.filesystem = filesystem
         end
 
+        boot = Agama::Storage::Configs::Boot.new.tap do |b|
+          b.configure = false
+        end
+
         Agama::Storage::Config.new.tap do |config|
           config.drives = [drive]
+          config.boot = boot
         end
       end
 

--- a/service/test/agama/storage/action_test.rb
+++ b/service/test/agama/storage/action_test.rb
@@ -38,6 +38,7 @@ describe Agama::Storage::Action do
     sda2.filesystem.delete_btrfs_subvolume("home")
 
     # Resize sda2
+    allow(sda2).to receive(:resize_info).and_return(resize_info)
     sda2.resize(Y2Storage::DiskSize.GiB(30))
   end
 
@@ -57,6 +58,13 @@ describe Agama::Storage::Action do
       .find { |a| a.target_device.is?(:btrfs_subvolume) }
 
     described_class.new(action, system_graph)
+  end
+
+  let(:resize_info) do
+    instance_double(
+      Y2Storage::ResizeInfo, resize_ok?: true,
+      min_size: Y2Storage::DiskSize.GiB(20), max_size: Y2Storage::DiskSize.GiB(40)
+    )
   end
 
   describe "#device_sid" do

--- a/service/test/agama/storage/actions_generator_test.rb
+++ b/service/test/agama/storage/actions_generator_test.rb
@@ -44,6 +44,7 @@ describe Agama::Storage::ActionsGenerator do
       sda2.filesystem.delete_btrfs_subvolume("home")
 
       # Resize sda2
+      allow(sda2).to receive(:resize_info).and_return(resize_info)
       sda2.resize(Y2Storage::DiskSize.GiB(30))
 
       # Create new partition
@@ -54,6 +55,13 @@ describe Agama::Storage::ActionsGenerator do
       # Delete sda3
       sda3 = staging_graph.find_by_name("/dev/sda3")
       partition_table.delete_partition(sda3)
+    end
+
+    let(:resize_info) do
+      instance_double(
+        Y2Storage::ResizeInfo, resize_ok?: true,
+        min_size: Y2Storage::DiskSize.GiB(20), max_size: Y2Storage::DiskSize.GiB(40)
+      )
     end
 
     it "generates a sorted list of actions" do

--- a/service/test/agama/storage/proposal_settings_conversions/to_y2storage_test.rb
+++ b/service/test/agama/storage/proposal_settings_conversions/to_y2storage_test.rb
@@ -298,7 +298,14 @@ describe Agama::Storage::ProposalSettingsConversions::ToY2Storage do
       context "when the space policy is set to :resize" do
         before do
           settings.space.policy = :resize
+
+          allow(Agama::Storage::DeviceShrinking).to receive(:new) do |dev|
+            dev.name == "/dev/sda2" ? shrink_true : shrink_false
+          end
         end
+
+        let(:shrink_false) { instance_double(Agama::Storage::DeviceShrinking, supported?: false) }
+        let(:shrink_true) { instance_double(Agama::Storage::DeviceShrinking, supported?: true) }
 
         it "generates resize actions for the partitions that support shrinking" do
           y2storage_settings = subject.convert

--- a/service/test/agama/storage/proposal_settings_conversions/to_y2storage_test.rb
+++ b/service/test/agama/storage/proposal_settings_conversions/to_y2storage_test.rb
@@ -64,7 +64,9 @@ describe Agama::Storage::ProposalSettingsConversions::ToY2Storage do
       expect(y2storage_settings.encryption_method).to eq(Y2Storage::EncryptionMethod::LUKS2)
       expect(y2storage_settings.encryption_pbkdf).to eq(Y2Storage::PbkdFunction::ARGON2ID)
       expect(y2storage_settings.space_settings.strategy).to eq(:bigger_resize)
-      expect(y2storage_settings.space_settings.actions).to eq({ "/dev/sda" => :force_delete })
+      expect(y2storage_settings.space_settings.actions).to eq(
+        [Y2Storage::SpaceActions::Delete.new("/dev/sda", mandatory: true)]
+      )
       expect(y2storage_settings.volumes).to include(
         an_object_having_attributes(
           mount_point: "/test",
@@ -286,11 +288,11 @@ describe Agama::Storage::ProposalSettingsConversions::ToY2Storage do
 
           expect(y2storage_settings.space_settings).to have_attributes(
             strategy: :bigger_resize,
-            actions:  {
-              "/dev/sda1" => :force_delete,
-              "/dev/sda2" => :force_delete,
-              "/dev/sda3" => :force_delete
-            }
+            actions:  [
+              Y2Storage::SpaceActions::Delete.new("/dev/sda1", mandatory: true),
+              Y2Storage::SpaceActions::Delete.new("/dev/sda2", mandatory: true),
+              Y2Storage::SpaceActions::Delete.new("/dev/sda3", mandatory: true)
+            ]
           )
         end
       end
@@ -312,9 +314,7 @@ describe Agama::Storage::ProposalSettingsConversions::ToY2Storage do
 
           expect(y2storage_settings.space_settings).to have_attributes(
             strategy: :bigger_resize,
-            actions:  {
-              "/dev/sda2" => :resize
-            }
+            actions:  [Y2Storage::SpaceActions::Resize.new("/dev/sda2")]
           )
         end
       end

--- a/service/test/agama/storage/proposal_test.rb
+++ b/service/test/agama/storage/proposal_test.rb
@@ -204,6 +204,7 @@ describe Agama::Storage::Proposal do
       let(:config_json) do
         {
           storage: {
+            boot:   { configure: false },
             drives: [
               {
                 filesystem: {


### PR DESCRIPTION
https://github.com/joseivanlopez/agama/pull/1 documented the approach to follow for resizing partitions at Agama, based on the partitioning config (a.k.a. the "profile").

The current pull request implements the basis of the described management.

It depends on the improvements introduced at yast2-storage-ng by https://github.com/yast/yast-storage-ng/pull/1388

### Pending

Some aspects of partition growing are not fully handled. That's planned for a future iteration and documented at https://trello.com/c/opInsicQ/531-storage-profile-partition-growing