### PR TITLE
doc(products): update products changelog

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Sep 24 09:30:26 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Update products translations (gh#openSUSE/agama#1607).
+
+-------------------------------------------------------------------
 Thu Sep  5 16:25:00 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Show product logo in product selector (gh#openSUSE/agama#1415).


### PR DESCRIPTION
One of our SRs was rejected because an entry in the changes file was missing (see [1202586](https://build.opensuse.org/request/show/1202586)). To avoid this kind of rejection, we might need to automatically update the changes file in those cases.
