### PR TITLE
agama config load/store for "storage" uses the HTTP API

### DIFF
--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -5,9 +5,7 @@ use std::{
 };
 
 use crate::show_progress;
-use agama_lib::{
-    auth::AuthToken, connection, install_settings::InstallSettings, Store as SettingsStore,
-};
+use agama_lib::{auth::AuthToken, install_settings::InstallSettings, Store as SettingsStore};
 use anyhow::anyhow;
 use clap::Subcommand;
 use std::io::Write;
@@ -48,7 +46,7 @@ pub async fn run(subcommand: ConfigCommands) -> anyhow::Result<()> {
     };
 
     let client = agama_lib::http_client(token.as_str())?;
-    let store = SettingsStore::new(connection().await?, client).await?;
+    let store = SettingsStore::new(client).await?;
 
     match subcommand {
         ConfigCommands::Show => {

--- a/rust/agama-cli/src/profile.rs
+++ b/rust/agama-cli/src/profile.rs
@@ -1,6 +1,5 @@
 use agama_lib::{
     auth::AuthToken,
-    connection,
     install_settings::InstallSettings,
     profile::{AutoyastProfile, ProfileEvaluator, ProfileValidator, ValidationResult},
     Store as SettingsStore,
@@ -149,7 +148,7 @@ async fn import(url_string: String, dir: Option<PathBuf>) -> anyhow::Result<()> 
 async fn store_settings<P: AsRef<Path>>(path: P) -> anyhow::Result<()> {
     let token = AuthToken::find().context("You are not logged in")?;
     let client = agama_lib::http_client(token.as_str())?;
-    let store = SettingsStore::new(connection().await?, client).await?;
+    let store = SettingsStore::new(client).await?;
     let settings = InstallSettings::from_file(&path)?;
     store.store(&settings).await?;
     Ok(())

--- a/rust/agama-lib/src/storage.rs
+++ b/rust/agama-lib/src/storage.rs
@@ -1,6 +1,7 @@
 //! Implements support for handling the storage settings
 
 pub mod client;
+pub mod http_client;
 pub mod model;
 pub mod proxies;
 mod settings;

--- a/rust/agama-lib/src/storage/http_client.rs
+++ b/rust/agama-lib/src/storage/http_client.rs
@@ -1,0 +1,28 @@
+//! Implements a client to access Agama's storage service.
+use crate::base_http_client::BaseHTTPClient;
+use crate::storage::StorageSettings;
+use crate::ServiceError;
+
+pub struct StorageHTTPClient {
+    client: BaseHTTPClient,
+}
+
+impl StorageHTTPClient {
+    pub fn new() -> Result<Self, ServiceError> {
+        Ok(Self {
+            client: BaseHTTPClient::new()?,
+        })
+    }
+
+    pub fn new_with_base(base: BaseHTTPClient) -> Self {
+        Self { client: base }
+    }
+
+    pub async fn get_config(&self) -> Result<StorageSettings, ServiceError> {
+        self.client.get("/storage/config").await
+    }
+
+    pub async fn set_config(&self, config: &StorageSettings) -> Result<(), ServiceError> {
+        self.client.put_void("/storage/config", config).await
+    }
+}

--- a/rust/agama-lib/src/storage/store.rs
+++ b/rust/agama-lib/src/storage/store.rs
@@ -20,8 +20,8 @@ impl StorageStore {
         Ok(self.storage_client.get_config().await?)
     }
 
-    pub async fn store(&self, settings: StorageSettings) -> Result<(), ServiceError> {
-        self.storage_client.set_config(&settings).await?;
+    pub async fn store(&self, settings: &StorageSettings) -> Result<(), ServiceError> {
+        self.storage_client.set_config(settings).await?;
         Ok(())
     }
 }
@@ -90,7 +90,7 @@ mod test {
             storage_autoyast: Some(boxed_raw_value),
         };
 
-        let result = store.store(settings).await;
+        let result = store.store(&settings).await;
 
         // main assertion
         result?;

--- a/rust/agama-lib/src/storage/store.rs
+++ b/rust/agama-lib/src/storage/store.rs
@@ -1,18 +1,18 @@
 //! Implements the store for the storage settings.
 
-use super::{StorageClient, StorageSettings};
+use super::StorageSettings;
 use crate::error::ServiceError;
-use zbus::Connection;
+use crate::storage::http_client::StorageHTTPClient;
 
-/// Loads and stores the storage settings from/to the D-Bus service.
-pub struct StorageStore<'a> {
-    storage_client: StorageClient<'a>,
+/// Loads and stores the storage settings from/to the HTTP service.
+pub struct StorageStore {
+    storage_client: StorageHTTPClient,
 }
 
-impl<'a> StorageStore<'a> {
-    pub async fn new(connection: Connection) -> Result<StorageStore<'a>, ServiceError> {
+impl StorageStore {
+    pub fn new() -> Result<StorageStore, ServiceError> {
         Ok(Self {
-            storage_client: StorageClient::new(connection).await?,
+            storage_client: StorageHTTPClient::new()?,
         })
     }
 
@@ -21,7 +21,7 @@ impl<'a> StorageStore<'a> {
     }
 
     pub async fn store(&self, settings: StorageSettings) -> Result<(), ServiceError> {
-        self.storage_client.set_config(settings).await?;
+        self.storage_client.set_config(&settings).await?;
         Ok(())
     }
 }

--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -7,7 +7,6 @@ use crate::{
     localization::LocalizationStore, network::NetworkStore, product::ProductStore,
     software::SoftwareStore, storage::StorageStore, users::UsersStore,
 };
-use zbus::Connection;
 
 /// Struct that loads/stores the settings from/to the D-Bus services.
 ///
@@ -15,27 +14,24 @@ use zbus::Connection;
 /// settings for each service.
 ///
 /// This struct uses the default connection built by [connection function](super::connection).
-pub struct Store<'a> {
+pub struct Store {
     users: UsersStore,
     network: NetworkStore,
     product: ProductStore,
     software: SoftwareStore,
-    storage: StorageStore<'a>,
+    storage: StorageStore,
     localization: LocalizationStore,
 }
 
-impl<'a> Store<'a> {
-    pub async fn new(
-        connection: Connection,
-        http_client: reqwest::Client,
-    ) -> Result<Store<'a>, ServiceError> {
+impl Store {
+    pub async fn new(http_client: reqwest::Client) -> Result<Store, ServiceError> {
         Ok(Self {
             localization: LocalizationStore::new()?,
             users: UsersStore::new()?,
             network: NetworkStore::new(http_client).await?,
             product: ProductStore::new()?,
             software: SoftwareStore::new()?,
-            storage: StorageStore::new(connection).await?,
+            storage: StorageStore::new()?,
         })
     }
 

--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -73,7 +73,7 @@ impl Store {
             self.users.store(user).await?;
         }
         if settings.storage.is_some() || settings.storage_autoyast.is_some() {
-            self.storage.store(settings.into()).await?
+            self.storage.store(&settings.into()).await?
         }
         Ok(())
     }

--- a/rust/agama-server/src/storage/web.rs
+++ b/rust/agama-server/src/storage/web.rs
@@ -125,11 +125,7 @@ pub async fn storage_service(dbus: zbus::Connection) -> Result<Router, ServiceEr
 )]
 async fn get_config(State(state): State<StorageState<'_>>) -> Result<Json<StorageSettings>, Error> {
     // StorageSettings is just a wrapper over serde_json::value::RawValue
-    let settings = state
-        .client
-        .get_config()
-        .await
-        .map_err(|e| Error::Service(e))?;
+    let settings = state.client.get_config().await.map_err(Error::Service)?;
     Ok(Json(settings))
 }
 
@@ -155,7 +151,7 @@ async fn set_config(
         .client
         .set_config(settings)
         .await
-        .map_err(|e| Error::Service(e))?;
+        .map_err(Error::Service)?;
     Ok(Json(()))
 }
 

--- a/rust/agama-server/src/storage/web.rs
+++ b/rust/agama-server/src/storage/web.rs
@@ -10,12 +10,12 @@ use agama_lib::{
     storage::{
         model::{Action, Device, DeviceSid, ProposalSettings, ProposalSettingsPatch, Volume},
         proxies::Storage1Proxy,
-        StorageClient,
+        StorageClient, StorageSettings,
     },
 };
 use axum::{
     extract::{Query, State},
-    routing::{get, post},
+    routing::{get, post, put},
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
@@ -71,7 +71,7 @@ struct StorageState<'a> {
     client: StorageClient<'a>,
 }
 
-/// Sets up and returns the axum service for the software module.
+/// Sets up and returns the axum service for the storage module.
 pub async fn storage_service(dbus: zbus::Connection) -> Result<Router, ServiceError> {
     const DBUS_SERVICE: &str = "org.opensuse.Agama.Storage1";
     const DBUS_PATH: &str = "/org/opensuse/Agama/Storage1";
@@ -87,6 +87,7 @@ pub async fn storage_service(dbus: zbus::Connection) -> Result<Router, ServiceEr
     let client = StorageClient::new(dbus.clone()).await?;
     let state = StorageState { client };
     let router = Router::new()
+        .route("/config", put(set_config).get(get_config))
         .route("/probe", post(probe))
         .route("/devices/dirty", get(devices_dirty))
         .route("/devices/system", get(system_devices))
@@ -107,6 +108,55 @@ pub async fn storage_service(dbus: zbus::Connection) -> Result<Router, ServiceEr
         .nest("/dasd", dasd_router)
         .with_state(state);
     Ok(router)
+}
+
+/// Returns the storage configuration.
+///
+/// * `state` : service state.
+#[utoipa::path(
+    get,
+    path = "/config",
+    context_path = "/api/storage",
+    operation_id = "get_storage_config",
+    responses(
+        (status = 200, description = "storage configuration", body = StorageSettings),
+        (status = 400, description = "The D-Bus service could not perform the action")
+    )
+)]
+async fn get_config(State(state): State<StorageState<'_>>) -> Result<Json<StorageSettings>, Error> {
+    // StorageSettings is just a wrapper over serde_json::value::RawValue
+    let settings = state
+        .client
+        .get_config()
+        .await
+        .map_err(|e| Error::Service(e))?;
+    Ok(Json(settings))
+}
+
+/// Sets the storage configuration.
+///
+/// * `state`: service state.
+/// * `config`: storage configuration.
+#[utoipa::path(
+    put,
+    path = "/config",
+    context_path = "/api/storage",
+    operation_id = "set_storage_config",
+    responses(
+        (status = 200, description = "Set the storage configuration"),
+        (status = 400, description = "The D-Bus service could not perform the action")
+    )
+)]
+async fn set_config(
+    State(state): State<StorageState<'_>>,
+    Json(settings): Json<StorageSettings>,
+) -> Result<Json<()>, Error> {
+    let _status: u32 = state
+        .client
+        .set_config(settings)
+        .await
+        .map_err(|e| Error::Service(e))?;
+    Ok(Json(()))
 }
 
 /// Probes the storage devices.

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 18 08:27:13 UTC 2024 - Martin Vidner <mvidner@suse.com>
+
+- For CLI, use HTTP clients instead of D-Bus clients,
+  final piece: Storage (gh#openSUSE/agama#1600)
+  - added StorageHTTPClient
+
+-------------------------------------------------------------------
 Wed Sep 13 12:25:28 UTC 2024 - Jorik Cronenberg <jorik.cronenberg@suse.com>
 
 - Add additional wireless settings (gh#openSUSE/agama#1602).


### PR DESCRIPTION
## Problem

- https://trello.com/c/hvPtBtMD

To recap: 
> When moving to the new HTTP-based architecture, we took some shortcuts. One of them was not using HTTP clients in the command-line interface. 

## Solution

- Add `StorageHTTPClient`
- This :stop_sign: ends D-Bus :stop_sign: usage from `SettingsStore` :heavy_check_mark: 

## Testing

- Added a new unit test
- Tested manually: note that it is easy to pass invalid Storage config in this way which will confuse the UI to the point of not rendering the storage parts at all.


## Screenshots

No
