### PR TITLE
fix(web): consider TypeScript files for translation

### DIFF
--- a/web/build_pot
+++ b/web/build_pot
@@ -8,7 +8,8 @@ cd "$(dirname "$0")"
 
 OUTPUT="${1:-agama.pot}"
 
-find . ! -name cockpit.js ! -name '*.test.js' -name '*.js' -o ! -name '*.test.jsx' -name '*.jsx' |
+find . ! -name cockpit.js ! -name '*.test.js' -name '*.js' -o ! -name '*.test.jsx' -name '*.jsx' \
+  -o ! -name '*.test.ts' -name '*.ts' -o ! -name '*.test.tsx' -name '*.tsx' |
 grep -vE "node_modules/|dist/|coverage/" | \
 xgettext --default-domain=agama --output="$OUTPUT" --language=C --files-from=- \
   --keyword= --keyword=_:1 --keyword=N_:1 --keyword=n_:1,2,3t --keyword=Nn_:1,2,3t \

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 16 05:40:25 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Consider TypeScript files for translation
+  (gh#openSUSE/agama#1604).
+
+-------------------------------------------------------------------
 Fri Sep  6 16:38:06 UTC 2024 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
 
 - Do not try to install assets/ and products/ directories (everything


### PR DESCRIPTION
Fix for #1604. After converting many files to TypeScript, we discovered that those files are not considered when building the `agama.pot` file.