### PR TITLE
Add additional wireless settings

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -186,7 +186,7 @@
                     "title": "Only allow connection to this mac address",
                     "type": "string"
                   },
-                  "group_algorithms": {
+                  "groupAlgorithms": {
                     "type": "array",
                     "items": {
                       "title": "A list of group/broadcast encryption algorithms",
@@ -199,7 +199,7 @@
                       ]
                     },
                   },
-                  "pairwise_algorithms": {
+                  "pairwiseAlgorithms": {
                     "type": "array",
                     "items": {
                       "title": "A list of pairwise encryption algorithms",
@@ -210,7 +210,7 @@
                       ]
                     }
                   },
-                  "wpa_protocol_versions": {
+                  "wpaProtocolVersions": {
                     "type": "array",
                     "items": {
                       "title": "A list of allowed WPA protocol versions",
@@ -312,7 +312,7 @@
                       ]
                     }
                   },
-                  "phase2_auth": {
+                  "phase2Auth": {
                     "title": "Phase 2 inner auth method",
                     "type": "string",
                     "enum": [
@@ -334,35 +334,35 @@
                     "title": "Password string used for EAP authentication",
                     "type": "string"
                   },
-                  "ca_cert": {
+                  "caCert": {
                     "title": "Path to CA certificate",
                     "type": "string"
                   },
-                  "ca_cert_password": {
+                  "caCertPassword": {
                     "title": "Password string for CA certificate if it is encrypted",
                     "type": "string"
                   },
-                  "client_cert": {
+                  "clientCert": {
                     "title": "Path to client certificate",
                     "type": "string"
                   },
-                  "client_cert_password": {
+                  "clientCertPassword": {
                     "title": "Password string for client certificate if it is encrypted",
                     "type": "string"
                   },
-                  "private_key": {
+                  "privateKey": {
                     "title": "Path to private key",
                     "type": "string"
                   },
-                  "private_key_password": {
+                  "privateKeyPassword": {
                     "title": "Password string for private key if it is encrypted",
                     "type": "string"
                   },
-                  "anonymous_identity": {
+                  "anonymousIdentity": {
                     "title": "Anonymous identity string for EAP authentication methods",
                     "type": "string"
                   },
-                  "peap_version": {
+                  "peapVersion": {
                     "title": "Which PEAP version is used when PEAP is set as the EAP method in the 'eap' property",
                     "type": "string",
                     "enum": [
@@ -370,7 +370,7 @@
                       "1"
                     ]
                   },
-                  "peap_label": {
+                  "peapLabel": {
                     "title": "Force the use of the new PEAP label during key derivation",
                     "type": "boolean"
                   }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -164,6 +164,66 @@
                       "mesh",
                       "ap"
                     ]
+                  },
+                  "hidden": {
+                    "title": "Indicates that the wifi network is not broadcasting it's SSID",
+                    "type": "boolean"
+                  },
+                  "band": {
+                    "title": "Frequency band of the wifi network",
+                    "type": "string",
+                    "enum": [
+                      "a",
+                      "bg"
+                    ]
+                  },
+                  "channel": {
+                    "title": "Wireless channel of the wifi network",
+                    "type": "integer",
+                    "minimum" : 0
+                  },
+                  "bssid": {
+                    "title": "Only allow connection to this mac address",
+                    "type": "string"
+                  },
+                  "group_algorithms": {
+                    "type": "array",
+                    "items": {
+                      "title": "A list of group/broadcast encryption algorithms",
+                      "type": "string",
+                      "enum": [
+                        "wep40",
+                        "wep104",
+                        "tkip",
+                        "ccmp"
+                      ]
+                    },
+                  },
+                  "pairwise_algorithms": {
+                    "type": "array",
+                    "items": {
+                      "title": "A list of pairwise encryption algorithms",
+                      "type": "string",
+                      "enum": [
+                        "tkip",
+                        "ccmp"
+                      ]
+                    }
+                  },
+                  "wpa_protocol_versions": {
+                    "type": "array",
+                    "items": {
+                      "title": "A list of allowed WPA protocol versions",
+                      "type": "string",
+                      "enum": [
+                        "wpa",
+                        "rsn"
+                      ]
+                    }
+                  },
+                  "pmf": {
+                    "title": "Indicates whether Protected Management Frames must be enabled for the connection",
+                    "type": "integer"
                   }
                 }
               },

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -139,9 +139,11 @@
                 "additionalProperties": false,
                 "properties": {
                   "password": {
+                    "title": "Password of the wireless network",
                     "type": "string"
                   },
                   "security": {
+                    "title": "Security method/key management",
                     "type": "string",
                     "enum": [
                       "none",
@@ -154,9 +156,11 @@
                     ]
                   },
                   "ssid": {
+                    "title": "SSID of the wireless network",
                     "type": "string"
                   },
                   "mode": {
+                    "title": "Wireless network mode",
                     "type": "string",
                     "enum": [
                       "infrastructure",
@@ -166,11 +170,11 @@
                     ]
                   },
                   "hidden": {
-                    "title": "Indicates that the wifi network is not broadcasting it's SSID",
+                    "title": "Indicates that the wireless network is not broadcasting its SSID",
                     "type": "boolean"
                   },
                   "band": {
-                    "title": "Frequency band of the wifi network",
+                    "title": "Frequency band of the wireless network",
                     "type": "string",
                     "enum": [
                       "a",
@@ -178,7 +182,7 @@
                     ]
                   },
                   "channel": {
-                    "title": "Wireless channel of the wifi network",
+                    "title": "Wireless channel of the wireless network",
                     "type": "integer",
                     "minimum" : 0
                   },

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -35,13 +35,42 @@ impl MatchSettings {
     }
 }
 
+/// Wireless configuration
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct WirelessSettings {
+    /// Password of the wifi network
     #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<String>,
+    /// Security method/key management
     pub security: String,
+    /// SSID of the wifi network
     pub ssid: String,
+    /// Wifi network mode
     pub mode: String,
+    /// Frequency band of the wifi network
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub band: Option<String>,
+    /// Wireless channel of the wifi network
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub channel: u32,
+    /// Only allow connection to this mac address
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bssid: Option<String>,
+    /// Indicates that the wifi network is not broadcasting it's SSID
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub hidden: bool,
+    /// A list of group/broadcast encryption algorithms
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub group_algorithms: Vec<String>,
+    /// A list of pairwise encryption algorithms
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub pairwise_algorithms: Vec<String>,
+    /// A list of allowed WPA protocol versions
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub wpa_protocol_versions: Vec<String>,
+    /// Indicates whether Protected Management Frames must be enabled for the connection
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub pmf: i32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -154,8 +183,8 @@ pub struct NetworkConnection {
     pub ieee_8021x: Option<IEEE8021XSettings>,
 }
 
-fn is_zero(u: &u32) -> bool {
-    *u == 0
+fn is_zero<T: PartialEq + From<u16>>(u: &T) -> bool {
+    *u == T::from(0)
 }
 
 impl NetworkConnection {

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -37,6 +37,7 @@ impl MatchSettings {
 
 /// Wireless configuration
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct WirelessSettings {
     /// Password of the wifi network
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -94,6 +95,7 @@ impl Default for BondSettings {
 
 /// IEEE 802.1x (EAP) settings
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IEEE8021XSettings {
     /// List of EAP methods used
     #[serde(skip_serializing_if = "Vec::is_empty", default)]

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -39,25 +39,25 @@ impl MatchSettings {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WirelessSettings {
-    /// Password of the wifi network
+    /// Password of the wireless network
     #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<String>,
     /// Security method/key management
     pub security: String,
-    /// SSID of the wifi network
+    /// SSID of the wireless network
     pub ssid: String,
-    /// Wifi network mode
+    /// Wireless network mode
     pub mode: String,
-    /// Frequency band of the wifi network
+    /// Frequency band of the wireless network
     #[serde(skip_serializing_if = "Option::is_none")]
     pub band: Option<String>,
-    /// Wireless channel of the wifi network
+    /// Wireless channel of the wireless network
     #[serde(skip_serializing_if = "is_zero", default)]
     pub channel: u32,
     /// Only allow connection to this mac address
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bssid: Option<String>,
-    /// Indicates that the wifi network is not broadcasting it's SSID
+    /// Indicates that the wireless network is not broadcasting its SSID
     #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     pub hidden: bool,
     /// A list of group/broadcast encryption algorithms

--- a/rust/agama-server/src/network/error.rs
+++ b/rust/agama-server/src/network/error.rs
@@ -40,6 +40,16 @@ pub enum NetworkStateError {
     InvalidEAPMethod(String),
     #[error("Invalid phase2 authentication method: '{0}'")]
     InvalidPhase2AuthMethod(String),
+    #[error("Invalid group algorithm: '{0}'")]
+    InvalidGroupAlgorithm(String),
+    #[error("Invalid pairwise algorithm: '{0}'")]
+    InvalidPairwiseAlgorithm(String),
+    #[error("Invalid WPA protocol version: '{0}'")]
+    InvalidWPAProtocolVersion(String),
+    #[error("Invalid wireless band: '{0}'")]
+    InvalidWirelessBand(String),
+    #[error("Invalid bssid: '{0}'")]
+    InvalidBssid(String),
 }
 
 impl From<NetworkStateError> for zbus::fdo::Error {

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Sep 13 12:25:28 UTC 2024 - Jorik Cronenberg <jorik.cronenberg@suse.com>
+
+- Add additional wireless settings (gh#openSUSE/agama#1602).
+
+-------------------------------------------------------------------
 Wed Sep 10 15:00:33 UTC 2024 - Jorik Cronenberg <jorik.cronenberg@suse.com>
 
 - Implement 802.1x (EAP) in network settings (gh#openSUSE/agama#1597).


### PR DESCRIPTION
## Problem

Network model was missing some required fields for the wicked migration.

## Solution

Added the required fields to both the model and settings. I've also added some fields present in the model to be available via the settings.

## Testing

- *Extended existing unit tests*
- *Tested manually*
```bash
sudo agama auth login && AGAMA_TOKEN=`sudo agama auth show`
curl http://localhost/api/network/connections \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $AGAMA_TOKEN" \
    -d '{ "id": "wifi", "method4": "auto", "method6": "auto", "ignoreAutoDns": false, "wireless": { "security": "wpa-psk", "ssid": "test-ssid", "mode": "infrastructure", "groupAlgorithms": [ "wep40", "wep104" ], "pairwiseAlgorithms": [ "tkip", "ccmp" ], "wpaProtocolVersions": [ "wpa" ], "pmf": 2, "hidden": true, "band": "a", "channel": 100, "bssid": "12:34:56:78:9A:BC" }, "status": "down" }'
curl -X POST http://localhost/api/network/system/apply \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $AGAMA_TOKEN"
nmcli con show wifi
# See relevant fields in 802-11-wireless.* and 802-11-wireless-security.* set.
```