### PR TITLE
Revert graphical tty change

### DIFF
--- a/live/root/etc/systemd/system/x11-autologin.service
+++ b/live/root/etc/systemd/system/x11-autologin.service
@@ -8,16 +8,16 @@ WorkingDirectory=~
 
 PAMName=login
 Environment=XDG_SESSION_TYPE=x11
-TTYPath=/dev/tty2
+TTYPath=/dev/tty7
 StandardInput=tty
 UnsetEnvironment=TERM
 
-UtmpIdentifier=tty2
+UtmpIdentifier=tty7
 UtmpMode=user
 
 StandardOutput=journal
-ExecStartPre=/usr/bin/chvt 2
-ExecStart=/usr/bin/startx -- vt2 -keeptty -verbose 3 -logfile /dev/null
+ExecStartPre=/usr/bin/chvt 7
+ExecStart=/usr/bin/startx -- vt7 -keeptty -verbose 3 -logfile /dev/null
 Restart=no
 
 [Install]

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Sep  8 13:26:00 UTC 2024 - Joaquín Rivera <jeriveramoya@suse.com>
+
+- Revert to use tty7 (gh#openSUSE/agama#1582)
+  openQA tty expectations for installer are always in this tty.
+  The change to tty2 created an sporadic failure assigning tty2
+  as a non-grafical one anyway in ppc64le and aarch64.
+
+-------------------------------------------------------------------
 Mon Sep 16 15:46:23 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Define boot menu for all arches by scripts in config-cdroot


### PR DESCRIPTION
Revert to use tty7 (gh#openSUSE/agama#1582)  as a graphical one again.

openQA tty expectations for an installer were always in this tty (SLES and openSUSE).
The change to tty2 created an sporadic failure (possibly a race condition) assigning tty2 as a non-grafical one anyway in ppc64le and aarch64.
The change was introduced in https://github.com/openSUSE/agama/pull/1592 and it is blocking/slowing down our testing effort with agama.
Examples:
- https://openqa.opensuse.org/tests/4490850#step/boot_agama/10
- https://openqa.opensuse.org/tests/4489125#step/boot_agama/6
Confirmed with the developer that it can also happens in x86_64.