### PR TITLE
Fix ProposalSettings conversion

### DIFF
--- a/service/lib/agama/storage/proposal_settings_conversions/from_y2storage.rb
+++ b/service/lib/agama/storage/proposal_settings_conversions/from_y2storage.rb
@@ -64,7 +64,16 @@ module Agama
         #
         # @param target [Agama::Storage::ProposalSettings]
         def space_actions_conversion(target)
-          target.space.actions = y2storage_settings.space_settings.actions
+          target.space.actions = y2storage_settings.space_settings.actions.map do |action|
+            [action.device, action_to_symbol(action)]
+          end.to_h
+        end
+
+        # @see #space_action_conversion
+        def action_to_symbol(action)
+          return :resize if action.is?(:resize)
+
+          action.mandatory ? :force_delete : :delete
         end
 
         # Some values of the volumes have to be recovered from Y2Storage proposal.

--- a/service/test/agama/storage/proposal_settings_conversions/from_y2storage_test.rb
+++ b/service/test/agama/storage/proposal_settings_conversions/from_y2storage_test.rb
@@ -30,10 +30,11 @@ describe Agama::Storage::ProposalSettingsConversions::FromY2Storage do
 
   let(:y2storage_settings) do
     Y2Storage::ProposalSettings.new.tap do |settings|
-      settings.space_settings.actions = {
-        "/dev/sda"  => :force_delete,
-        "/dev/sdb1" => :resize
-      }
+      settings.space_settings.actions = [
+        Y2Storage::SpaceActions::Delete.new("/dev/sda", mandatory: true),
+        Y2Storage::SpaceActions::Resize.new("/dev/sdb1"),
+        Y2Storage::SpaceActions::Delete.new("/dev/sdb2")
+      ]
     end
   end
 
@@ -45,7 +46,7 @@ describe Agama::Storage::ProposalSettingsConversions::FromY2Storage do
       settings.encryption.method = Y2Storage::EncryptionMethod::LUKS2
       settings.encryption.pbkd_function = Y2Storage::PbkdFunction::ARGON2ID
       settings.space.policy = :delete
-      settings.space.actions = []
+      settings.space.actions = {}
       settings.volumes = [Agama::Storage::Volume.new("/test")]
     end
   end
@@ -72,7 +73,8 @@ describe Agama::Storage::ProposalSettingsConversions::FromY2Storage do
 
       expect(settings.space.actions).to eq(
         "/dev/sda"  => :force_delete,
-        "/dev/sdb1" => :resize
+        "/dev/sdb1" => :resize,
+        "/dev/sdb2" => :delete
       )
     end
   end


### PR DESCRIPTION
https://github.com/yast/yast-storage-ng/pull/1388 introduced a change in the API of Y2Storage.

Agama was adapted at #1599, but one particular conversion was left behind.

This PR fixes that omission.