### PR TITLE
fix(ci): add "which" until yast2-devtools gets fixed

### DIFF
--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install tools
         run: |
           RUBY_VERSION=$(ruby -e "puts RbConfig::CONFIG['ruby_version']")
-          zypper --non-interactive install --no-recommends diffutils git gettext-tools npm-default "rubygem(ruby:$RUBY_VERSION:yast-rake)" "rubygem(ruby:$RUBY_VERSION:gettext)" yast2-devtools
+          zypper --non-interactive install --no-recommends diffutils git gettext-tools npm-default "rubygem(ruby:$RUBY_VERSION:yast-rake)" "rubygem(ruby:$RUBY_VERSION:gettext)" yast2-devtools which
 
       - name: Checkout Agama sources
         uses: actions/checkout@v4


### PR DESCRIPTION
- The `which` command is required by `y2makepot`, from the `yast2-devtools` package.
- https://github.com/yast/yast-devtools/pull/176 fixes the problem, but until
  the fix lands in Factory, we would like to have our CI working again (it has been broken for at least two weeks).
